### PR TITLE
Issue 8 add ons ids everywhere

### DIFF
--- a/app/controllers/user/constituencies_controller.rb
+++ b/app/controllers/user/constituencies_controller.rb
@@ -14,6 +14,6 @@ class User::ConstituenciesController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:constituency_id, :email)
+    params.require(:user).permit(:constituency_ons_id, :email)
   end
 end

--- a/app/controllers/user/constituencies_controller.rb
+++ b/app/controllers/user/constituencies_controller.rb
@@ -3,7 +3,7 @@ class User::ConstituenciesController < ApplicationController
   before_action :require_login
 
   def edit
-    @constituencies = Constituency.all.order(:name)
+    @constituencies = OnsConstituency.all.order(:name)
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,8 +45,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:preferred_party_id, :willing_party_id,
-                                 :constituency_id, :email)
+    params.require(:user).permit(:preferred_party_id, :willing_party_id, :constituency_ons_id, :email)
   end
 
   def phone_param

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,7 +17,7 @@ class UsersController < ApplicationController
   def edit
     @mobile_number = @user.mobile_number
     @parties = Party.all
-    @constituencies = Constituency.all.order(:name)
+    @constituencies = OnsConstituency.all.order(:name)
   end
 
   def update

--- a/app/models/ons_constituency.rb
+++ b/app/models/ons_constituency.rb
@@ -1,3 +1,6 @@
 class OnsConstituency < ApplicationRecord
   NUMBER_OF_UK_CONSTITUENCIES = 650
+  has_many :polls,
+           foreign_key: "constituency_ons_id",
+           primary_key: "ons_id"
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -1,4 +1,9 @@
 class Poll < ApplicationRecord
-  belongs_to :constituency
+  belongs_to :constituency,
+             class_name: "OnsConstituency",
+             foreign_key: "constituency_ons_id",
+             primary_key: "ons_id",
+             inverse_of: "polls",
+             optional: true
   belongs_to :party
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,12 @@
 class User < ApplicationRecord
   belongs_to :preferred_party, class_name: "Party", optional: true
   belongs_to :willing_party, class_name: "Party", optional: true
-  belongs_to :constituency, optional: true
   has_one    :mobile_phone, dependent: :destroy
+  belongs_to :constituency,
+             class_name: "OnsConstituency",
+             foreign_key: "constituency_ons_id",
+             primary_key: "ons_id",
+             optional: true
 
   belongs_to :outgoing_swap, class_name: "Swap", foreign_key: "swap_id",
              dependent: :destroy, optional: true
@@ -68,7 +72,7 @@ class User < ApplicationRecord
     swaps = User.where(
       preferred_party_id: willing_party_id,
       willing_party_id: preferred_party_id
-    ).where.not({ constituency_id: nil })
+    ).where.not({ constituency_ons_id: nil })
     offset = rand(swaps.count)
     target_user = swaps.offset(offset).limit(1).first
     return nil unless target_user
@@ -142,18 +146,18 @@ class User < ApplicationRecord
   end
 
   def details_changed?
-    preferred_party_id_changed? || willing_party_id_changed? || constituency_id_changed?
+    preferred_party_id_changed? || willing_party_id_changed? || constituency_ons_id_changed?
   end
 
   def ready_to_swap?
     ready =
       !preferred_party_id.blank? &&
       !willing_party_id.blank? &&
-      !constituency_id.blank?
+      !constituency_ons_id.blank?
     first_time =
       preferred_party_id_was.blank? ||
       willing_party_id_was.blank? ||
-      constituency_id_was.blank?
+      constituency_ons_id_was.blank?
     return (ready && first_time)
   end
 

--- a/app/views/user/constituencies/edit.html.haml
+++ b/app/views/user/constituencies/edit.html.haml
@@ -8,9 +8,9 @@
           .subdued.small We only need your email to let you know when we've found a swap partner for you. No spam, and your details will stay private with us.
       %p.ui-widget
         My constituency is
