### PR TITLE
Allow Facebook log in to be disabled

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,16 +58,19 @@ module ApplicationHelper
   # will be shown but the dialog is not shown automatically.
 
   def log_in_with_facebook?
+    return false if %w[all facebook].include? ENV["DISABLE_LOG_INS"]
     return true unless params[:log_in_with]
     return %w[any facebook].include? params[:log_in_with]
   end
 
   def log_in_with_twitter?
+    return false if %w[all twitter].include? ENV["DISABLE_LOG_INS"]
     return true unless params[:log_in_with]
     return %w[any twitter].include? params[:log_in_with]
   end
 
-  def log_in_method_restricted?
+  def log_in_method_unrestricted?
+    return false if ENV["DISABLE_LOG_INS"]
     return !params[:log_in_with] || params[:log_in_with] == "any"
   end
 

--- a/app/views/layouts/_login.html.haml
+++ b/app/views/layouts/_login.html.haml
@@ -20,9 +20,9 @@
           Log in with Twitter
     - if ENV["DISABLE_LOG_INS"] == 'facebook'
       %p.text-center
-        We're still waiting for our Facebook app to be approved, and we're working
-        on adding support for signing up with an email address. In the meantime,
-        you can log in with Twitter.
+        We're still waiting for our Facebook app to be approved, and we're
+        working on adding support for signing up with an email address. In
+        the meantime, you can log in with Twitter.
     %p.text-center.small.subdued
       (We will never share anything with anyone about your voting preferences <br/> or post to your feed without your permission)
     %p.text-center

--- a/app/views/layouts/_login.html.haml
+++ b/app/views/layouts/_login.html.haml
@@ -10,7 +10,7 @@
                 class: "button button-facebook"}
           = image_tag('facebook_icon.png')
           Log in with Facebook
-    - if log_in_method_restricted?
+    - if log_in_method_unrestricted?
       %p.text-center.subdued &#8212; or &#8212;
     - if log_in_with_twitter?
       %p.text-center
@@ -18,6 +18,11 @@
                 class: "button button-twitter"}
           %i.fa.fa-fw.fa-twitter
           Log in with Twitter
+    - if ENV["DISABLE_LOG_INS"] == 'facebook'
+      %p.text-center
+        We're still waiting for our Facebook app to be approved, and we're working
+        on adding support for signing up with an email address. In the meantime,
+        you can log in with Twitter.
     %p.text-center.small.subdued
       (We will never share anything with anyone about your voting preferences <br/> or post to your feed without your permission)
     %p.text-center


### PR DESCRIPTION
Adds a `DISABLE_LOG_INS` env var, which if set to `facebook` will disable Facebook logins (via the `log_in_with` helpers, and show a message about it coming soon.

I'm changed `log_in_method_restricted` -> `log_in_method_unrestricted` (note the `un-`), because the semantics of this seemed to be backwards with what it actually returned. I might have missed something though.

### Screenshot with Facebook disabled

<img width="657" alt="Screenshot 2019-11-29 at 10 54 26" src="https://user-images.githubusercontent.com/31305/69864560-2185cd00-1297-11ea-98e5-1c4e8caaffb4.png">

Closes #201.