### PR TITLE
Store profile_url for facebook identities (#48)

### DIFF
--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -11,21 +11,23 @@ class Identity < ApplicationRecord
       identity.image_url = auth.info.image
       identity.name = auth.info.name
       identity.email = auth.info.email unless auth.info.email.blank?
-
       identity.user_id = user_id
+
+      if auth.provider == "facebook"
+        identity.profile_url = auth.info.urls["Facebook"]
+        # It looks like auth.extra.raw_info.link would also work here.
+      end
 
       identity.save!
     end
   end
 
   def profile_url
+    return self[:profile_url] unless self[:profile_url].blank?
+
     case provider
     when "twitter"
       "https://twitter.com/intent/user?user_id=#{uid}"
-    when "facebook"
-      # This is not the profile url, but will also not produce errors, and should only be temporary until
-      # we have proper fb permissions
-      "https://facebook.com/"
     else
       "#"
     end

--- a/db/migrate/20191127224254_add_profile_url_to_identity.rb
+++ b/db/migrate/20191127224254_add_profile_url_to_identity.rb
@@ -1,0 +1,5 @@
+class AddProfileUrlToIdentity < ActiveRecord::Migration[5.2]
+  def change
+    add_column :identities, :profile_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_27_125417) do
+ActiveRecord::Schema.define(version: 2019_11_27_224254) do
 
   create_table "constituencies", force: :cascade do |t|
     t.string "name"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2019_11_27_125417) do
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "profile_url"
     t.index ["user_id"], name: "index_identities_on_user_id"
   end
 

--- a/spec/requests/user/callbacks_spec.rb
+++ b/spec/requests/user/callbacks_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-RSpec.describe "Sessions", type: :request do
-  context "For omniauth testing" do
+RSpec.describe "OmniAuth", type: :request do
+  context "Twitter login" do
     before do
       OmniAuth.config.test_mode = true
       OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new({
@@ -47,6 +47,41 @@ RSpec.describe "Sessions", type: :request do
       expect(user.image_url).to eq "https://image.com/654321"
       expect(user.provider).to eq "twitter"
       expect(user.profile_url).to eq "https://twitter.com/intent/user?user_id=123545"
+      expect(user.token).to eq "ABC123"
+      expect(user.expires_at).to eq Time.zone.now.midnight
+    end
+  end
+
+  context "Facebook login" do
+    before do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.mock_auth[:facebook] = OmniAuth::AuthHash.new({
+        provider: "facebook",
+        uid: "98723948",
+        info: {
+          name: "Joe Bloggs",
+          email: "joe@bloggs.com",
+          image: "http://graph.facebook.com/v3.0/98723948/picture",
+          urls: { Facebook: "https://facebook.com/joe.bloggs" },
+        },
+        credentials: { token: "ABC123", expires_at: Time.zone.now.midnight }
+      })
+    end
+
+    it "creates both user and identity on first login" do
+      get "/auth/facebook/callback", params: {}, headers: {}
+
+      expect(response.status).to eq 302
+
+      user = User.joins(:identity).find_by(identities: { uid: "98723948" })
+      expect(user.name).to eq "Joe Bloggs"
+      expect(user.email).to eq "joe@bloggs.com"
+      expect(user.identity.email).to eq "joe@bloggs.com"
+      expect(user.image_url) \
+        .to eq "http://graph.facebook.com/v3.0/98723948/picture"
+      expect(user.provider).to eq "facebook"
+      expect(user.profile_url) \
+        .to eq "https://facebook.com/joe.bloggs"
       expect(user.token).to eq "ABC123"
       expect(user.expires_at).to eq Time.zone.now.midnight
     end


### PR DESCRIPTION
Add a new `profile_url` field to the `identities` db table, and store Facebook profile URLs in it for use in view templates.

Fixes #48.