### PR TITLE
Improve 'user swap' poll charts

### DIFF
--- a/app/assets/javascripts/polls.coffee
+++ b/app/assets/javascripts/polls.coffee
@@ -7,15 +7,23 @@ _drawCharts = () ->
     _drawPollChart(chart...)
   window.drawPollChart = _drawPollChart
 
-google.load("visualization", "1", {packages:["corechart"]})
+google.charts.load('1', {packages: ['corechart']})
 google.setOnLoadCallback(_drawCharts)
 
-_drawPollChart = (selector, poll_data) ->
-  data = google.visualization.arrayToDataTable([
-    ['Party', 'Vote %', { role: "style" }]
-  ].concat(poll_data))
 
-  max = Math.max(poll_data.map((d) -> d[1]))
+_drawPollChart = (selector, poll_data) ->
+  formatMS = new google.visualization.NumberFormat({
+    suffix: '%',
+    fractionDigits: 0
+  });
+
+  rows = poll_data.map((row) -> [row[0], row[1], row[2], row[1] + '%']);
+  data = google.visualization.arrayToDataTable([
+    ['Party', 'Vote', { role: "style" }, { role: "annotation" }]
+  ].concat(rows))
+  formatMS.format(data, 1)
+
+  max = Math.max.apply(null, poll_data.map((d) -> d[1]))
 
   options = {
     hAxis: { textPosition: 'none' },
@@ -26,19 +34,20 @@ _drawPollChart = (selector, poll_data) ->
       },
       viewWindow: {
         min: 0, max: max
-      }
+      },
+      baselineColor: 'none',
     },
     legend: { position: "none" },
     bar: { groupWidth: '90%' },
     chartArea: {
-      width: '60%',
-      height: '80%'
+      width: '90%',
+      height: '90%'
     },
     height: 120,
     tooltip: {
       textStyle: {
         fontSize: 12,
-        fontName: "Open Sans"
+        fontFamily: "Open Sans"
       }
     }
   }

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -54,3 +54,9 @@ a.profile {
     text-decoration: none;
   }
 }
+
+// Work around a flicker when hovering on the poll bars
+// (https://stackoverflow.com/questions/37902708/google-charts-tooltip-flickering)
+.google-visualization-tooltip {
+  pointer-events:none;
+}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -17,7 +17,7 @@
     = favicon_link_tag(source="favicon_32.png", {:sizes => "32x32"})
 
     %link{:href => "//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css", :rel => "stylesheet"}/
-    %script{:src => "https://www.google.com/jsapi", :type => "text/javascript"}
+    %script{:src => "https://www.gstatic.com/charts/loader.js", :type => "text/javascript"}
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true
     = javascript_include_tag 'application', 'data-turbolinks-track' => true
     = csrf_meta_tags


### PR DESCRIPTION
Update Google Charts, prevent a flicker on hover, improve the styling, and add vote % by default.

Before:
<img width="500" alt="2019:11:08-14 47 51" src="https://user-images.githubusercontent.com/84737/68485235-d730a380-0236-11ea-9007-787c8b2c3810.png">

After:
<img width="500" alt="2019:11:08-14 48 06" src="https://user-images.githubusercontent.com/84737/68485250-de57b180-0236-11ea-9046-f39561717310.png">

