### PR TITLE
don't prevent deep-linking

### DIFF
--- a/app/views/static_pages/terms.html.haml
+++ b/app/views/static_pages/terms.html.haml
@@ -177,9 +177,7 @@
 
     %p
 
-      Our website must not be framed on any other website, nor may you
-      create a link to any part of our website other than the home
-      page.
+      Our website must not be framed on any other website.
 
     %p
 


### PR DESCRIPTION
This seems a bit draconian; unless there is a really good reason
let's drop it.