### PR TITLE
Redact names

### DIFF
--- a/app/lib/name_redactor.rb
+++ b/app/lib/name_redactor.rb
@@ -1,0 +1,32 @@
+require "singleton"
+require "forwardable"
+
+class NameRedactor
+  include Singleton
+  extend SingleForwardable
+
+  def_delegator :instance, :redact
+
+  def redact(name)
+    return nil unless name
+
+    first, second, _rest = split_names(strip_leading_blanks(name))
+    [first, first_grapheme(second)].compact.join(' ')
+  end
+
+  private
+
+  def split_names(str)
+    str.split(/[[:space:]]+/)
+  end
+
+  def first_grapheme(str)
+    return nil unless str
+
+    str.each_grapheme_cluster.first
+  end
+
+  def strip_leading_blanks(str)
+    str.sub(/\A[[:space:]]+/, '')
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -167,4 +167,8 @@ class User < ApplicationRecord
     save
     UserMailer.reminder_to_vote(self).deliver_now
   end
+
+  def redacted_name
+    NameRedactor.redact(name)
+  end
 end

--- a/app/views/user/swaps/_swap_profile.html.haml
+++ b/app/views/user/swaps/_swap_profile.html.haml
@@ -1,6 +1,6 @@
 %img.profile-img{src: other_user.image_url}
 .profile-content
-  .profile-name= other_user.name
+  .profile-name= other_user.redacted_name
   .profile-constituency.subdued
     in #{other_user.constituency.try(:name) or "Unknown?"}
   .profile-votes

--- a/app/views/user/swaps/new.html.haml
+++ b/app/views/user/swaps/new.html.haml
@@ -4,10 +4,10 @@
       = render partial: "swap_profile", object: @swap_with, as: "other_user"
     = render partial: "user/swaps/double_check_constituency", locals: { swap_with: @swap_with }
     %p.text-center
-      Are you sure you would like to swap your vote with #{@swap_with.name}?
+      Are you sure you would like to swap your vote with #{@swap_with.redacted_name}?
     %p.text-center
       = link_to "Yes", user_swap_path(user_id: @swap_with.id), method: :post, class: "button"
     %p.text-center.small.subdued
-      We'll send #{@swap_with.name} a confirmation email, and if they agree,
+      We'll send #{@swap_with.redacted_name} a confirmation email, and if they agree,
       you're all good to go! Democracy here we come.
 

--- a/app/views/user_mailer/confirm_swap.html.haml
+++ b/app/views/user_mailer/confirm_swap.html.haml
@@ -1,8 +1,8 @@
 %p
 	Hi #{@user.name},
 %p
-	Good news! #{@swap_with.name} would like to swap their vote with you.
-	#{@swap_with.name} is voting in the #{@swap_with.constituency.name} constituency,
+	Good news! #{@swap_with.redacted_name} would like to swap their vote with you.
+	#{@swap_with.redacted_name} is voting in the #{@swap_with.constituency.name} constituency,
 	and will vote for the #{@swap_with.willing_party.name} party if you vote for the #{@swap_with.preferred_party.name} party in
 	your constituency!
 %p
@@ -11,9 +11,9 @@
 	Please confirm this swap as soon as possible. Votes for the #{@swap_with.willing_party.name}
 	party are in demand, so if you don't confirm this swap, we may not be able to find you someone else to swap with.
 	If we don't get a confirmation in the next 6 hours, we'll have to look for someone else to swap
-	#{@swap_with.name}'s vote with.
+	#{@swap_with.redacted_name}'s vote with.
 %p
-	If for any reason you don't wish to swap with #{@swap_with.name}, you can find new potential voting partners by simply updating your info using the link that says "Not right? Update your info". This will reset the swap, letting your partner know it has been cancelled. You are then free to select another voting partner from the list.
+	If for any reason you don't wish to swap with #{@swap_with.redacted_name}, you can find new potential voting partners by simply updating your info using the link that says "Not right? Update your info". This will reset the swap, letting your partner know it has been cancelled. You are then free to select another voting partner from the list.
 %p
 	Lastly, why not share Swap My Vote with your social networks so that more people can make their vote count?
 

