### PR TITLE
ditch /uk from API path (#80)

### DIFF
--- a/API.md
+++ b/API.md
@@ -3,11 +3,11 @@ Swap My Vote API
 
 We currently have a single end point to pre-populate some of the fields that a user can choose:
 
-http://www.swapmyvote.org/uk/swap
+https://www.swapmyvote.uk/swap
 
 Parameters should be passed in the query string, e.g.
 
-http://www.swapmyvote.uk/uk/swap?preferred_party_name=labour
+https://www.swapmyvote.uk/swap?preferred_party_name=labour
 
 Available parameters are:
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,5 +25,5 @@ Rails.application.routes.draw do
 
   get "admin/stats", to: "admin#stats"
 
-  get "uk/swap", to: "api#pre_populate"
+  get "swap", to: "api#pre_populate"
 end


### PR DESCRIPTION
We already have `.uk` in the domain.

(Much) later on we'll need to revisit this when adding support for other countries as in #43.

Fixes #80.