### PR TITLE
Add notion of test users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,4 +31,8 @@ export ADMIN_PASSWORD=...
 # export SWAPS_CLOSED=yes
 
 # Uncomment this and edit to adjust the swap expiry duration
-export SWAP_EXPIRY_HOURS=12  # hours
+# export SWAP_EXPIRY_HOURS=12  # hours
+
+# Uncomment this to allow test users (example.com / Facebook test
+# users) to skip mobile verification
+# export TEST_USERS_SKIP_MOBILE_VERIFICATION=yes

--- a/app/controllers/user/swaps_controller.rb
+++ b/app/controllers/user/swaps_controller.rb
@@ -44,7 +44,7 @@ class User::SwapsController < ApplicationController
   private
 
   def assert_mobile_phone_verified
-    return if @user.phone_verified?
+    return unless @user.mobile_verification_missing?
 
     flash[:errors] = ["Please verify your mobile phone number before you swap!"]
     redirect_to edit_user_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -36,7 +36,7 @@ class UsersController < ApplicationController
 
   def redirect_path
     # If the user came from the edit path, and the mobile still needs verification, return there
-    return edit_user_path if params[:user] && mobile_needs_verification?
+    return edit_user_path if params[:user] && mobile_set_but_not_verified?
     # Otherwise, return to the user path - user will see a verification prompt if needed
     user_path
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,7 +38,7 @@ module ApplicationHelper
     return current_user.try(:mobile_phone).try(:verified)
   end
 
-  def mobile_needs_verification?
+  def mobile_set_but_not_verified?
     return current_user.try(:mobile_phone) &&
            !current_user.mobile_phone.verified
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,11 +35,11 @@ module ApplicationHelper
   end
 
   def mobile_verified?
-    return current_user.try(:mobile_phone).try(:verified)
+    return current_user&.mobile_phone&.verified
   end
 
   def mobile_set_but_not_verified?
-    return current_user.try(:mobile_phone) &&
+    return current_user&.mobile_phone &&
            !current_user.mobile_phone.verified
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,9 +74,9 @@ class User < ApplicationRecord
     PotentialSwap.destroy(incoming_potential_swaps.pluck(:id))
   end
 
-  def phone_verified?
-    return false unless mobile_phone
-    mobile_phone.verified
+  # This allows mocking in tests
+  def mobile_phone_verified?
+    mobile_phone&.verified
   end
 
   def swap_with_user_id(user_id)
@@ -174,6 +174,13 @@ class User < ApplicationRecord
       end
       create_mobile_phone!(number: new_number)
     end
+  end
+
+  # This is used to determine whether to enforce the requirement for
+  # mobile verification.
+  def mobile_verification_missing?
+    return false if test_user? && ENV["TEST_USERS_SKIP_MOBILE_VERIFICATION"]
+    return !mobile_phone_verified?
   end
 
   def image_url

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -155,8 +155,12 @@ class User < ApplicationRecord
     UserMailer.reminder_to_vote(self).deliver_now
   end
 
+  def name
+    self[:name].try { |n| n + test_user_suffix }
+  end
+
   def redacted_name
-    NameRedactor.redact(name)
+    NameRedactor.redact(self[:name]) + test_user_suffix
   end
 
   def mobile_number
@@ -182,5 +186,13 @@ class User < ApplicationRecord
 
   def uid
     identity&.uid
+  end
+
+  def test_user?
+    email.present? && email =~ /@(example\.com|tfbnw\.net)$/
+  end
+
+  def test_user_suffix
+    test_user? ? " (test user)" : ""
   end
 end

--- a/app/views/user/swaps/_searching_for_swap.html.haml
+++ b/app/views/user/swaps/_searching_for_swap.html.haml
@@ -11,9 +11,9 @@
 
 %h2 While you're waiting ...
 
-- if !@user.phone_verified?
+- if !@user.mobile_phone_verified?
 
-  %h3 Why not verify your phone number?
+  %h3 Why not verify your mobile phone number?
 
   %p
 

--- a/app/views/users/show/_confirm_incoming_swap.html.haml
+++ b/app/views/users/show/_confirm_incoming_swap.html.haml
@@ -9,22 +9,23 @@
 = render partial: "user/swaps/double_check_constituency",
     locals: { swap_with: user.swapped_with }
 
