### PR TITLE
Enforce phone verification

### DIFF
--- a/app/controllers/user/swaps_controller.rb
+++ b/app/controllers/user/swaps_controller.rb
@@ -29,7 +29,6 @@ class User::SwapsController < ApplicationController
   end
 
   def update
-    update_phone
     if swap_params[:confirmed] == "true"
       @user.confirm_swap
     end
@@ -60,19 +59,6 @@ class User::SwapsController < ApplicationController
   def assert_parties_exist
     return if @user.willing_party && @user.preferred_party
     redirect_to edit_user_path
-  end
-
-  def update_phone
-    return if phone_param.blank?
-    return if @user.mobile_number == phone_param
-
-    begin
-      @user.mobile_number = phone_param
-    rescue ActiveRecord::RecordInvalid
-      flash[:errors] = @user.mobile_phone.errors.full_messages
-      redirect_to edit_user_path
-      return
-    end
   end
 
   def swap_params

--- a/app/controllers/user/swaps_controller.rb
+++ b/app/controllers/user/swaps_controller.rb
@@ -3,7 +3,7 @@ class User::SwapsController < ApplicationController
   before_action :require_login
   before_action :assert_incoming_swap_exists, only: [:update, :destroy]
   before_action :assert_parties_exist, only: [:show]
-  before_action :assert_mobile_phone_verified, only: [:new, :create]
+  before_action :assert_mobile_phone_verified, only: [:new, :create, :update]
 
   include UsersHelper
 
@@ -42,7 +42,7 @@ class User::SwapsController < ApplicationController
   private
 
   def assert_mobile_phone_verified
-    return if @user.verified
+    return if @user.phone_verified?
 
     flash[:errors] = ["Please verify your mobile phone number before you swap!"]
     redirect_to edit_user_path

--- a/app/controllers/user/swaps_controller.rb
+++ b/app/controllers/user/swaps_controller.rb
@@ -8,6 +8,7 @@ class User::SwapsController < ApplicationController
   include UsersHelper
 
   def show
+    @mobile_number = @user.mobile_number
     if @user.swapped?
       redirect_to user_path
       return
@@ -28,9 +29,11 @@ class User::SwapsController < ApplicationController
   end
 
   def update
+    update_phone
     if swap_params[:confirmed] == "true"
       @user.confirm_swap
     end
+
     redirect_to user_path
   end
 
@@ -57,6 +60,19 @@ class User::SwapsController < ApplicationController
   def assert_parties_exist
     return if @user.willing_party && @user.preferred_party
     redirect_to edit_user_path
+  end
+
+  def update_phone
+    return if phone_param.blank?
+    return if @user.mobile_number == phone_param
+
+    begin
+      @user.mobile_number = phone_param
+    rescue ActiveRecord::RecordInvalid
+      flash[:errors] = @user.mobile_phone.errors.full_messages
+      redirect_to edit_user_path
+      return
+    end
   end
 
   def swap_params

--- a/app/controllers/user/swaps_controller.rb
+++ b/app/controllers/user/swaps_controller.rb
@@ -3,6 +3,7 @@ class User::SwapsController < ApplicationController
   before_action :require_login
   before_action :assert_incoming_swap_exists, only: [:update, :destroy]
   before_action :assert_parties_exist, only: [:show]
+  before_action :assert_mobile_phone_verified, only: [:new, :create]
 
   include UsersHelper
 
@@ -39,6 +40,13 @@ class User::SwapsController < ApplicationController
   end
 
   private
+
+  def assert_mobile_phone_verified
+    return if @user.verified
+
+    flash[:errors] = ["Please verify your mobile phone number before you swap!"]
+    redirect_to edit_user_path
+  end
 
   def assert_incoming_swap_exists
     return if @user.incoming_swap

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,8 +28,6 @@ class UsersController < ApplicationController
         @user.mobile_number = phone_param
       rescue ActiveRecord::RecordInvalid
         flash[:errors] = @user.mobile_phone.errors.full_messages
-        redirect_to redirect_path
-        return
       end
     end
 