-        = f.collection_select :constituency_id, @constituencies,
+        = f.collection_select :constituency_ons_id, @constituencies,
                               :id, :name,
-                              selected: @user.constituency_id,
+                              selected: @user.constituency_ons_id,
                               prompt: true
       %p.text-center
         = submit_tag("Save", class: "button")

--- a/app/views/user/constituencies/edit.html.haml
+++ b/app/views/user/constituencies/edit.html.haml
@@ -9,7 +9,7 @@
       %p.ui-widget
         My constituency is
         = f.collection_select :constituency_ons_id, @constituencies,
-                              :id, :name,
+                              :ons_id, :name,
                               selected: @user.constituency_ons_id,
                               prompt: true
       %p.text-center

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -20,9 +20,9 @@
 
       %p
         My constituency is
-        = f.collection_select :constituency_id, @constituencies,
+        = f.collection_select :constituency_ons_id, @constituencies,
                               :id, :name, prompt: "...",
-                              selected: @user.constituency_id
+                              selected: @user.constituency_ons_id
 
       %p
         My email address is

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -21,7 +21,7 @@
       %p
         My constituency is
         = f.collection_select :constituency_ons_id, @constituencies,
-                              :id, :name, prompt: "...",
+                              :ons_id, :name, prompt: "...",
                               selected: @user.constituency_ons_id
 
       %p

--- a/db/migrate/20191123143443_change_user_to_ons_constituency.rb
+++ b/db/migrate/20191123143443_change_user_to_ons_constituency.rb
@@ -1,0 +1,19 @@
+require_relative "../fixtures/ons_constituency_lookup"
+
+class ChangeUserToOnsConstituency < ActiveRecord::Migration[5.2]
+  def up
+    cons_id_to_ons_lookup = OnsConstituencyLookup.new
+
+    User.all.each do |user|
+      unless user.constituency_id.nil?
+        ons_id = cons_id_to_ons_lookup.find_by_id(user.constituency_id)
+        user.update!(constituency_ons_id: ons_id) unless ons_id.nil?
+      end
+    end
+    rename_column :users, :constituency_id, :old_constituency_id
+  end
+
+  def down
+    rename_column :users, :old_constituency_id, :constituency_id
+  end
+end

--- a/db/migrate/20191123145905_change_poll_to_ons_constituency.rb
+++ b/db/migrate/20191123145905_change_poll_to_ons_constituency.rb
@@ -1,0 +1,19 @@
+require_relative "../fixtures/ons_constituency_lookup"
+
+class ChangePollToOnsConstituency < ActiveRecord::Migration[5.2]
+  def up
+    cons_id_to_ons_lookup = OnsConstituencyLookup.new
+
+    Poll.all.each do |poll|
+      unless poll.constituency_id.nil?
+        ons_id = cons_id_to_ons_lookup.find_by_id(poll.constituency_id)
+        poll.update!(constituency_ons_id: ons_id) unless ons_id.nil?
+      end
+    end
+    rename_column :polls, :constituency_id, :old_constituency_id
+  end
+
+  def down
+    rename_column :polls, :old_constituency_id, :constituency_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_23_122646) do
+ActiveRecord::Schema.define(version: 2019_11_23_145905) do
 
   create_table "constituencies", force: :cascade do |t|
     t.string "name"
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 2019_11_23_122646) do
   end
 
   create_table "polls", force: :cascade do |t|
-    t.integer "constituency_id"
+    t.integer "old_constituency_id"
     t.integer "party_id"
     t.integer "votes"
     t.datetime "created_at", null: false
@@ -77,15 +77,15 @@ ActiveRecord::Schema.define(version: 2019_11_23_122646) do
     t.datetime "expires_at"
     t.integer "preferred_party_id"
     t.integer "willing_party_id"
-    t.integer "constituency_id"
+    t.integer "old_constituency_id"
     t.integer "swap_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "has_voted", default: false
     t.boolean "sent_vote_reminder_email", default: false
+    t.string "constituency_ons_id"
     t.integer "mobile_phone_id"
     t.index ["mobile_phone_id"], name: "index_users_on_mobile_phone_id", unique: true
