### PR TITLE
Clarify the matching process

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -132,10 +132,6 @@ input[type=text] {
         // scss-lint:disable VendorPrefix
         margin-right: 6px;
         color: #aaa;
-        -webkit-animation: oscillate 2s linear infinite; // Chrome, Safari 5
-        -moz-animation:    oscillate 2s linear infinite; // Firefox 5-15
-        -o-animation:      oscillate 2s linear infinite; // Opera 12+
-        animation:         oscillate 2s linear infinite;
     }
 
     span {

--- a/app/views/static_pages/faq.html.haml
+++ b/app/views/static_pages/faq.html.haml
@@ -81,15 +81,6 @@
 
     If you have changed your voting preferences or moved constituency (or if you would like to change partner) you can just update your info using the link that says "Not right? Update your info" and it will reset the swap, letting your partner know it has been cancelled.
 
-    %a(name="working")
-    %h2 The timer keeps turning - is the site working?
-    %p Yes it is. The platform is either:
-    %ol
-      %li
-        waiting for your proposed partner to confirm a swap - they only have #{swap_validity_hours} hours to do confirm and then you can find another
-      %li
-        waiting for a new person with the appropriate (opposite) voting preferences to join up. You may wish to spread the word to encourage more people to join.
-
     %a(name="better")
     %h2 The swap I’ve been offered isn’t a good one - how can I find a better voting partner?
     %p You can just update your info using the link that says "Not right? Update your info" and it will reset the swap, letting your partner know it has been cancelled. You are then free to select another voting partner from the list.

--- a/app/views/users/show/_confirm_outgoing_swap.html.haml
+++ b/app/views/users/show/_confirm_outgoing_swap.html.haml
@@ -6,6 +6,21 @@
     = render partial: "user/swaps/swap_profile", object: @user.swapped_with, as: "other_user"
 
 %p.text-center
-  %i.fa.fa-fw.fa-spin.fa-spinner
-  We're just waiting for #{@user.swapped_with.redacted_name} to confirm the swap!
-  If we don't hear back from them in #{swap_validity_hours} hours, we'll cancel the swap and you can pick someone else.
+  %i.fa.fa-fw.fa-hourglass-half
+  We're just waiting for #{@user.swapped_with.redacted_name} to confirm the
+  swap!
+
+  - if @user.email.blank?
+
+    Keep checking back here, or
+    = link_to("set an email address", edit_user_path)
+    so that we can keep you posted.
+
+  - else
+
+    When they do we'll send you an email.
+
+%p.text-center
+
+  If we don't hear back from them in #{swap_validity_hours} hours,
+  we'll cancel the swap and you can pick someone else.


### PR DESCRIPTION
Ditch the oscillation of the `fa-search` magnifying glass, and replace the rotating spinner with a static hourglass.

The animations made it look a bit like the views could automatically update, leading people to thinking they just have to sit there waiting for it.  As a result we needed a FAQ entry explaining it.  So ditch the animation, as cute as it was :'(

Closes #71.