@@ -56,7 +54,7 @@ class UsersController < ApplicationController
   end
 
   def phone_param
-    return params[:mobile_phone][:number] if params[:mobile_phone][:number]
+    return params[:mobile_phone][:number] if params[:mobile_phone] && params[:mobile_phone][:number]
 
     (params[:mobile_phone] || {})[:full]
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,6 @@ class User < ApplicationRecord
   has_many :sent_emails, dependent: :destroy
 
   delegate :profile_url, to: :identity, prefix: false
-  delegate :verified, to: :mobile_phone, prefix: false
 
   before_save :clear_swap, if: :details_changed?
   after_save :send_welcome_email, if: :needs_welcome_email?
@@ -73,6 +72,11 @@ class User < ApplicationRecord
   def destroy_all_potential_swaps
     PotentialSwap.destroy(potential_swaps.pluck(:id))
     PotentialSwap.destroy(incoming_potential_swaps.pluck(:id))
+  end
+
+  def phone_verified?
+    return false unless mobile_phone
+    mobile_phone.verified
   end
 
   def swap_with_user_id(user_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,7 @@ class User < ApplicationRecord
   has_many :sent_emails, dependent: :destroy
 
   delegate :profile_url, to: :identity, prefix: false
+  delegate :verified, to: :mobile_phone, prefix: false
 
   before_save :clear_swap, if: :details_changed?
   after_save :send_welcome_email, if: :needs_welcome_email?

--- a/app/views/mobile_phone/_form.html.haml
+++ b/app/views/mobile_phone/_form.html.haml
@@ -1,0 +1,12 @@
+%p
+  My phone number is
+  = telephone_field_tag "mobile_phone[number]", @mobile_number
+
+  - if @mobile_number.present?
+    - if mobile_verified?
+      Verified!
+    - else
+      = button_tag "Verify", formaction: verify_mobile_path,
+        formmethod: :get
+  - else
+    = submit_tag("Save")

--- a/app/views/mobile_phone/_form.html.haml
+++ b/app/views/mobile_phone/_form.html.haml
@@ -1,6 +1,6 @@
 %p
   My phone number is
-  = telephone_field_tag "mobile_phone[number]", mobile_number, size: 14
+  = telephone_field_tag "mobile_phone[full]", mobile_number, size: 14
 
   - if mobile_number.present?
     - if mobile_verified?

--- a/app/views/mobile_phone/_form.html.haml
+++ b/app/views/mobile_phone/_form.html.haml
@@ -1,6 +1,6 @@
 %p
   My phone number is
-  = telephone_field_tag "mobile_phone[number]", mobile_number
+  = telephone_field_tag "mobile_phone[number]", mobile_number, size: 14
 
   - if mobile_number.present?
     - if mobile_verified?

--- a/app/views/mobile_phone/_form.html.haml
+++ b/app/views/mobile_phone/_form.html.haml
@@ -1,8 +1,8 @@
 %p
   My phone number is
-  = telephone_field_tag "mobile_phone[number]", @mobile_number
+  = telephone_field_tag "mobile_phone[number]", mobile_number
 
-  - if @mobile_number.present?
+  - if mobile_number.present?
     - if mobile_verified?
       Verified!
     - else

--- a/app/views/user/swaps/_searching_for_swap.html.haml
+++ b/app/views/user/swaps/_searching_for_swap.html.haml
@@ -2,13 +2,39 @@
   %span
     %i.fa.fa-2x.fa-search
     We’re looking for a voting partner for you.
-%p At the moment we have more voters who want to vote the same way as you, but fewer with complementary preferences.
+
 %p
-  Help us find more potential voting partners by sharing Swap My Vote with your friends!
+
+  At the moment we have more voters who want to vote the same way as
+  you, but fewer with complementary preferences.
+
+%h2 While you're waiting ...
+
+- if !@user.phone_verified?
+
+  %h3 Why not verify your phone number?
+
+  %p
+
+    This is required before confirming a swap in order to prove you're
+    a genuine account.
+
+  = form_for @user, url: user_path do
+    = render partial: 'mobile_phone/form', locals: {mobile_number: @mobile_number}
+
+%h3 Spread the word!
+
+%p
+
+  You can also help us find more potential voting partners by sharing
+  Swap My Vote with your friends!
+
 %p.text-center
+
   %a.button.button-facebook{href: "#", onclick: "shareOnFacebook('#{ENV['FACEBOOK_KEY']}', 'http://www.swapmyvote.uk', 'Join me in making our votes count for more: #swapmyvote'); return false"}
     %i.fa.fa-facebook.fa-fw
     Share on Facebook
+
   %a.button.button-twitter{href: "#", onclick: "shareOnTwitter('http://www.swapmyvote.uk', 'Join me in making our votes count for more: #swapmyvote'); return false"}
     %i.fa.fa-twitter.fa-fw
     Share on Twitter

--- a/app/views/user/swaps/_summary.html.haml
+++ b/app/views/user/swaps/_summary.html.haml
@@ -1,0 +1,8 @@
+
+%p.text-center
+  You have
+  %strong= @potential_swaps.length
+  potential swaps.
+
+%p.text-center
+  %a{href: edit_user_path} Please verify your mobile phone number before you swap

--- a/app/views/user/swaps/_summary.html.haml
+++ b/app/views/user/swaps/_summary.html.haml
@@ -1,8 +1,0 @@
-
-%p.text-center
-  You have
-  %strong= @potential_swaps.length
-  potential swaps.
-
-%p.text-center
-  %a{href: edit_user_path} You must verify your mobile phone number before you swap

--- a/app/views/user/swaps/_summary.html.haml
+++ b/app/views/user/swaps/_summary.html.haml
@@ -5,4 +5,4 @@
   potential swaps.
 
 %p.text-center
-  %a{href: edit_user_path} Please verify your mobile phone number before you swap
+  %a{href: edit_user_path} You must verify your mobile phone number before you swap

--- a/app/views/user/swaps/show.html.haml
+++ b/app/views/user/swaps/show.html.haml
@@ -15,3 +15,4 @@
         = render partial: 'mobile_phone/form', locals: {mobile_number: @mobile_number}
 
 = render partial: "users/info_summary"
+

--- a/app/views/user/swaps/show.html.haml
+++ b/app/views/user/swaps/show.html.haml
@@ -1,3 +1,6 @@
+= javascript_pack_tag "intlTelInput"
+= stylesheet_pack_tag "intlTelInput"
+
 .background-pattern.border-bottom
   .container.container-narrow
 

--- a/app/views/user/swaps/show.html.haml
+++ b/app/views/user/swaps/show.html.haml
@@ -1,5 +1,6 @@
 .background-pattern.border-bottom
   .container.container-narrow
+
     - if @potential_swaps.length > 0
       = render partial: "user/swaps/list_potential_swaps"
     - else

--- a/app/views/user/swaps/show.html.haml
+++ b/app/views/user/swaps/show.html.haml
@@ -7,6 +7,11 @@
       - else
         = render partial: "user/swaps/searching_for_swap"
     - else
-      = render partial: "user/swaps/summary"
+      %p.text-center
+        You have
+        %strong= @potential_swaps.length
+        potential swaps. You must verify your phone number before you can swap.
+      = form_for @user, url: user_path do
+        = render partial: 'mobile_phone/form'
 
 = render partial: "users/info_summary"

--- a/app/views/user/swaps/show.html.haml
+++ b/app/views/user/swaps/show.html.haml
@@ -1,9 +1,12 @@
 .background-pattern.border-bottom
   .container.container-narrow
 
-    - if @potential_swaps.length > 0
-      = render partial: "user/swaps/list_potential_swaps"
+    - if @user.verified
+      - if @potential_swaps.length > 0
+        = render partial: "user/swaps/list_potential_swaps"
+      - else
+        = render partial: "user/swaps/searching_for_swap"
     - else
-      = render partial: "user/swaps/searching_for_swap"
+      = render partial: "user/swaps/summary"
 
 = render partial: "users/info_summary"

--- a/app/views/user/swaps/show.html.haml
+++ b/app/views/user/swaps/show.html.haml
@@ -12,6 +12,6 @@
         %strong= @potential_swaps.length
         potential swaps. You must verify your phone number before you can swap.
       = form_for @user, url: user_path do
-        = render partial: 'mobile_phone/form'
+        = render partial: 'mobile_phone/form', locals: {mobile_number: @mobile_number}
 
 = render partial: "users/info_summary"

--- a/app/views/user/swaps/show.html.haml
+++ b/app/views/user/swaps/show.html.haml
@@ -1,7 +1,7 @@
 .background-pattern.border-bottom
   .container.container-narrow
 
-    - if @user.verified
+    - if @user.phone_verified?
       - if @potential_swaps.length > 0
         = render partial: "user/swaps/list_potential_swaps"
       - else

--- a/app/views/user/swaps/show.html.haml
+++ b/app/views/user/swaps/show.html.haml
@@ -1,18 +1,10 @@
 .background-pattern.border-bottom
   .container.container-narrow
 
-    - if @user.phone_verified?
-      - if @potential_swaps.length > 0
-        = render partial: "user/swaps/list_potential_swaps"
-      - else
-        = render partial: "user/swaps/searching_for_swap"
+    - if @potential_swaps.length > 0
+      = render partial: "user/swaps/list_potential_swaps"
     - else
-      %p.text-center
-        You have
-        %strong= @potential_swaps.length
-        potential swaps. You must verify your phone number before you can swap.
-      = form_for @user, url: user_path do
-        = render partial: 'mobile_phone/form', locals: {mobile_number: @mobile_number}
+      = render partial: "user/swaps/searching_for_swap"
 
 = render partial: "users/info_summary"
 

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -31,7 +31,8 @@
         My email address is
         = f.email_field :email, placeholder: "me@example.com", autofocus: true
 
-      = render partial: 'mobile_phone/form', locals: {mobile_number: @mobile_number}
+      = render partial: 'mobile_phone/form',
+        locals: {mobile_number: @mobile_number}
 
       %p.subdued.small
 

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -29,7 +29,8 @@
 
       %p
         My email address is
-        = f.email_field :email, placeholder: "me@example.com", autofocus: true
+        = f.email_field :email, placeholder: "me@example.com",
+                        autofocus: true, size: 30
 
       = render partial: 'mobile_phone/form',
         locals: {mobile_number: @mobile_number}

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -31,7 +31,7 @@
         My email address is
         = f.email_field :email, placeholder: "me@example.com", autofocus: true
 
-      = render partial: 'mobile_phone/form'
+      = render partial: 'mobile_phone/form', locals: {mobile_number: @mobile_number}
 
       %p.subdued.small
 

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -31,16 +31,7 @@
         My email address is
         = f.email_field :email, placeholder: "me@example.com", autofocus: true
 
-      %p
-        My phone number is
-        = telephone_field_tag "mobile_phone[number]", @mobile_number
-
-        - if @mobile_number.present?
-          - if mobile_verified?
-            Verified!
-          - else
-            = button_tag "Verify", formaction: verify_mobile_path,
-                         formmethod: :get
+      = render partial: 'mobile_phone/form'
 
       %p.subdued.small
 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,3 +1,6 @@
+= javascript_pack_tag "intlTelInput"
+= stylesheet_pack_tag "intlTelInput"
+
 .background-pattern.border-bottom
   .container.container-narrow
     - if @user.swap_confirmed?

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -5,6 +5,6 @@
     - elsif @user.outgoing_swap
       = render partial: "users/show/confirm_outgoing_swap"
     - elsif @user.incoming_swap
-      = render partial: "users/show/confirm_incoming_swap"
+      = render partial: "users/show/confirm_incoming_swap", locals: {user: @user, mobile_number: @mobile_number}
 
 = render partial: "users/info_summary"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -5,6 +5,7 @@
     - elsif @user.outgoing_swap
       = render partial: "users/show/confirm_outgoing_swap"
     - elsif @user.incoming_swap
-      = render partial: "users/show/confirm_incoming_swap", locals: {user: @user, mobile_number: @mobile_number}
+      = render partial: "users/show/confirm_incoming_swap",
+        locals: {user: @user, mobile_number: @mobile_number}
 
 = render partial: "users/info_summary"

--- a/app/views/users/show/_confirm_incoming_swap.html.haml
+++ b/app/views/users/show/_confirm_incoming_swap.html.haml
@@ -1,36 +1,40 @@
 %h3.text-center
-  #{@user.swapped_with.redacted_name} would like to swap their vote with you!
+  #{user.swapped_with.redacted_name} would like to swap their vote with you!
 
 %p
   .card.profile
-    = render partial: "user/swaps/swap_profile", object: @user.swapped_with, as: "other_user"
+    = render partial: "user/swaps/swap_profile", object: user.swapped_with, as: "other_user"
 
-= render partial: "user/swaps/double_check_constituency", locals: { swap_with: @user.swapped_with }
+= render partial: "user/swaps/double_check_constituency",
+    locals: { swap_with: user.swapped_with }
 
 
 %p.text-center
-  - if @user.phone_verified?
+  - if user.phone_verified?
     %p.text-center
-    Please confirm that you would like to swap with #{@user.swapped_with.redacted_name}.
-    = link_to "Yes please!", user_swap_path("swap[confirmed]" => "true"), method: "put", class: "button"
+      Please confirm that you would like to swap
+      with #{user.swapped_with.redacted_name}.
+      = link_to "Yes please!", user_swap_path("swap[confirmed]" => "true"),
+        method: "put", class: "button"
   - else
     %p.text-center
       You must verify your phone number before you swap
-    = form_for @user, url: user_path do
-      = render partial: 'mobile_phone/form'
+    = form_for user, url: user_path do
+      = render partial: 'mobile_phone/form', locals: {mobile_number: mobile_number}
 
 
 %p.text-center
-  = link_to "No thanks", "#", class: "small subdued", onclick: "showModal($('.js-reject-modal')); return false"
+  = link_to "No thanks", "#", class: "small subdued",
+    onclick: "showModal($('.js-reject-modal')); return false"
 
 
 .modal.js-reject-modal{style: "display: none"}
   .modal-dialog
     %i.fa.fa-times.subdued.modal-close
     %p.text-center
-      Are you sure you want to reject #{@user.swapped_with.redacted_name}?
+      Are you sure you want to reject #{user.swapped_with.redacted_name}?
     %p.subdued.small.text-center
       Some voting preferences are in high demand, and we can't be sure that we'll
-      find anyone else to swap with if you turn down #{@user.swapped_with.redacted_name}
+      find anyone else to swap with if you turn down #{user.swapped_with.redacted_name}
     %p.text-center
       = link_to "Reject", user_swap_path, method: "delete", class: "button"

--- a/app/views/users/show/_confirm_incoming_swap.html.haml
+++ b/app/views/users/show/_confirm_incoming_swap.html.haml
@@ -17,18 +17,18 @@
       with #{user.swapped_with.redacted_name}.
       = link_to "Yes please!", user_swap_path("swap[confirmed]" => "true"),
         method: "put", class: "button"
+
   - else
-    %p.text-center
-      You must verify your phone number before you swap
-    = form_for user, url: user_path do
-      = render partial: 'mobile_phone/form',
-        locals: {mobile_number: mobile_number}
+    .mobile-phone.text-center
+      %p
+        You must verify your phone number before you swap.
+      = form_for user, url: user_path, class: "text-center" do
+        = render partial: 'mobile_phone/form',
+                 locals: {mobile_number: mobile_number}
 
-
-%p.text-center
-  = link_to "No thanks", "#", class: "small subdued",
-    onclick: "showModal($('.js-reject-modal')); return false"
-
+  %p.text-center
+    = link_to "I'd prefer to swap with someone else", "#", class: "small subdued",
+      onclick: "showModal($('.js-reject-modal')); return false"
 
 .modal.js-reject-modal{style: "display: none"}
   .modal-dialog

--- a/app/views/users/show/_confirm_incoming_swap.html.haml
+++ b/app/views/users/show/_confirm_incoming_swap.html.haml
@@ -7,13 +7,18 @@
 
 = render partial: "user/swaps/double_check_constituency", locals: { swap_with: @user.swapped_with }
 
-%p.text-center
-  Please confirm that you would like to swap with #{@user.swapped_with.redacted_name}.
 
 %p.text-center
-  = link_to "Yes please!", user_swap_path("swap[confirmed]" => "true"), method: "put", class: "button"
-  &nbsp;
+  - if @user.phone_verified?
+    %p.text-center
+    Please confirm that you would like to swap with #{@user.swapped_with.redacted_name}.
+    = link_to "Yes please!", user_swap_path("swap[confirmed]" => "true"), method: "put", class: "button"
+  - else
+    %a{href: edit_user_path} You must verify your mobile phone number before you swap
+
+%p.text-center
   = link_to "No thanks", "#", class: "small subdued", onclick: "showModal($('.js-reject-modal')); return false"
+
 
 .modal.js-reject-modal{style: "display: none"}
   .modal-dialog

--- a/app/views/users/show/_confirm_incoming_swap.html.haml
+++ b/app/views/users/show/_confirm_incoming_swap.html.haml
@@ -20,7 +20,8 @@
     %p.text-center
       You must verify your phone number before you swap
     = form_for user, url: user_path do
-      = render partial: 'mobile_phone/form', locals: {mobile_number: mobile_number}
+      = render partial: 'mobile_phone/form',
+        locals: {mobile_number: mobile_number}
 
 
 %p.text-center
@@ -35,6 +36,7 @@
       Are you sure you want to reject #{user.swapped_with.redacted_name}?
     %p.subdued.small.text-center
       Some voting preferences are in high demand, and we can't be sure that we'll
-      find anyone else to swap with if you turn down #{user.swapped_with.redacted_name}
+      find anyone else to swap with if you turn
+      down #{user.swapped_with.redacted_name}
     %p.text-center
       = link_to "Reject", user_swap_path, method: "delete", class: "button"

--- a/app/views/users/show/_confirm_incoming_swap.html.haml
+++ b/app/views/users/show/_confirm_incoming_swap.html.haml
@@ -3,7 +3,8 @@
 
 %p
   .card.profile
-    = render partial: "user/swaps/swap_profile", object: user.swapped_with, as: "other_user"
+    = render partial: "user/swaps/swap_profile",
+      object: user.swapped_with, as: "other_user"
 
 = render partial: "user/swaps/double_check_constituency",
     locals: { swap_with: user.swapped_with }

--- a/app/views/users/show/_confirm_incoming_swap.html.haml
+++ b/app/views/users/show/_confirm_incoming_swap.html.haml
@@ -14,7 +14,11 @@
     Please confirm that you would like to swap with #{@user.swapped_with.redacted_name}.
     = link_to "Yes please!", user_swap_path("swap[confirmed]" => "true"), method: "put", class: "button"
   - else
-    %a{href: edit_user_path} You must verify your mobile phone number before you swap
+    %p.text-center
+      You must verify your phone number before you swap
+    = form_for @user, url: user_path do
+      = render partial: 'mobile_phone/form'
+
 
 %p.text-center
   = link_to "No thanks", "#", class: "small subdued", onclick: "showModal($('.js-reject-modal')); return false"

--- a/spec/controllers/user/swaps_controller_spec.rb
+++ b/spec/controllers/user/swaps_controller_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe User::SwapsController, type: :controller do
+  context "when users are logged in" do
+    let(:new_user) do
+      build(:user, id: 121,
+            constituency: build(:ons_constituency, ons_id: "E121"),
+            email: "foo@bar.com")
+    end
+
+    let(:mobile_phone) do
+      build(:mobile_phone, user_id: 121, number: "07400 123456", verified: true)
+    end
+
+    let(:swap_user) do
+      build(:user, id: 131,
+            constituency: build(:ons_constituency, name: "Fareham", ons_id: "E131"),
+            email: "match@foo.com")
+    end
+
+    let(:an_email) { double(:an_email) }
+
+    before do
+      session[:user_id] = new_user.id
+      allow(User).to receive(:find_by_id).with(new_user.id)
+                       .and_return(new_user)
+      allow(User).to receive(:find).with(swap_user.id.to_s)
+                       .and_return(swap_user)
+      allow(new_user).to receive(:phone_verified?).and_return(true)
+      allow(an_email).to receive(:deliver_now)
+      allow(UserMailer).to receive(:confirm_swap).and_return(an_email)
+      allow(UserMailer).to receive(:swap_cancelled).and_return(an_email)
+    end
+
+    describe "POST #create" do
+      it "redirects to user page" do
+        expect(new_user.swap).to be_nil
+
+        post :create, params: { user_id: swap_user.id }
+
+        expect(response).to redirect_to :user
+        expect(new_user.swap.chosen_user_id).to eq swap_user.id
+
+      end
+    end
+  end
+end

--- a/spec/controllers/user/swaps_controller_spec.rb
+++ b/spec/controllers/user/swaps_controller_spec.rb
@@ -61,4 +61,61 @@ RSpec.describe User::SwapsController, type: :controller do
       end
     end
   end
+
+  context "when users are not verified" do
+    let(:new_user) do
+      build(:user, id: 122,
+            constituency: build(:ons_constituency, ons_id: "E121"),
+            email: "foo@bar.com")
+    end
+
+    let(:mobile_phone) do
+      build(:mobile_phone, user_id: 122, number: "07400 123456", verified: false)
+    end
+
+    let(:swap_user) do
+      build(:user, id: 132,
+            constituency: build(:ons_constituency, name: "Fareham", ons_id: "E131"),
+            email: "match@foo.com")
+    end
+
+    let(:an_email) { double(:an_email) }
+
+    before do
+      session[:user_id] = new_user.id
+      allow(User).to receive(:find_by_id).with(new_user.id)
+                       .and_return(new_user)
+      allow(User).to receive(:find).with(swap_user.id.to_s)
+                       .and_return(swap_user)
+      allow(new_user).to receive(:phone_verified?).and_return(false)
+    end
+
+    describe "POST #create" do
+      it "redirects to user page" do
+        expect(new_user.swap).to be_nil
+
+        post :create, params: { user_id: swap_user.id }
+
+        expect(response).to redirect_to :edit_user
+        expect(flash[:errors].first).to eq "Please verify your mobile phone number before you swap!"
+        expect(new_user.swap).to be_nil
+      end
+    end
+
+    describe "PUT #update" do
+      it "confirms the swap if all ducks are lined up" do
+        swap = Swap.create(chosen_user_id: swap_user.id)
+        new_user.incoming_swap = swap
+        swap_user.outgoing_swap = swap
+
+        expect(swap_user.swap.confirmed).to be nil
+
+        put :update, params: { swap: { confirmed: true } }
+
+        expect(response).to redirect_to :edit_user
+        expect(flash[:errors].first).to eq "Please verify your mobile phone number before you swap!"
+        expect(swap_user.swap.confirmed).to be nil
+      end
+    end
+  end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -53,7 +53,9 @@ RSpec.describe UsersController, type: :controller do
     end
 
     describe "POST #update" do
-      it "redirects to #show" do
+      it "redirects to #show if user has verified phone number" do
+        build(:mobile_phone, number: "07400 123456", verified: true, user_id: logged_in_user.id)
+
         expect(logged_in_user).to receive(:update)
         post :update, params: { user: { constituency_ons_id: 2, email: "a@b.c" } }
         expect(response).to redirect_to(:user)


### PR DESCRIPTION
Don't allow users to accept or suggest a swap until they have verified their phone number

New tests for the swaps controller

I *think* I have caught all the places where hound was complaining about line length...

Screen shots:
![image](https://user-images.githubusercontent.com/6781954/69820012-0748e200-11f8-11ea-8b09-9747664ec0bd.png)

![image](https://user-images.githubusercontent.com/6781954/69820118-4d9e4100-11f8-11ea-8c96-f54901990c4c.png)