-
 %p.text-center
-  - if user.phone_verified?
-    %p.text-center
-      Please confirm that you would like to swap
-      with #{user.swapped_with.redacted_name}.
-      = link_to "Yes please!", user_swap_path("swap[confirmed]" => "true"),
-        method: "put", class: "button"
+  - if mobile_verification_missing?
 
-  - else
     .mobile-phone.text-center
       %p
         You must verify your phone number before you swap.
       = form_for user, url: user_path, class: "text-center" do
         = render partial: 'mobile_phone/form',
                  locals: {mobile_number: mobile_number}
+
+  - else
+
+    %p.text-center
+      Please confirm that you would like to swap
+      with #{user.swapped_with.redacted_name}.
+      = link_to "Yes please!", user_swap_path("swap[confirmed]" => "true"),
+        method: "put", class: "button"
 
   %p.text-center
     = link_to "I'd prefer to swap with someone else", "#", class: "small subdued",

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,4 +45,10 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 end
 
-ENV.delete "SWAPS_CLOSED"
+%w[
+  SWAPS_CLOSED
+  SWAP_EXPIRY_HOURS
+  TEST_USERS_SKIP_MOBILE_VERIFICATION
+].each do |var|
+  ENV.delete var
+end

--- a/spec/controllers/user/swaps_controller_spec.rb
+++ b/spec/controllers/user/swaps_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe User::SwapsController, type: :controller do
                        .and_return(new_user)
       allow(User).to receive(:find).with(swap_user.id.to_s)
                        .and_return(swap_user)
-      allow(new_user).to receive(:phone_verified?).and_return(true)
+      allow(new_user).to receive(:mobile_phone_verified?).and_return(true)
       allow(an_email).to receive(:deliver_now)
       allow(UserMailer).to receive(:confirm_swap).and_return(an_email)
       allow(UserMailer).to receive(:swap_cancelled).and_return(an_email)
@@ -87,7 +87,7 @@ RSpec.describe User::SwapsController, type: :controller do
                        .and_return(new_user)
       allow(User).to receive(:find).with(swap_user.id.to_s)
                        .and_return(swap_user)
-      allow(new_user).to receive(:phone_verified?).and_return(false)
+      allow(new_user).to receive(:mobile_phone_verified?).and_return(false)
     end
 
     describe "POST #create" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -95,19 +95,19 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe "#mobile_needs_verification?" do
+  describe "#mobile_set_but_not_verified?" do
     context "when logged out" do
       # This should never happen, but let's be safe
 
       it "returns false" do
-        expect(helper.mobile_needs_verification?).to be_falsey
+        expect(helper.mobile_set_but_not_verified?).to be_falsey
       end
     end
 
     context "when logged in", logged_in: true do
       context "with no mobile phone" do
         it "returns false" do
-          expect(helper.mobile_needs_verification?).to be_falsey
+          expect(helper.mobile_set_but_not_verified?).to be_falsey
         end
       end
 
@@ -118,7 +118,7 @@ RSpec.describe ApplicationHelper, type: :helper do
         end
 
         it "returns true when not verified" do
-          expect(helper.mobile_needs_verification?).to be_truthy
+          expect(helper.mobile_set_but_not_verified?).to be_truthy
         end
 
         it "returns false when verified" do
@@ -130,7 +130,7 @@ RSpec.describe ApplicationHelper, type: :helper do
           # reads it from current_user.
           current_user.mobile_phone.verified = true
 
-          expect(helper.mobile_needs_verification?).to be_falsey
+          expect(helper.mobile_set_but_not_verified?).to be_falsey
         end
       end
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -105,8 +105,10 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     context "when logged in", logged_in: true do
-      it "with no mobile phone returns false" do
-        expect(helper.mobile_needs_verification?).to be_falsey
+      context "with no mobile phone" do
+        it "returns false" do
+          expect(helper.mobile_needs_verification?).to be_falsey
+        end
       end
 
       context "with mobile phone" do
@@ -115,11 +117,11 @@ RSpec.describe ApplicationHelper, type: :helper do
           user.mobile_phone = phone
         end
 
-        it "returns false when not verified" do
-          expect(helper.mobile_verified?).to be_falsey
+        it "returns true when not verified" do
+          expect(helper.mobile_needs_verification?).to be_truthy
         end
 
