### PR TITLE
Only require email updates / notices for significant changes

### DIFF
--- a/app/views/static_pages/privacy.html.haml
+++ b/app/views/static_pages/privacy.html.haml
@@ -2,7 +2,7 @@
   .container
     %h1 Privacy Policy
 
-    %p Date this policy was last updated: November 18, 2019
+    %p Date this policy was last updated: November 19, 2019
 
     %h2(id="who") Who we are and how to contact us
 
@@ -303,13 +303,12 @@
 
       We may update our Privacy Policy from time to time. We will
       notify you of any changes by posting the new Privacy Policy on
-      this page.
+      this page, and update the "last updated date" at the top.
 
     %p
 
-      We will let you know via email or a prominent notice on our
-      website, and update the "last updated date" at the top of this
-      Privacy Policy.
+      We will let you know of any significant changes to the Policy
+      via email or a prominent notice on our website.
 
     %p
 


### PR DESCRIPTION
If we want to make minor tweaks to the policy (e.g. formatting,
grammar, fixing typos) then we shouldn't have to send out emails
or display prominent notices notifying users of the change.