### PR TITLE
Add guard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,14 @@ group :development, :test do
   # Have not fixed all the issues, because many of the fixes are high risk: suggest
   # we tidy up each file as and when working on it
   gem "rubocop"
+
+  # Guard checks everything when you save a file
+  gem "guard"
+  gem "guard-rspec"
+  gem "guard-rails"
+  gem "guard-bundler"
+  gem "guard-rubocop"
+  # gem "terminal-notifier-guard"
 end
 
 group :production do

--- a/Gemfile
+++ b/Gemfile
@@ -1,21 +1,21 @@
-source 'https://rubygems.org'
-ruby '2.6.5'
+source "https://rubygems.org"
+ruby "2.6.5"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 5.2.0'
+gem "rails", "~> 5.2.0"
 # Use SCSS for stylesheets
-gem 'sass-rails'
+gem "sass-rails"
 # Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
+gem "uglifier", ">= 1.3.0"
 # Use CoffeeScript for .coffee assets and views
-gem 'coffee-rails'
+gem "coffee-rails"
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 
-gem 'bootsnap', require: false
+gem "bootsnap", require: false
 
 # Use jquery as the JavaScript library
-gem 'jquery-rails'
+gem "jquery-rails"
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 # gem 'turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
@@ -32,55 +32,54 @@ gem 'jquery-rails'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
-gem 'omniauth-facebook'
-gem 'omniauth-twitter'
-gem 'omniauth-rails_csrf_protection', '~> 0.1'
+gem "omniauth-facebook"
+gem "omniauth-twitter"
+gem "omniauth-rails_csrf_protection", "~> 0.1"
 
-gem 'haml-rails'
-gem 'addressable'
-gem 'normalize-rails'
+gem "haml-rails"
+gem "addressable"
+gem "normalize-rails"
 
-gem 'seedbank'
+gem "seedbank"
 
-gem 'random_data'
+gem "random_data"
 
-gem 'json'
+gem "json"
 
-gem 'airbrake', '~> 9.5.0'
+gem "airbrake", "~> 9.5.0"
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
-  gem 'web-console'
-  gem 'listen'  # required by config.file_watcher
-  gem 'bundler-audit'
+  gem "web-console"
+  gem "listen"  # required by config.file_watcher
+  gem "bundler-audit"
 end
 
 group :development, :test do
-  gem 'jazz_fingers'
-  gem 'pry-byebug'
+  gem "jazz_fingers"
+  gem "pry-byebug"
 
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug'
+  gem "byebug"
 
-  gem 'dotenv-rails'
+  gem "dotenv-rails"
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  gem 'spring'
+  gem "spring"
 
   # Use sqlite3 as the database for Active Record
-  gem 'sqlite3'
+  gem "sqlite3"
 
   # add rspec
-  gem 'rspec-rails', '~> 3.8'
-  gem 'database_cleaner'
+  gem "rspec-rails", "~> 3.8"
+  gem "database_cleaner"
 
   # Make rubocop available for developers
   # Have not fixed all the issues, because many of the fixes are high risk: suggest
   # we tidy up each file as and when working on it
-  gem 'rubocop'
-
+  gem "rubocop"
 end
 
 group :production do
