### PR TITLE
Only allow login if swaps are open

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -33,7 +33,7 @@
 
       - if logged_in?
         = render partial: "layouts/current_user"
-      - else
+      - elsif swapping_open? || params[:opensesame]
         = render partial: "layouts/login"
 
     - if flash[:errors]


### PR DESCRIPTION
Leave a (secure) backdoor so we can test login prior to launch.