### PR TITLE
add terminal-notifier to guard for mac users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ group :development, :test do
   gem "guard-rails"
   gem "guard-bundler"
   gem "guard-rubocop"
-  # gem "terminal-notifier-guard"
+  gem "terminal-notifier-guard"
 
   gem "rails-controller-testing"
   gem "factory_bot_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,6 +316,7 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.4.1)
     temple (0.8.2)
+    terminal-notifier-guard (1.7.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -376,6 +377,7 @@ DEPENDENCIES
   seedbank
   spring
   sqlite3
+  terminal-notifier-guard
   uglifier (>= 1.3.0)
   web-console
 

--- a/Guardfile
+++ b/Guardfile
@@ -15,6 +15,8 @@
 #
 # and, you'll have to watch "config/Guardfile" instead of "Guardfile"
 
+notification :terminal_notifier if `uname` =~ /Darwin/
+
 group :all_plugins, halt_on_fail: true do
 
   guard :bundler do


### PR DESCRIPTION
I don't know what happens if the teminal-notifier binary is not installed (e.g. with brew). Based on what happened when the gem is not installed, I would expect a friendly error message telling you exactly what to do. 

maybe add 'brew install terminal-notifier' (for mac users only) to the README ?