-  gem 'pg'
+  gem "pg"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,8 +83,33 @@ GEM
     faraday (0.17.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
+    formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    guard (2.16.1)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-bundler (2.2.1)
+      bundler (>= 1.3.0, < 3)
+      guard (~> 2.2)
+      guard-compat (~> 1.1)
+    guard-compat (1.2.1)
+    guard-rails (0.8.1)
+      guard (~> 2.11)
+      guard-compat (~> 1.0)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
+    guard-rubocop (1.3.0)
+      guard (~> 2.0)
+      rubocop (~> 0.20)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -120,6 +145,7 @@ GEM
     loofah (2.3.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    lumberjack (1.0.13)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
@@ -133,10 +159,14 @@ GEM
     multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
+    nenv (0.3.0)
     nio4r (2.5.2)
     nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     normalize-rails (4.1.1)
+    notiffany (0.1.3)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
     oauth (0.5.4)
     oauth2 (1.4.2)
       faraday (>= 0.8, < 2.0)
@@ -208,6 +238,10 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     rbtree3 (0.5.0)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
     rspec-core (3.9.0)
       rspec-support (~> 3.9.0)
     rspec-expectations (3.9.0)
@@ -248,6 +282,7 @@ GEM
     seedbank (0.5.0)
       rake (>= 10.0)
     sexp_processor (4.13.0)
+    shellany (0.0.1)
     spring (2.1.0)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
@@ -288,6 +323,11 @@ DEPENDENCIES
   coffee-rails
   database_cleaner
   dotenv-rails
+  guard
+  guard-bundler
+  guard-rails
+  guard-rspec
+  guard-rubocop
   haml-rails
   jazz_fingers
   jquery-rails

--- a/Guardfile
+++ b/Guardfile
@@ -15,94 +15,98 @@
 #
 # and, you'll have to watch "config/Guardfile" instead of "Guardfile"
 
-guard :bundler do
-  require 'guard/bundler'
-  require 'guard/bundler/verify'
-  helper = Guard::Bundler::Verify.new
+group :all_plugins, halt_on_fail: true do
 
-  files = ['Gemfile']
-  files += Dir['*.gemspec'] if files.any? { |f| helper.uses_gemspec?(f) }
+  guard :bundler do
+    require 'guard/bundler'
+    require 'guard/bundler/verify'
+    helper = Guard::Bundler::Verify.new
 
-  # Assume files are symlinked from somewhere
-  files.each { |file| watch(helper.real_path(file)) }
-end
+    files = ['Gemfile']
+    files += Dir['*.gemspec'] if files.any? { |f| helper.uses_gemspec?(f) }
 
-# Guard-Rails supports a lot options with default values:
-# daemon: false                        # runs the server as a daemon.
-# debugger: false                      # enable ruby-debug gem.
-# environment: 'development'           # changes server environment.
-# force_run: false                     # kills any process that's holding the listen port before attempting to (re)start Rails.
-# pid_file: 'tmp/pids/[RAILS_ENV].pid' # specify your pid_file.
-# host: 'localhost'                    # server hostname.
-# port: 3000                           # server port number.
-# root: '/spec/dummy'                  # Rails' root path.
-# server: thin                         # webserver engine.
-# start_on_start: true                 # will start the server when starting Guard.
-# timeout: 30                          # waits untill restarting the Rails server, in seconds.
-# zeus_plan: server                    # custom plan in zeus, only works with `zeus: true`.
-# zeus: false                          # enables zeus gem.
-# CLI: 'rails server'                  # customizes runner command. Omits all options except `pid_file`!
-
-guard 'rails' do
-  watch('Gemfile.lock')
-  watch(%r{^(config|lib)/.*})
-end
-
-# Note: The cmd option is now required due to the increasing number of ways
-#       rspec may be run, below are examples of the most common uses.
-#  * bundler: 'bundle exec rspec'
-#  * bundler binstubs: 'bin/rspec'
-#  * spring: 'bin/rspec' (This will use spring if running and you have
-#                          installed the spring binstubs per the docs)
-#  * zeus: 'zeus rspec' (requires the server to be started separately)
-#  * 'just' rspec: 'rspec'
-
-guard :rspec, cmd: "bundle exec rspec" do
-  require "guard/rspec/dsl"
-  dsl = Guard::RSpec::Dsl.new(self)
-
-  # Feel free to open issues for suggestions and improvements
-
-  # RSpec files
-  rspec = dsl.rspec
-  watch(rspec.spec_helper) { rspec.spec_dir }
-  watch(rspec.spec_support) { rspec.spec_dir }
-  watch(rspec.spec_files)
-
-  # Ruby files
-  ruby = dsl.ruby
-  dsl.watch_spec_files_for(ruby.lib_files)
-
-  # Rails files
-  rails = dsl.rails(view_extensions: %w(erb haml slim))
-  dsl.watch_spec_files_for(rails.app_files)
-  dsl.watch_spec_files_for(rails.views)
-
-  watch(rails.controllers) do |m|
-    [
-      rspec.spec.call("routing/#{m[1]}_routing"),
-      rspec.spec.call("controllers/#{m[1]}_controller"),
-      rspec.spec.call("acceptance/#{m[1]}")
-    ]
+    # Assume files are symlinked from somewhere
+    files.each { |file| watch(helper.real_path(file)) }
   end
 
-  # Rails config changes
-  watch(rails.spec_helper)     { rspec.spec_dir }
-  watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
-  watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
+  # Guard-Rails supports a lot options with default values:
+  # daemon: false                        # runs the server as a daemon.
+  # debugger: false                      # enable ruby-debug gem.
+  # environment: 'development'           # changes server environment.
+  # force_run: false                     # kills any process that's holding the listen port before attempting to (re)start Rails.
+  # pid_file: 'tmp/pids/[RAILS_ENV].pid' # specify your pid_file.
+  # host: 'localhost'                    # server hostname.
+  # port: 3000                           # server port number.
+  # root: '/spec/dummy'                  # Rails' root path.
+  # server: thin                         # webserver engine.
+  # start_on_start: true                 # will start the server when starting Guard.
+  # timeout: 30                          # waits untill restarting the Rails server, in seconds.
+  # zeus_plan: server                    # custom plan in zeus, only works with `zeus: true`.
+  # zeus: false                          # enables zeus gem.
+  # CLI: 'rails server'                  # customizes runner command. Omits all options except `pid_file`!
 
-  # Capybara features specs
-  watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
-  watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
-
-  # Turnip features and steps
-  watch(%r{^spec/acceptance/(.+)\.feature$})
-  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
-    Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
+  guard 'rails' do
+    watch('Gemfile.lock')
+    watch(%r{^(config|lib)/.*})
   end
-end
 
-guard :rubocop do
-  watch(%r{.+\.rb$})
-  watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
-end
+  # Note: The cmd option is now required due to the increasing number of ways
+  #       rspec may be run, below are examples of the most common uses.
+  #  * bundler: 'bundle exec rspec'
+  #  * bundler binstubs: 'bin/rspec'
+  #  * spring: 'bin/rspec' (This will use spring if running and you have
+  #                          installed the spring binstubs per the docs)
+  #  * zeus: 'zeus rspec' (requires the server to be started separately)
+  #  * 'just' rspec: 'rspec'
+
+  guard :rspec, cmd: "bundle exec rspec" do
+    require "guard/rspec/dsl"
+    dsl = Guard::RSpec::Dsl.new(self)
+
+    # Feel free to open issues for suggestions and improvements
+
+    # RSpec files
+    rspec = dsl.rspec
+    watch(rspec.spec_helper) { rspec.spec_dir }
+    watch(rspec.spec_support) { rspec.spec_dir }
+    watch(rspec.spec_files)
+
+    # Ruby files
+    ruby = dsl.ruby
+    dsl.watch_spec_files_for(ruby.lib_files)
+
+    # Rails files
+    rails = dsl.rails(view_extensions: %w(erb haml slim))
+    dsl.watch_spec_files_for(rails.app_files)
+    dsl.watch_spec_files_for(rails.views)
+
+    watch(rails.controllers) do |m|
+      [
+        rspec.spec.call("routing/#{m[1]}_routing"),
+        rspec.spec.call("controllers/#{m[1]}_controller"),
+        rspec.spec.call("acceptance/#{m[1]}")
+      ]
+    end
+
+    # Rails config changes
+    watch(rails.spec_helper)     { rspec.spec_dir }
+    watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
+    watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
+
+    # Capybara features specs
+    watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
+    watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
+
+    # Turnip features and steps
+    watch(%r{^spec/acceptance/(.+)\.feature$})
+    watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
+      Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
+    end
+  end
+
+  guard :rubocop do
+    watch(%r{.+\.rb$})
+    watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
+  end
+
+end # halt_on_fail

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,108 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+## Uncomment and set this to only include directories you want to watch
+# directories %w(app lib config test spec features) \
+#  .select{|d| Dir.exist?(d) ? d : UI.warning("Directory #{d} does not exist")}
+
+## Note: if you are using the `directories` clause above and you are not
+## watching the project directory ('.'), then you will want to move
+## the Guardfile to a watched dir and symlink it back, e.g.
+#
+#  $ mkdir config
+#  $ mv Guardfile config/
+#  $ ln -s config/Guardfile .
+#
+# and, you'll have to watch "config/Guardfile" instead of "Guardfile"
+
+guard :bundler do
+  require 'guard/bundler'
+  require 'guard/bundler/verify'
+  helper = Guard::Bundler::Verify.new
+
+  files = ['Gemfile']
+  files += Dir['*.gemspec'] if files.any? { |f| helper.uses_gemspec?(f) }
+
+  # Assume files are symlinked from somewhere
+  files.each { |file| watch(helper.real_path(file)) }
+end
+
+# Guard-Rails supports a lot options with default values:
+# daemon: false                        # runs the server as a daemon.
+# debugger: false                      # enable ruby-debug gem.
+# environment: 'development'           # changes server environment.
+# force_run: false                     # kills any process that's holding the listen port before attempting to (re)start Rails.
+# pid_file: 'tmp/pids/[RAILS_ENV].pid' # specify your pid_file.
+# host: 'localhost'                    # server hostname.
+# port: 3000                           # server port number.
+# root: '/spec/dummy'                  # Rails' root path.
+# server: thin                         # webserver engine.
+# start_on_start: true                 # will start the server when starting Guard.
+# timeout: 30                          # waits untill restarting the Rails server, in seconds.
+# zeus_plan: server                    # custom plan in zeus, only works with `zeus: true`.
+# zeus: false                          # enables zeus gem.
+# CLI: 'rails server'                  # customizes runner command. Omits all options except `pid_file`!
+
+guard 'rails' do
+  watch('Gemfile.lock')
+  watch(%r{^(config|lib)/.*})
+end
+
+# Note: The cmd option is now required due to the increasing number of ways
+#       rspec may be run, below are examples of the most common uses.
+#  * bundler: 'bundle exec rspec'
+#  * bundler binstubs: 'bin/rspec'
+#  * spring: 'bin/rspec' (This will use spring if running and you have
+#                          installed the spring binstubs per the docs)
+#  * zeus: 'zeus rspec' (requires the server to be started separately)
+#  * 'just' rspec: 'rspec'
+
+guard :rspec, cmd: "bundle exec rspec" do
+  require "guard/rspec/dsl"
+  dsl = Guard::RSpec::Dsl.new(self)
+
+  # Feel free to open issues for suggestions and improvements
+
+  # RSpec files
+  rspec = dsl.rspec
+  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(rspec.spec_support) { rspec.spec_dir }
+  watch(rspec.spec_files)
+
+  # Ruby files
+  ruby = dsl.ruby
+  dsl.watch_spec_files_for(ruby.lib_files)
+
+  # Rails files
+  rails = dsl.rails(view_extensions: %w(erb haml slim))
+  dsl.watch_spec_files_for(rails.app_files)
+  dsl.watch_spec_files_for(rails.views)
+
+  watch(rails.controllers) do |m|
+    [
+      rspec.spec.call("routing/#{m[1]}_routing"),
+      rspec.spec.call("controllers/#{m[1]}_controller"),
+      rspec.spec.call("acceptance/#{m[1]}")
+    ]
+  end
+
+  # Rails config changes
+  watch(rails.spec_helper)     { rspec.spec_dir }
+  watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
+  watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
+
+  # Capybara features specs
+  watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
+  watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
+
+  # Turnip features and steps
+  watch(%r{^spec/acceptance/(.+)\.feature$})
+  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
+    Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
+  end
+end
+
+guard :rubocop do
+  watch(%r{.+\.rb$})
+  watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
+end

--- a/Guardfile
+++ b/Guardfile
@@ -59,7 +59,9 @@ group :all_plugins, halt_on_fail: true do
   #  * zeus: 'zeus rspec' (requires the server to be started separately)
   #  * 'just' rspec: 'rspec'
 
-  guard :rspec, cmd: "bundle exec rspec" do
+  guard( :rspec,
+      cmd: 'bundle exec rspec --no-profile',
+      all_after_pass: true, all_on_start: true) do
     require "guard/rspec/dsl"
     dsl = Guard::RSpec::Dsl.new(self)
 
@@ -93,15 +95,10 @@ group :all_plugins, halt_on_fail: true do
     watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
     watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
 
-    # Capybara features specs
-    watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
-    watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
+    # # Capybara features specs
+    # watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
+    # watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
 
-    # Turnip features and steps
-    watch(%r{^spec/acceptance/(.+)\.feature$})
-    watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
-      Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
-    end
   end
 
   guard :rubocop do

--- a/Guardfile
+++ b/Guardfile
@@ -101,7 +101,7 @@ group :all_plugins, halt_on_fail: true do
 
   end
 
-  guard :rubocop do
+  guard( :rubocop, cli: %w(--fail-fast) ) do
     watch(%r{.+\.rb$})
     watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
   end


### PR DESCRIPTION
Leave guard running in a separate terminal, 

    $ bundle exec guard

and it will run specs every time you save a file.

Will also run bundler when needed, and rubocop, though in a fail-fast mode, as we have so many rubcop errors right now, so you'll only ever see errors for the most recently touched bad file. 

If rspec gives errors, you won't be bothered  with rubocop notifications. 