--- a/app/views/user_mailer/swap_confirmed.html.haml
+++ b/app/views/user_mailer/swap_confirmed.html.haml
@@ -2,13 +2,13 @@
 	Hi #{@user.name},
 %p
 	You're all set to swap your vote with
-	%a{href: @swap_with.profile_url} #{@swap_with.name}!
-	#{@swap_with.name} is going to vote for the #{@swap_with.willing_party.name} party for you, in the #{@swap_with.constituency.name} constituency.
+	%a{href: @swap_with.profile_url} #{@swap_with.redacted_name}!
+	#{@swap_with.redacted_name} is going to vote for the #{@swap_with.willing_party.name} party for you, in the #{@swap_with.constituency.name} constituency.
 	In return, you will vote for the #{@swap_with.preferred_party.name} party in your constituency (#{@user.constituency.name}).
 %p
-	We'll send some reminders to #{@swap_with.name} to remind them to vote for your chosen party on December 12th, and we'll ask them for confirmation once they have.
+	We'll send some reminders to #{@swap_with.redacted_name} to remind them to vote for your chosen party on December 12th, and we'll ask them for confirmation once they have.
 	In the meantime, why not
-	%a{href: @swap_with.profile_url} reach out to #{@swap_with.name} directly?
+	%a{href: @swap_with.profile_url} reach out to #{@swap_with.redacted_name} directly?
 
 %p
 	Lastly, why not share Swap My Vote with your social networks so that more people can make their vote count?

--- a/app/views/user_mailer/swap_not_confirmed.html.haml
+++ b/app/views/user_mailer/swap_not_confirmed.html.haml
@@ -1,7 +1,7 @@
 %p
   Hi #{@user.name},
 %p
-  The 2019 General Election polls have just opened, but I'm afraid we haven't been able to confirm your pending swap with #{@user.swapped_with.name}.
+  The 2019 General Election polls have just opened, but I'm afraid we haven't been able to confirm your pending swap with #{@user.swapped_with.redacted_name}.
   All is not lost though - you can still vote tactically, or for the party you most wish to support.
 %p
   Thank you for taking part - together we are making democracy better and more representative.

--- a/app/views/users/show/_confirm_incoming_swap.html.haml
+++ b/app/views/users/show/_confirm_incoming_swap.html.haml
@@ -1,5 +1,5 @@
 %h3.text-center
-  #{@user.swapped_with.name} would like to swap their vote with you!
+  #{@user.swapped_with.redacted_name} would like to swap their vote with you!
 
 %p
   .card.profile
@@ -8,7 +8,7 @@
 = render partial: "user/swaps/double_check_constituency", locals: { swap_with: @user.swapped_with }
 
 %p.text-center
-  Please confirm that you would like to swap with #{@user.swapped_with.name}.
+  Please confirm that you would like to swap with #{@user.swapped_with.redacted_name}.
 
 %p.text-center
   = link_to "Yes please!", user_swap_path("swap[confirmed]" => "true"), method: "put", class: "button"
@@ -19,9 +19,9 @@
   .modal-dialog
     %i.fa.fa-times.subdued.modal-close
     %p.text-center
-      Are you sure you want to reject #{@user.swapped_with.name}?
+      Are you sure you want to reject #{@user.swapped_with.redacted_name}?
     %p.subdued.small.text-center
       Some voting preferences are in high demand, and we can't be sure that we'll
-      find anyone else to swap with if you turn down #{@user.swapped_with.name}
+      find anyone else to swap with if you turn down #{@user.swapped_with.redacted_name}
     %p.text-center
       = link_to "Reject", user_swap_path, method: "delete", class: "button"

--- a/app/views/users/show/_confirm_outgoing_swap.html.haml
+++ b/app/views/users/show/_confirm_outgoing_swap.html.haml
@@ -1,5 +1,5 @@
 %h3.text-center
-  You've asked to swap your vote with #{@user.swapped_with.name}!
+  You've asked to swap your vote with #{@user.swapped_with.redacted_name}!
 
 %p
   .card.profile
@@ -7,5 +7,5 @@
 
 %p.text-center
   %i.fa.fa-fw.fa-spin.fa-spinner