-    t.string "constituency_ons_id"
   end
 
 end

--- a/db/seeds/development/users.seeds.rb
+++ b/db/seeds/development/users.seeds.rb
@@ -1,11 +1,17 @@
+
+
 def create_random_user(i, preferred_party_id, willing_party_id)
   gender = rand > 0.5 ? "female" : "male"
   firstname = gender == "male" ? Random.firstname_male : Random.firstname_female
 
+  ons_constituency_id = rand(1 + OnsConstituency.count)
+
+  ons_id = OnsConstituency.find_by_id(ons_constituency_id).ons_id
+
   User.create(
     name: "#{firstname} #{Random.lastname}",
     email: "#{firstname.downcase}@example.com",
-    constituency_id: rand(1 + Constituency.count),
+    constituency_ons_id: ons_id,
     preferred_party_id: preferred_party_id,
     willing_party_id: willing_party_id,
     image: format("http://api.randomuser.me/portraits/med/%s/#{i}.jpg",

--- a/spec/controllers/user/constituencies_controller_spec.rb
+++ b/spec/controllers/user/constituencies_controller_spec.rb
@@ -42,16 +42,16 @@ RSpec.describe User::ConstituenciesController, type: :controller do
 
         it "finds user based on session user_id" do
           expect(User).to receive(:find_by_id).with(:some_user_id).and_return(logged_in_user)
-          patch :update, params: { user: { constituency_id: 2, email: "a@b.c" }   }
+          patch :update, params: { user: { constituency_ons_id: 2, email: "a@b.c" }   }
         end
 
         it "updates the user" do
           expect(logged_in_user).to receive(:update)
-          patch :update, params: { user: { constituency_id: 2, email: "a@b.c" }   }
+          patch :update, params: { user: { constituency_ons_id: 2, email: "a@b.c" }   }
         end
 
         it "redirects to user share" do
-          patch :update, params: { user: { constituency_id: 2, email: "a@b.c" }   }
+          patch :update, params: { user: { constituency_ons_id: 2, email: "a@b.c" }   }
           expect(response).to redirect_to(:user_share)
         end
       end

--- a/spec/controllers/user/constituencies_controller_spec.rb
+++ b/spec/controllers/user/constituencies_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe User::ConstituenciesController, type: :controller do
       describe "GET #edit" do
         let(:constituencies_list) { double(:constituencies_list) }
         before do
-          allow(Constituency).to receive(:all).and_return(constituencies_list)
+          allow(OnsConstituency).to receive(:all).and_return(constituencies_list)
           allow(constituencies_list).to receive(:order).with(:name).and_return(double.as_null_object)
         end
 
@@ -27,7 +27,7 @@ RSpec.describe User::ConstituenciesController, type: :controller do
         end
 
         it "loads all constituencies" do
-          expect(Constituency).to receive(:all).and_return(constituencies_list)
+          expect(OnsConstituency).to receive(:all).and_return(constituencies_list)
           get :edit
         end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe UsersController, type: :controller do
   context "when user is logged in" do
     let(:logged_in_user) do
       build(:user, id: 1,
-            constituency: build(:constituency),
+            constituency: build(:ons_constituency),
             email: "foo@bar.com")
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe UsersController, type: :controller do
     describe "POST #update" do
       it "redirects to #show" do
         expect(logged_in_user).to receive(:update)
-        post :update, params: { user: { constituency_id: 2, email: "a@b.c" } }
+        post :update, params: { user: { constituency_ons_id: 2, email: "a@b.c" } }
         expect(response).to redirect_to(:user)
       end
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe UsersController, type: :controller do
     describe "GET #edit" do
       let(:constituencies_list) { double(:constituencies_list) }
       before do
-        allow(Constituency).to receive(:all).and_return(constituencies_list)
+        allow(OnsConstituency).to receive(:all).and_return(constituencies_list)
         allow(constituencies_list).to receive(:order).with(:name).and_return(double.as_null_object)
       end
 
@@ -35,7 +35,7 @@ RSpec.describe UsersController, type: :controller do
       end
 
       it "loads all constituencies" do
-        expect(Constituency).to receive(:all).and_return(constituencies_list)
+        expect(OnsConstituency).to receive(:all).and_return(constituencies_list)
         get :edit
       end
 

--- a/spec/factories/ons_constituency.rb
+++ b/spec/factories/ons_constituency.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :ons_constituency do
+    name { "Brighton Pavilion" }
+    ons_id { "factory-faked-ons-id"}
+  end
+end

--- a/spec/fixtures/ons_constituencies.yml
+++ b/spec/fixtures/ons_constituencies.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+lw:
+  name: Liverpool Walton
+  ons_id: E2092098
+
+knowsley:
+  name: Knowsley
+  ons_id: E2096666
+
+lwd:
+  name: Liverpool West Derby
+  ons_id: E2093333

--- a/spec/helpers/polls_helper_spec.rb
+++ b/spec/helpers/polls_helper_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe PollsHelper, type: :helper do
   describe "#poll_data_for" do
-    let(:constituency) { Constituency.new(id: 1) }
+    let(:constituency) { OnsConstituency.new(id: 1) }
 
     specify { expect { helper.poll_data_for(constituency) }.not_to raise_error }
   end

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Poll, type: :model do
     end
 
     context "with poll with constituency id" do
-      let(:constituency) { Constituency.create!(name: "test con 2 for polls") }
-      let(:poll) { Poll.new(votes: 654, constituency_id: constituency.id) }
+      let(:constituency) { OnsConstituency.create!(name: "test con 2 for polls", ons_id: "a-fake-ons-id") }
+      let(:poll) { Poll.new(votes: 654, constituency_ons_id: constituency.ons_id) }
 
       it "is expected constituency" do
         expect(poll.constituency).to eq(constituency)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe User, type: :model do
     end
 
     context "with user with constituency id" do
-      let(:constituency) { Constituency.create!(name: "test con 1") }
-      let(:user) { User.new(name: "test user", constituency_id: constituency.id) }
+      let(:constituency) { OnsConstituency.create!(name: "test con 1", ons_id: "another-fake-ons-id") }
+      let(:user) { User.new(name: "test user", constituency_ons_id: constituency.ons_id) }
 
       it "is expected constituency" do
         expect(user.constituency).to eq(constituency)
@@ -46,7 +46,7 @@ RSpec.describe User, type: :model do
     specify { expect(no_swap_user).not_to be_ready_to_swap}
 
     context "setting constituency" do
-      let(:the_change) { ->{ no_swap_user.constituency_id = 3 } }
+      let(:the_change) { ->{ no_swap_user.constituency_ons_id = "some-fake-ons-id" } }
 
       specify { expect(&the_change).to change(no_swap_user, :details_changed?).from(false).to(true) }
       specify { expect(&the_change).not_to change(no_swap_user, :ready_to_swap?).from(false) }

--- a/spec/views/user/constituencies/edit.html.haml_spec.rb
+++ b/spec/views/user/constituencies/edit.html.haml_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "user/constituencies/edit.html.haml", type: :view do
+  fixtures :ons_constituencies
+
   it "asks for constituency" do
     assign(:user, User.new)
     assign(:constituencies, OnsConstituency.all.order(:name))
@@ -9,7 +11,7 @@ RSpec.describe "user/constituencies/edit.html.haml", type: :view do
 
     # puts rendered
 
-    ["My constituency is", "Liverpool", "Knowsley", "E14000775"].each do |s|
+    ["My constituency is", "Liverpool", "Knowsley", "E2096666"].each do |s|
       expect(rendered).to include s
     end
   end

--- a/spec/views/user/constituencies/edit.html.haml_spec.rb
+++ b/spec/views/user/constituencies/edit.html.haml_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "user/constituencies/edit.html.haml", type: :view do
-
   it "asks for constituency" do
     assign(:user, User.new)
     assign(:constituencies, OnsConstituency.all.order(:name))

--- a/spec/views/user/constituencies/edit.html.haml_spec.rb
+++ b/spec/views/user/constituencies/edit.html.haml_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe "user/constituencies/edit.html.haml", type: :view do
 
     render
 
-    ["My constituency is", "Liverpool", "Knowsley"].each do |s|
+    # puts rendered
+
+    ["My constituency is", "Liverpool", "Knowsley", "E14000775"].each do |s|
       expect(rendered).to include s
     end
   end

--- a/spec/views/user/constituencies/edit.html.haml_spec.rb
+++ b/spec/views/user/constituencies/edit.html.haml_spec.rb
@@ -1,11 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "user/constituencies/edit.html.haml", type: :view do
-  fixtures :constituencies
 
   it "asks for constituency" do
     assign(:user, User.new)
-    assign(:constituencies, Constituency.all.order(:name))
+    assign(:constituencies, OnsConstituency.all.order(:name))
 
     render
 

--- a/spec/views/users/edit.html.haml_spec.rb
+++ b/spec/views/users/edit.html.haml_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe "users/edit", type: :view do
-  it "does not blow up" do
+
+  before do
     user = build(:user)
-    # session[:user_id] = user.id
 
     assign(:mobile_number, user.mobile_number)
     assign(:user, user)
@@ -11,5 +11,14 @@ RSpec.describe "users/edit", type: :view do
     assign(:constituencies, OnsConstituency.all.order(:name))
 
     expect { render }.not_to raise_error
+  end
+
+  it "displays constituency" do
+    render
+
+    ["My constituency is", "Liverpool", "Knowsley", "E14000775"].each do |s|
+      expect(rendered).to include s
+    end
+
   end
 end

--- a/spec/views/users/edit.html.haml_spec.rb
+++ b/spec/views/users/edit.html.haml_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "users/edit", type: :view do
+  it "does not blow up" do
+    user = build(:user)
+    # session[:user_id] = user.id
+
+    assign(:mobile_number, user.mobile_number)
+    assign(:user, user)
+    assign(:parties, Party.all)
+    assign(:constituencies, Constituency.all.order(:name))
+
+    expect { render }.not_to raise_error
+  end
+end

--- a/spec/views/users/edit.html.haml_spec.rb
+++ b/spec/views/users/edit.html.haml_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "users/edit", type: :view do
     assign(:mobile_number, user.mobile_number)
     assign(:user, user)
     assign(:parties, Party.all)
-    assign(:constituencies, Constituency.all.order(:name))
+    assign(:constituencies, OnsConstituency.all.order(:name))
 
     expect { render }.not_to raise_error
   end

--- a/spec/views/users/edit.html.haml_spec.rb
+++ b/spec/views/users/edit.html.haml_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "users/edit", type: :view do
-
   before do
     user = build(:user)
 
@@ -19,6 +18,5 @@ RSpec.describe "users/edit", type: :view do
     ["My constituency is", "Liverpool", "Knowsley", "E14000775"].each do |s|
       expect(rendered).to include s
     end
-
   end
 end

--- a/spec/views/users/edit.html.haml_spec.rb
+++ b/spec/views/users/edit.html.haml_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "users/edit", type: :view do
+  fixtures :ons_constituencies
+
   before do
     user = build(:user)
 
@@ -15,7 +17,7 @@ RSpec.describe "users/edit", type: :view do
   it "displays constituency" do
     render
 
-    ["My constituency is", "Liverpool", "Knowsley", "E14000775"].each do |s|
+    ["My constituency is", "Liverpool", "Knowsley", "E2096666"].each do |s|
       expect(rendered).to include s
     end
   end


### PR DESCRIPTION
This is the PR that changes everything for Constituencies.

* we add the ONS id in the User and Poll models
* the Constituency model retains the old-style names ... but it gets disconnected from polls and users and we use the new OnsConstituency model in its place. Relationships like `.constituency` continue to work, they just return the OnsConstituency instances. 
* the OnsConstituency model retains the new-style names ... which may have a detrimental UX effect when picking constituencies. 
