### PR TITLE
Improvements to Sass/CSS, use normalize.css, basic fixes for small viewports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'omniauth-rails_csrf_protection', '~> 0.1'
 gem 'haml-rails'
 gem 'addressable'
 gem 'normalize-rails'
+gem "autoprefixer-rails"
 
 gem 'seedbank'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,8 @@ GEM
       rbtree3 (~> 0.5)
     arel (9.0.0)
     ast (2.4.0)
+    autoprefixer-rails (9.7.1)
+      execjs
     awesome_print (1.8.0)
     bindex (0.8.1)
     bootsnap (1.4.5)
@@ -282,6 +284,7 @@ PLATFORMS
 DEPENDENCIES
   addressable
   airbrake (~> 9.5.0)
+  autoprefixer-rails
   bootsnap
   bundler-audit
   byebug

--- a/app/assets/javascripts/polls.coffee
+++ b/app/assets/javascripts/polls.coffee
@@ -40,10 +40,9 @@ _drawPollChart = (selector, poll_data) ->
     legend: { position: "none" },
     bar: { groupWidth: '90%' },
     chartArea: {
-      width: '90%',
-      height: '90%'
+      width: '100%',
+      height: '100%'
     },
-    height: 120,
     tooltip: {
       textStyle: {
         fontSize: 12,

--- a/app/assets/stylesheets/_mixins.scss
+++ b/app/assets/stylesheets/_mixins.scss
@@ -1,0 +1,23 @@
+@mixin largescreen() {
+    @media screen and (min-width: $smallscreen-width) {
+        @content;
+    }
+}
+
+@mixin smallscreen() {
+    @media screen and (max-width: $smallscreen-width) {
+        @content;
+    }
+}
+
+@mixin highdpi() {
+    @media
+    only screen and (-webkit-min-device-pixel-ratio: 2),
+    only screen and (   min--moz-device-pixel-ratio: 2),
+    only screen and (     -o-min-device-pixel-ratio: 2/1),
+    only screen and (        min-device-pixel-ratio: 2),
+    only screen and (                min-resolution: 192dpi),
+    only screen and (                min-resolution: 2dppx) {
+      @content;
+  }
+}

--- a/app/assets/stylesheets/_mixins.scss
+++ b/app/assets/stylesheets/_mixins.scss
@@ -1,3 +1,5 @@
+@import "_variables";
+
 @mixin largescreen() {
     @media screen and (min-width: $smallscreen-width) {
         @content;

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,7 +1,9 @@
 $base-font-size: 18px;
 $base-line-height: 1.6;
-$computed-line-height: $base-line-height * $base-font-size;
+
+$smallscreen-width: 650px;
 
 $border-color: #ddd;
-
 $button-color: #457BDA;
+$facebook-color: #3B5998;
+$twitter-color: #55ACEE;

--- a/app/assets/stylesheets/button.scss
+++ b/app/assets/stylesheets/button.scss
@@ -21,7 +21,6 @@
   padding: 18px 36px;
 }
 
-$facebook-color: #3B5998;
 .button-facebook {
   background-color: $facebook-color;
   color: white;
@@ -30,7 +29,6 @@ $facebook-color: #3B5998;
   }
 }
 
-$twitter-color: #55ACEE;
 .button-twitter {
   background-color: $twitter-color;
   color: white;

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -1,28 +1,44 @@
+@import "_mixins";
+
 footer {
-	padding: 24px 0;
-	background-color: #fafafa;
-	.container {
-		padding: 0 100px;
-	}
-	ul {
-		display: inline-block;
-		width: 33%;
-		margin: 0;
-		box-sizing: border-box;
-		vertical-align: top;
-		list-style: none;
-		li {
-			padding: 3px 0;
-			line-height: 1.2;
-			h3 {
-				margin: 0;
-				font-variant: small-caps;
-				color: #888;
-				font-size: 16px;
-			}
-			a {
-				opacity: 0.8;
-			}
-		}
-	}
+  background-color: #fafafa;
+
+  @include largescreen {
+    padding: 24px 0;
+  }
+
+  @include smallscreen {
+    padding: 8px;
+  }
+
+  .container {
+    @include largescreen {
+      padding: 0 100px;
+      display: flex;
+    }
+  }
+  ul {
+    @include largescreen {
+      flex: 1;
+    }
+
+    box-sizing: border-box;
+    vertical-align: top;
+    list-style: none;
+    padding: 0;
+    margin-top: 0;
+
+    li {
+      padding: 3px 0;
+      line-height: 1.2;
+      h3 {
+        margin: 0;
+        color: #888;
+        font-size: 16px;
+      }
+      a {
+        opacity: 0.8;
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -3,6 +3,8 @@
 @import "_variables";
 @import "_mixins";
 
+@import 'normalize-rails/normalize';
+
 body {
   font-family: 'Open Sans', sans-serif;
   margin: 0;
@@ -21,6 +23,10 @@ a {
 
 p {
   margin: 12px 0;
+
+  &:first-child {
+    margin-top: 0;
+  }
 }
 
 select {
@@ -79,7 +85,7 @@ p.choose_party {
       height: 32px;
       width: 173px;
       background-size: 173px 32px;
-      margin-bottom: 8px;
+      margin-bottom: 16px;
     }
   }
 
@@ -103,6 +109,10 @@ p.choose_party {
   max-width: 960px;
   padding: 16px;
   margin: auto;
+
+  @include smallscreen {
+    padding: 16px;
+  }
 }
 
 .container-narrow {

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -66,7 +66,6 @@ p.choose_party {
   background-color: white;
 
   .user {
-    display: inline-block;
     float: right;
     position: relative;
     padding-left: 42px;

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,6 +1,7 @@
 @import url("//fonts.googleapis.com/css?family=Open+Sans");
 
 @import "_variables";
+@import "_mixins";
 
 body {
   font-family: 'Open Sans', sans-serif;
@@ -51,13 +52,7 @@ p.choose_party {
     width: 173px;
     background-size: 173px 32px;
   }
-  @media
-    only screen and (-webkit-min-device-pixel-ratio: 2),
-    only screen and (   min--moz-device-pixel-ratio: 2),
-    only screen and (     -o-min-device-pixel-ratio: 2/1),
-    only screen and (        min-device-pixel-ratio: 2),
-    only screen and (                min-resolution: 192dpi),
-    only screen and (                min-resolution: 2dppx) {
+  @include highdpi {
       a.brand {
         background-image: image-url('logo_nav@2x.png');
       }

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -42,42 +42,59 @@ p.choose_party {
 }
 
 .navbar {
-  padding: 16px 32px;
-  a.brand {
-    color: transparent;
-    display: inline-block;
-    background-image: image-url('logo_nav.png');
-    background-repeat: no-repeat;
-    height: 32px;
-    width: 173px;
-    background-size: 173px 32px;
-  }
-  @include highdpi {
-      a.brand {
-        background-image: image-url('logo_nav@2x.png');
-      }
-  }
   border-bottom: 1px solid $border-color;
   background-color: white;
+  display: flex;
+
+  @include largescreen {
+    padding: 16px 32px;
+    height: 32px;
+  }
+
+  @include smallscreen {
+    padding: 8px 16px;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  a.brand {
+    display: block;
+
+    color: transparent;
+    background-image: image-url('logo_nav.png');
+    background-repeat: no-repeat;
+
+    @include highdpi {
+      background-image: image-url('logo_nav@2x.png');
+    }
+
+    @include largescreen {
+      flex-grow: 1;
+      height: 32px;
+      width: 173px;
+      background-size: 173px 32px;
+    }
+
+    @include smallscreen {
+      height: 32px;
+      width: 173px;
+      background-size: 173px 32px;
+      margin-bottom: 8px;
+    }
+  }
 
   .user {
-    float: right;
-    position: relative;
-    padding-left: 42px;
+    display: flex;
+    align-items: center;
+
     img {
       height: 32px;
       width: 32px;
-      border: 1px solid $border-color;
       border-radius: 3px;
-      position: absolute;
-      left: 0;
-      top: -4px;;
+      margin-right: 8px;
     }
     a.logout {
-      padding-left: 12px;
-      display: inline-block;
-      vertical-align: middle;
-      margin-top: -3px;
+      margin-left: 8px;
     }
   }
 }

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -23,7 +23,9 @@ a {
 
 p {
   margin: 12px 0;
+}
 
+h1, h2, h3, h4, h5, h6, p {
   &:first-child {
     margin-top: 0;
   }

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -47,6 +47,11 @@
   }
 }
 
+.poll-chart {
+  margin-top: 12px;
+  height: 120px;
+}
+
 a.profile {
   &:hover {
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -1,4 +1,5 @@
 @import "_variables";
+@import "_mixins";
 
 .profile {
   color: inherit;
@@ -16,7 +17,7 @@
     padding-right: 6px;
     padding-left: 76px;
     box-sizing: border-box;
-    @media screen and (min-width: $smallscreen-width) {
+    @include largescreen {
       width: 60%;
       float: left;
     }
@@ -27,13 +28,13 @@
   .profile-poll {
     height: 100%;
     box-sizing: border-box;
-    @media screen and (min-width: $smallscreen-width) {
+    @include largescreen {
       width: 40%;
       float: right;
       border-left: 1px solid $border-color;
       padding-left: 6px
     }
-    @media screen and (max-width: $smallscreen-width) {
+    @include smallscreen {
       border-top: 1px solid $border-color;
       padding-top: 12px;
       margin-top: 12px;

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -1,7 +1,5 @@
 @import "_variables";
 
-$profile-small-size: 650px;
-
 .profile {
   color: inherit;
   display: block;
@@ -18,7 +16,7 @@ $profile-small-size: 650px;
     padding-right: 6px;
     padding-left: 76px;
     box-sizing: border-box;
-    @media screen and (min-width: $profile-small-size) {
+    @media screen and (min-width: $smallscreen-width) {
       width: 60%;
       float: left;
     }
@@ -29,13 +27,13 @@ $profile-small-size: 650px;
   .profile-poll {
     height: 100%;
     box-sizing: border-box;
-    @media screen and (min-width: $profile-small-size) {
+    @media screen and (min-width: $smallscreen-width) {
       width: 40%;
       float: right;
       border-left: 1px solid $border-color;
       padding-left: 6px
     }
-    @media screen and (max-width: $profile-small-size) {
+    @media screen and (max-width: $smallscreen-width) {
       border-top: 1px solid $border-color;
       padding-top: 12px;
       margin-top: 12px;

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,7 +11,7 @@
     %meta{:property => "og:site_name", :content => "Swap My Vote"}
     %meta{:property => "og:description", :content => "Make votes matter! Swap yours with someone in a constituency where both could count for more. You get to vote for who you really want, and help someone else do the same."}
     %meta{:property => "og:url", :content => "https://www.swapmyvote.uk"}
-
+    %meta{:name => "viewport", :content => "width=device-width, initial-scale=1"}
 
     = favicon_link_tag(source="favicon_16.png", {:sizes => "16x16"})
     = favicon_link_tag(source="favicon_32.png", {:sizes => "32x32"})

--- a/app/views/user/swaps/_swap_profile.html.haml
+++ b/app/views/user/swaps/_swap_profile.html.haml
@@ -13,6 +13,6 @@
   .profile-poll
     .text-center.small
       Polls in #{other_user.constituency.try(:name) or "Unknown"}
-    %div{id: "poll_#{other_user.id}"}
+    %div{class: "poll-chart", id: "poll_#{other_user.id}"}
   :javascript
     drawPollChart("poll_#{other_user.id}", #{poll_data_for(other_user.constituency)});


### PR DESCRIPTION
Smallscreen header:
<img width="333" alt="2019:11:08-22 20 28" src="https://user-images.githubusercontent.com/84737/68514661-411c6d80-0276-11ea-81c4-7ba1973b415d.png">

Smallscreen footer:
<img width="337" alt="2019:11:08-22 20 19" src="https://user-images.githubusercontent.com/84737/68514660-411c6d80-0276-11ea-868e-028d89230083.png">

Largescreen footer:
<img width="734" alt="2019:11:08-22 20 45" src="https://user-images.githubusercontent.com/84737/68514662-411c6d80-0276-11ea-93b9-ca0ea757eec9.png">
