### PR TITLE
Improve Mailchimp signup form

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -7,3 +7,4 @@ $border-color: #ddd;
 $button-color: #457BDA;
 $facebook-color: #3B5998;
 $twitter-color: #55ACEE;
+$error-color: #bf0000;

--- a/app/assets/stylesheets/mailchimp.scss
+++ b/app/assets/stylesheets/mailchimp.scss
@@ -1,0 +1,46 @@
+@import "_mixins";
+@import "_variables";
+
+#mc_embed_signup {
+    margin: 32px 0;
+
+    div.mce_inline_error {
+        position: absolute;
+        right: 0;
+        top: -20px;
+        font-size: 14px;
+    }
+}
+
+#mce-error-response {
+    color: $error-color;
+}
+
+.mc-field-group {
+    position: relative;
+
+    @include largescreen {
+        display: flex;
+    }
+}
+
+.mc-field-group .email {
+    padding: 4px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    font-size: 16px;
+    box-sizing: border-box;
+
+    @include largescreen {
+        flex: 1;
+        margin-left: 16px;
+    }
+
+    @include smallscreen {
+        width: 100%;
+    }
+}
+
+.mc-subscribe-button {
+    margin-top: 32px;
+}

--- a/app/views/home/_mailchimp.html
+++ b/app/views/home/_mailchimp.html
@@ -1,16 +1,38 @@
-<!-- Begin MailChimp Signup Form -->
-<link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
-<form action="//swapmyvote.us15.list-manage.com/subscribe/post?u=7076c2b7a929106d12659c8ff&amp;id=990c72457a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate text-center" target="_blank" novalidate>
-	<div class="mc-field-group">
-		<label for="mce-EMAIL">Email Address:</label>
-		<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" style="padding: 4px; border-radius: 4px; border: 1px solid #ccc; font-size: 16px; width: 350px" autofocus>
-	</div>
-	<div id="mce-responses" class="clear">
-		<div class="response" id="mce-error-response" style="display:none"></div>
-		<div class="response" id="mce-success-response" style="display:none"></div>
-	</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-	<div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_7076c2b7a929106d12659c8ff_86ca43a22f" tabindex="-1" value=""></div>
-	<div class="clear"><input type="submit" value="Subscribe for updates" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-</form>
-<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+<!-- Begin Mailchimp Signup Form -->
+<div id="mc_embed_signup">
+	<form action="https://swapmyvote.us15.list-manage.com/subscribe/post?u=7076c2b7a929106d12659c8ff&amp;id=990c72457a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+		<div id="mc_embed_signup_scroll">
+			<div class="mc-field-group">
+				<label for="mce-EMAIL">Email Address:</label>
+				<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" autofocus>
+			</div>
+			<div id="mce-responses" class="clear">
+				<div class="response" id="mce-error-response" style="display:none"></div>
+				<div class="response" id="mce-success-response" style="display:none"></div>
+			</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+			<div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_7076c2b7a929106d12659c8ff_990c72457a" tabindex="-1" value=""></div>
+			<div class="clear text-center"><input type="submit" value="Subscribe for updates" name="subscribe" id="mc-embedded-subscribe" class="button mc-subscribe-button"></div>
+		</div>
+	</form>
+</div>
+<script type="text/javascript">
+	// Don't allow Mailchimp to add CSS rules
+	var mc_custom_error_style = '';
+
+	$(function() {
+		$('<img/>')
+			.attr("src", "//mailchimp.com/favicon.ico")
+			.load(function(){
+				// The favicon could be loaded from Mailchimp, therefore there's
+				// a good chance that content blocking is not active. Load the
+				// Mailchimp for submit JS
+				$.getScript("//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js")
+			})
+			.error(function(){
+				console.log('Falling back to basic HTML form submit for Mailchimp, due to suspected content blocking');
+			});
+
+	});
+
+</script>
 <!--End mc_embed_signup-->


### PR DESCRIPTION
Fixes #56 

- Update to latest Mailchimp embed code
- Improve error message styling
- Conditionally load Mailchimp JS only if a test AJAX request works, to avoid content blocking issues in Firefox

Before:
<img width="400" alt="2019:11:12-20 45 48" src="https://user-images.githubusercontent.com/84737/68709384-80580080-058d-11ea-840a-382139741008.png">

After:
<img width="400" alt="2019:11:12-20 45 32" src="https://user-images.githubusercontent.com/84737/68709381-80580080-058d-11ea-96cd-7d9acdfbb342.png">

Before:
<img width="400" alt="2019:11:12-20 46 06" src="https://user-images.githubusercontent.com/84737/68709385-80580080-058d-11ea-88ae-8fbd5d6d77fc.png">

After:
<img width="400" alt="2019:11:12-20 45 39" src="https://user-images.githubusercontent.com/84737/68709383-80580080-058d-11ea-9e43-dc2cef97c45f.png">

