### PR TITLE
Add rubocop gem and config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@ config.local
 # https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 /.env.*.local
 /.env.local
+
+# Intellij files
+.idea/
+
+# Ruby version
+.ruby-version

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,25 @@
+AllCops:
+  Include:
+  - app/**/*.rb
+  - Rakefile
+  - '**/Gemfile'
+  - config.ru
+  Exclude:
+  - config/**/*
+  - db/**/*
+  - spec/**/*
+  - bin/**/*
+  - lib/tasks/*
+  TargetRubyVersion: 2.3
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+  Enabled: true
+Metrics/LineLength:
+  Max: 120
+Metrics/MethodLength:
+  Max: 12
+Style/Documentation:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  EnforcedStyle: compact

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
   - spec/**/*
   - bin/**/*
   - lib/tasks/*
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.6
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,12 @@ group :development, :test do
 
   # Use sqlite3 as the database for Active Record
   gem 'sqlite3'
+
+  # Make rubocop available for developers
+  # Have not fixed all the issues, because many of the fixes are high risk: suggest
+  # we tidy up each file as and when working on it
+  gem 'rubocop'
+
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
     airbrake-ruby (4.8.0)
       rbtree3 (~> 0.5)
     arel (9.0.0)
+    ast (2.4.0)
     awesome_print (1.8.0)
     bindex (0.8.1)
     bootsnap (1.4.5)
@@ -99,6 +100,7 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.4)
     jazz_fingers (5.0.1)
       awesome_print (~> 1.6)
       pry (~> 0.10)
@@ -157,6 +159,9 @@ GEM
     omniauth-twitter (1.4.0)
       omniauth-oauth (~> 1.1)
       rack
+    parallel (1.18.0)
+    parser (2.6.5.0)
+      ast (~> 2.4.0)
     pg (1.1.4)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -194,12 +199,21 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
+    rainbow (3.0.0)
     rake (13.0.0)
     random_data (1.6.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     rbtree3 (0.5.0)
+    rubocop (0.76.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.6)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    ruby-progressbar (1.10.1)
     ruby_parser (3.14.1)
       sexp_processor (~> 4.9)
     sass-rails (6.0.0)
@@ -232,6 +246,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (1.6.0)
     unicode_utils (1.4.0)
     web-console (3.7.0)
       actionview (>= 5.0)
@@ -266,6 +281,7 @@ DEPENDENCIES
   pry-byebug
   rails (~> 5.2.0)
   random_data
+  rubocop
   sass-rails
   seedbank
   spring


### PR DESCRIPTION
Rubocop gem and config only, with no fixes - the fixes seemed pretty high risk, so this just enables developers to run and fix for themselves.

At time of commit, currently rubocop was finding 338 offenses