-  We're just waiting for #{@user.swapped_with.name} to confirm the swap!
+  We're just waiting for #{@user.swapped_with.redacted_name} to confirm the swap!
   If we don't hear back from them in 6 hours, we'll cancel the swap and you can pick someone else.

--- a/spec/lib/name_redactor_spec.rb
+++ b/spec/lib/name_redactor_spec.rb
@@ -1,0 +1,101 @@
+require "spec_helper"
+require_relative "../../app/lib/name_redactor"
+
+RSpec.describe NameRedactor do
+  subject { described_class.redact(name) }
+
+  context "when the name has two ASCII parts" do
+    let(:name) { "Bob Smith" }
+    it "returns the first name and first initial of second name" do
+      expect(subject).to eq("Bob S")
+    end
+  end
+
+  context "when there is leading ASCII space" do
+    let(:name) { "  Bob Smith" }
+    it "skips the space" do
+      expect(subject).to eq("Bob S")
+    end
+  end
+
+  context "when there is leading non-ASCII space" do
+    let(:name) { "　　Bob Smith" }
+    it "skips the space" do
+      expect(subject).to eq("Bob S")
+    end
+  end
+
+  context "when the name has multiple ASCII parts" do
+    let(:name) { "Melissa Auf der Maur" }
+    it "returns the first name and first initial of second name" do
+      expect(subject).to eq("Melissa A")
+    end
+  end
+
+  context "when the name has only one part" do
+    let(:name) { "Teller" }
+    it "returns the name" do
+      expect(subject).to eq(name)
+    end
+
+    context "and it is surrounded by ASCII space" do
+      let(:name) { "  Teller  " }
+      it "strips the surrounding space" do
+        expect(subject).to eq("Teller")
+      end
+    end
+
+    context "and it is surrounded by non-ASCII space" do
+      let(:name) { "　　Teller　　" }
+      it "strips the surrounding space" do
+        expect(subject).to eq("Teller")
+      end
+    end
+  end
+
+  context "when the name is in a non-Latin script" do
+    context "and there is no space" do
+      let(:name) { "山田太郎" }
+      it "returns the whole name" do
+        expect(subject).to eq(name)
+      end
+    end
+
+    context "and there is an ASCII space" do
+      let(:name) { "山田 太郎" }
+      it "returns the first name and first character of second name" do
+        expect(subject).to eq("山田 太")
+      end
+    end
+
+    context "and there is a non-ASCII space" do
+      let(:name) { "山田　太郎" }
+      it "returns the first name and first character of second name" do
+        expect(subject).to eq("山田 太")
+      end
+    end
+  end
+
+  context "when there is a diacritic on the initial" do
+    context "and the diacritic is precombined" do
+      let(:name) { "Dara \u00D3 Briain" }
+      it "returns the first name and first grapheme cluster of second name" do
+        expect(subject).to eq("Dara Ó")
+      end
+    end
+
+    context "and the diacritic is combining" do
+      let(:name) { "Dara O\u0301 Briain" }
+      it "returns the first name and first grapheme cluster of second name" do
+        expect(subject).to eq("Dara Ó")
+      end
+    end
+  end
+
+  context "when the name is nil" do
+    let(:name) { nil }
+    it "returns nil" do
+      expect(subject).to be_nil
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -66,4 +66,11 @@ RSpec.describe User, type: :model do
       specify { expect(&the_change).not_to change(no_swap_user, :ready_to_swap?).from(false) }
     end
   end
+
+  describe "#redacted_name" do
+    it "redacts the user's surname" do
+      subject.name = "Ada Lovelace"
+      expect(subject.redacted_name).to eq("Ada L")
+    end
+  end
 end


### PR DESCRIPTION
This:

- Redacts names as described in #47, paying attention to potential edge cases and non-ASCII names
- Exposes a `redacted_name` attribute on the `User` model (with an eye towards letting people set their on redacted name in future)
- Changes references to `name` in the views to use `redacted_name`

I think I've captured all the locations in which the name is displayed before a swap is confirmed, but it would be good if someone who is more familiar with the app could check that I (a) haven't missed any, and (b) haven't been too assiduous and redacted names where they shouldn't be.

Closes #47