### PR TITLE
Cookie consent

### DIFF
--- a/app/assets/javascripts/cookie_consent.coffee
+++ b/app/assets/javascripts/cookie_consent.coffee
@@ -1,6 +1,6 @@
-// The cookie consent cookie is set immediately on click, but does not take effect
-// until the next page refresh (possibly helped by turbolinks)
-// As a workaround, hide it until the user refreshes or changes page,
+# The cookie consent cookie is set immediately on click, but does not take effect
+# until the next page refresh (possibly helped by turbolinks)
+# Hide it until the user refreshes or changes page, when cookies consent should take care of it
 $ () ->
   $(document).on "click", ".cc-dismiss", ->
     console.log("Clicked dismiss")

--- a/app/assets/javascripts/cookie_consent.coffee
+++ b/app/assets/javascripts/cookie_consent.coffee
@@ -1,0 +1,8 @@
+// The cookie consent cookie is set immediately on click, but does not take effect
+// until the next page refresh (possibly helped by turbolinks)
+// As a workaround, hide it until the user refreshes or changes page,
+$ () ->
+  $(document).on "click", ".cc-dismiss", ->
+    console.log("Clicked dismiss")
+    $(".cc-message").hide()
+    $(".cc-dismiss").hide()

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -192,6 +192,24 @@ p.choose_party {
   }
 }
 
+// Cookie consent styling
+.cc-message {
+  display: block;
+  text-align: center
+}
+
+.cc-compliance {
+  padding-bottom: 5px;
+}
+
+.cc-dismiss {
+  margin: 0 auto;
+  border-radius: 2px;
+  padding: 5px;
+  display: block;
+  width: 172px;
+}
+
 $oscillation-size: 3px;
 @-webkit-keyframes oscillate {
 	from { 	-webkit-transform: rotate(0deg) translateX($oscillation-size) rotate(0deg); }

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -200,6 +200,10 @@ p.choose_party {
 
 .cc-compliance {
   padding-bottom: 5px;
+
+  a:hover {
+    text-decoration: none;
+  }
 }
 
 .cc-dismiss {
@@ -208,6 +212,7 @@ p.choose_party {
   padding: 5px;
   display: block;
   width: 172px;
+  cursor: pointer;
 }
 
 $oscillation-size: 3px;

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -22,6 +22,18 @@
     = javascript_include_tag 'application', 'data-turbolinks-track' => true
     = csrf_meta_tags
 
+    %script{:src => "https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js", :data-cfasync=> "false"}
+    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true
+    = javascript_include_tag 'application', 'data-turbolinks-track' => true
+    = csrf_meta_tags
+
+    %script{type: "text/javascript"}
+      (window.addEventListener("load", function(){
+      window.cookieconsent.initialise({ palette: { popup: { background: "#000"}, button: {background: "#f1d600" } },
+      content: { message: "This website uses cookies to ensure you get the best experience on our website",
+      dismiss: "Don't show this again" },
+      cookie: { domain: "swapmyvote.uk", domain: "swapmyvote.herokuapp.com", domain: "localhost"}})}));
+
     - if ENV['GOOGLE_ANALYTICS_ID']
       %script{:type => "text/javascript"}
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -27,6 +27,13 @@
     = javascript_include_tag 'application', 'data-turbolinks-track' => true
     = csrf_meta_tags
 
+    %script{type: "text/javascript"}
+      (window.addEventListener("load", function(){
+      window.cookieconsent.initialise({ palette: { popup: { background: "#000"}, button: {background: "#f1d600" } },
+      content: { message: "This website uses cookies to make sure you get the best experience on our website",
+      dismiss: "Don't show this again" },
+      cookie: { domain: ".swapmyvote.uk", domain: ".swapmyvote.herokuapp.com", domain: "localhost"}})}));
+
     - if ENV['GOOGLE_ANALYTICS_ID']
       %script{:type => "text/javascript"}
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -79,13 +86,6 @@
           %p.text-error.text-center= error
 
     = yield
-
-    %script{type: "text/javascript"}
-      (window.addEventListener("load", function(){
-      window.cookieconsent.initialise({ palette: { popup: { background: "#000"}, button: {background: "#f1d600" } },
-      content: { message: "This website uses cookies to make sure you get the best experience on our website",
-      dismiss: "Don't show this again" },
-      cookie: { domain: ".swapmyvote.uk", domain: ".swapmyvote.herokuapp.com", domain: "localhost"}})}));
 
     %footer
       .container

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -29,7 +29,7 @@
 
     %script{type: "text/javascript"}
       (window.addEventListener("load", function(){
-      window.cookieconsent.initialise({ palette: { popup: { background: "#000"}, button: {background: "#f1d600" } },
+      window.cookieconsent.initialise({ palette: { popup: { background: "#5cbdd3"}, button: {background: "#f1d600" } },
       content: { message: "This website uses cookies to make sure you get the best experience on our website",
       dismiss: "Don't show this again" },
       cookie: { domain: ".swapmyvote.uk", domain: ".swapmyvote.herokuapp.com", domain: "localhost"}})}));

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -27,13 +27,6 @@
     = javascript_include_tag 'application', 'data-turbolinks-track' => true
     = csrf_meta_tags
 
-    %script{type: "text/javascript"}
-      (window.addEventListener("load", function(){
-      window.cookieconsent.initialise({ palette: { popup: { background: "#000"}, button: {background: "#f1d600" } },
-      content: { message: "This website uses cookies to ensure you get the best experience on our website",
-      dismiss: "Don't show this again" },
-      cookie: { domain: "swapmyvote.uk", domain: "swapmyvote.herokuapp.com", domain: "localhost"}})}));
-
     - if ENV['GOOGLE_ANALYTICS_ID']
       %script{:type => "text/javascript"}
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -86,6 +79,13 @@
           %p.text-error.text-center= error
 
     = yield
+
+    %script{type: "text/javascript"}
+      (window.addEventListener("load", function(){
+      window.cookieconsent.initialise({ palette: { popup: { background: "#000"}, button: {background: "#f1d600" } },
+      content: { message: "This website uses cookies to make sure you get the best experience on our website",
+      dismiss: "Don't show this again" },
+      cookie: { domain: ".swapmyvote.uk", domain: ".swapmyvote.herokuapp.com", domain: "localhost"}})}));
 
     %footer
       .container

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -32,7 +32,7 @@
       window.cookieconsent.initialise({ palette: { popup: { background: "#5cbdd3"}, button: {background: "#f1d600" } },
       content: { message: "This website uses cookies to make sure you get the best experience on our website",
       dismiss: "Don't show this again" },
-      cookie: { domain: ".swapmyvote.uk", domain: ".swapmyvote.herokuapp.com", domain: "localhost"}})}));
+      cookie: { name: "_swapmyvote_cookie_consent", domain: ".swapmyvote.uk", domain: ".swapmyvote.herokuapp.com", domain: "localhost"}})}));
 
     - if ENV['GOOGLE_ANALYTICS_ID']
       %script{:type => "text/javascript"}


### PR DESCRIPTION
Display cookie consent for new users, use osana cookie consent with cdn

Cookie consent adds its own (cookie_consent status) cookie on accept, so it will need to be listed in our GDPR pages

Something (probably turbolinks) stops the cookie consent accept from firing properly until the next page refresh, so I've added some javascript with a temporary hide

API link for reference: https://www.osano.com/cookieconsent/documentation/javascript-api/
I use cookies inspector for chrome to make testing easier: https://chrome.google.com/webstore/detail/cookie-inspector/jgbbilmfbammlbbhmmgaagdkbkepnijn?hl=en
