### PR TITLE
separate SERVER_HOST from port so we can choose a cookie name correctly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,11 @@
+# Determine what cookie name to use.  This can also be used to
+# construct SERVER_HOST_PORT below.
+export SERVER_HOST=localhost
+
 # This is used to figure out what URLs to generate when sending out
 # email.  It can't be done dynamically because the mailer instance
 # doesn't have any context about the incoming request.
-export SERVER_HOST_PORT=localhost:3000
+export SERVER_HOST_PORT=$SERVER_HOST:3000
 
 # You will need a Facebook application to allow log-ins via Facebook.
 # Obtain the app key and secret from https://developers.facebook.com/apps/

--- a/app/views/layouts/_cookie_consent.html.haml
+++ b/app/views/layouts/_cookie_consent.html.haml
@@ -12,10 +12,7 @@
       },
       cookie: {
         name: "_swapmyvote_cookie_consent",
-        domain: ".swapmyvote.uk",
-        domain: ".swapmyvote.herokuapp.com",
-        domain: ".swapmyvotedev.herokuapp.com",
-        domain: "localhost"
+        domain: "#{ENV['SERVER_HOST']}"
       }
     });
   });

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ module SwapMyVote
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
-    config.action_mailer.default_url_options = { host: ENV["SERVER_HOST"] }
+    config.action_mailer.default_url_options = { host: ENV["SERVER_HOST_PORT"] }
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
Previously we were only using SERVER_HOST to construct URLs in emails we send.  Now we want to use it to decide the right cookie name, so store the port number (if needed) in a separate variable.

Note that this requires every developer to tweak their `.env.development.localhost` file to match `.env.example`!

Fixes #134.