### PR TITLE
Rubocop config tweaks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,6 @@ Style/Documentation:
   Enabled: false
 Style/ClassAndModuleChildren:
   EnforcedStyle: compact
+Style/SymbolArray:
+  # Turned off because the associated auto-correct makes a real mess
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
   - bin/**/*
   - lib/tasks/*
   TargetRubyVersion: 2.6
+  StyleGuideCopsOnly: true
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes


### PR DESCRIPTION
Two tweaks aimed at de-risking rubocop autocorrect changes, at least for the time being.

1) Enforce the minimum cops for the style guide only 
2) Turn off one cop known to cause problems