### PR TITLE
Delete prepopulated fields from session once they've been used

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,14 +7,23 @@ class HomeController < ApplicationController
 
     @parties = Party.all
 
-    return if session["pre_populate"].nil?
+    prepopulate_fields_from_session
+  end
+
+  private
+
+  def prepopulate_fields_from_session
+    prepop = session["pre_populate"]
+    return if prepop.nil?
 
     @parties.each do |party|
       if canonical_name(party.name) == prepopulated_party("preferred_party_name")
         @preferred_party_id = party.id
+        prepop.delete "preferred_party_name"
       end
       if canonical_name(party.name) == prepopulated_party("willing_party_name")
         @willing_party_id = party.id
+        prepop.delete "willing_party_name"
       end
     end
   end


### PR DESCRIPTION
This means that prepopulation only happens the first time the link is followed, and if the user reloads the home page or returns to it later as normal (not via the API) then prepopulation will not occur.