-        it "returns true when verified" do
+        it "returns false when verified" do
           # Note that here we have to set verified = true on the
           # MobilePhone instance returned from current_user, since the
           # user local variable from let() is a different User
@@ -128,7 +130,7 @@ RSpec.describe ApplicationHelper, type: :helper do
           # reads it from current_user.
           current_user.mobile_phone.verified = true
 
-          expect(helper.mobile_verified?).to be_truthy
+          expect(helper.mobile_needs_verification?).to be_falsey
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -245,4 +245,67 @@ RSpec.describe User, type: :model do
       expect(subject.test_user?).to be_truthy
     end
   end
+
+  describe "#mobile_verification_missing?" do
+    context "with no mobile phone" do
+      it "returns false" do
+        expect(subject.mobile_verification_missing?).to be_truthy
+      end
+    end
+
+    context "with mobile phone" do
+      before do
+        subject.save
+        subject.build_mobile_phone(user: subject)
+      end
+
+      it "no email returns true" do
+        expect(subject.mobile_verification_missing?).to be_truthy
+      end
+
+      it "normal email returns true" do
+        subject.email = "foo@bar.com"
+        expect(subject.mobile_verification_missing?).to be_truthy
+      end
+
+      it "tfbnw.net email returns true" do
+        subject.email = "uypqkdhvcs_1575041689@tfbnw.net"
+        expect(subject.mobile_verification_missing?).to be_truthy
+      end
+
+      it "example.com email returns true" do
+        subject.email = "foo@example.com"
+        expect(subject.mobile_verification_missing?).to be_truthy
+      end
+
+      context "when skipping test user verification," do
+        before do
+          ENV["TEST_USERS_SKIP_MOBILE_VERIFICATION"] = "1"
+        end
+
+        after do
+          ENV.delete("TEST_USERS_SKIP_MOBILE_VERIFICATION")
+        end
+
+        it "no email returns true" do
+          expect(subject.mobile_verification_missing?).to be_truthy
+        end
+
+        it "normal email returns true" do
+          subject.email = "foo@bar.com"
+          expect(subject.mobile_verification_missing?).to be_truthy
+        end
+
+        it "tfbnw.net email returns false" do
+          subject.email = "uypqkdhvcs_1575041689@tfbnw.net"
+          expect(subject.mobile_verification_missing?).to be_falsey
+        end
+
+        it "example.com email returns false" do
+          subject.email = "foo@example.com"
+          expect(subject.mobile_verification_missing?).to be_falsey
+        end
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -50,10 +50,24 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#name" do
+    it "adds (test user)" do
+      subject.name = "Ada Lovelace"
+      subject.email = "ada@example.com"
+      expect(subject.name).to eq("Ada Lovelace (test user)")
+    end
+  end
+
   describe "#redacted_name" do
     it "redacts the user's surname" do
       subject.name = "Ada Lovelace"
       expect(subject.redacted_name).to eq("Ada L")
+    end
+
+    it "redacts the user's surname and adds (test user)" do
+      subject.name = "Ada Lovelace"
+      subject.email = "ada@example.com"
+      expect(subject.redacted_name).to eq("Ada L (test user)")
     end
   end
 
@@ -208,6 +222,27 @@ RSpec.describe User, type: :model do
           specify { expect { subject.save! }.not_to change(subject, :needs_welcome_email?).from(false) }
         end
       end
+    end
+  end
+
+  describe "#test_user?" do
+    it "with no email returns false" do
+      expect(subject.test_user?).to be_falsey
+    end
+
+    it "with normal email returns false" do
+      subject.email = "foo@bar.com"
+      expect(subject.test_user?).to be_falsey
+    end
+
+    it "with tfbnw.net email returns true" do
+      subject.email = "uypqkdhvcs_1575041689@tfbnw.net"
+      expect(subject.test_user?).to be_truthy
+    end
+
+    it "with example.com email returns true" do
+      subject.email = "foo@example.com"
+      expect(subject.test_user?).to be_truthy
     end
   end
 end


### PR DESCRIPTION
Support skipping mobile verification for test users.  This is useful for testing, and also required to pass Facebook's app review since they won't want to enter mobile numbers when testing the use of `user_link`.