### PR TITLE
Handle absence of user profile URL better in UI

### DIFF
--- a/app/controllers/user/swaps_controller.rb
+++ b/app/controllers/user/swaps_controller.rb
@@ -4,6 +4,8 @@ class User::SwapsController < ApplicationController
   before_action :assert_incoming_swap_exists, only: [:update, :destroy]
   before_action :assert_parties_exist, only: [:show]
 
+  include UsersHelper
+
   def show
     if @user.swapped?
       redirect_to user_path

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,5 @@
 module UsersHelper
+  def user_profile_link(user)
+    user.profile_url.blank? ? user.name : link_to(user.name, user.profile_url)
+  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,8 @@
 class UserMailer < ApplicationMailer
   default from: "Swap My Vote <hello@swapmyvote.uk>"
 
+  helper :users
+
   def welcome_email(user)
     @user = user
     mail(to: @user.email, subject: "Welcome to Swap My Vote")

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -30,7 +30,7 @@ class Identity < ApplicationRecord
     when "twitter"
       "https://twitter.com/intent/user?user_id=#{uid}"
     else
-      "#"
+      nil
     end
   end
 end

--- a/app/views/user_mailer/reminder_to_vote.html.haml
+++ b/app/views/user_mailer/reminder_to_vote.html.haml
@@ -2,7 +2,7 @@
   Hi #{@user.name},
 %p
   The 2019 General Election Polls are open!
-  %a{href: @user.swapped_with.profile_url} #{@user.swapped_with.name}
+  = user_profile_link(@user.swapped_with)
   is going to vote #{@user.swapped_with.willing_party.name} for you,
   in the #{@user.swapped_with.constituency.name} constituency.
 %p

--- a/app/views/user_mailer/swap_confirmed.html.haml
+++ b/app/views/user_mailer/swap_confirmed.html.haml
@@ -2,13 +2,15 @@
 	Hi #{@user.name},
 %p
 	You're all set to swap your vote with
-	%a{href: @swap_with.profile_url} #{@swap_with.name}!
+	= user_profile_link(@swap_with) + "!"
 	#{@swap_with.name} is going to vote for the #{@swap_with.willing_party.name} party for you, in the #{@swap_with.constituency.name} constituency.
 	In return, you will vote for the #{@swap_with.preferred_party.name} party in your constituency (#{@user.constituency.name}).
 %p
 	We'll send some reminders to #{@swap_with.name} to remind them to vote for your chosen party on December 12th, and we'll ask them for confirmation once they have.
-	In the meantime, why not
-	%a{href: @swap_with.profile_url} reach out to #{@swap_with.name} directly?
+
+	- if @swap_with.profile_url.present?
+		In the meantime, why not
+		%a{href: @swap_with.profile_url} reach out to #{@swap_with.name} directly?
 
 %p
 	Lastly, why not share Swap My Vote with your social networks so that more people can make their vote count?

--- a/app/views/users/show/_swap_confirmed.html.haml
+++ b/app/views/users/show/_swap_confirmed.html.haml
@@ -20,7 +20,9 @@
   %i.fa.fa-fw.fa-check
   #{@user.swapped_with.name} has confirmed the swap. You're all set!
 
-%p.text-center
-  You can reach out to
-  =link_to "#{@user.swapped_with.name} on social media", @user.swapped_with.profile_url
-  to get to know your swap partner.
+- if @user.swapped_with.profile_url.present?
+  %p.text-center
+    You can reach out to
+    = link_to "#{@user.swapped_with.name} on social media",
+              @user.swapped_with.profile_url
+    to get to know your swap partner.

--- a/spec/helpers/user_helper_spec.rb
+++ b/spec/helpers/user_helper_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe UsersHelper, type: :helper do
+  describe "#user_profile_link" do
+    let(:profile_url) { "https://facebook.com/alice.bloggs" }
+    let(:name) { "Alice Bloggs" }
+    let(:user) { create(:user, name: name) }
+
+    it "returns just the name when there is no profile URL" do
+      user.create_identity(provider: :facebook)
+      expect(helper.user_profile_link(user)).to eq name
+    end
+
+    it "returns a link when there is a profile URL" do
+      user.create_identity(provider: :facebook, profile_url: profile_url)
+      expect(helper.user_profile_link(user)) \
+        .to eq '<a href="https://facebook.com/alice.bloggs">Alice Bloggs</a>'
+    end
+  end
+end


### PR DESCRIPTION
Don't attempt to create links to the user's profile if we don't have the URL.

There is no guarantee a user logging in via Facebook will allow us permission to get their timeline (profile) link.  In fact if they've previously authorised the app before we started asking for the `user_link` permission in Omniauth, it might not even ask them whether it's OK to share that link - Facebook seems flakey like that.

So make sure we can survive gracefully without the profile link.