### PR TITLE
Add <MY GITHUB USERNAME> to CLA

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -8,7 +8,7 @@
     "stevebaxter",
     "coliff",
     "emersonmanabuaraki",
-    "fkorning"
+    "fkorning",
   ],
   "message": "Thanks a lot for your pull request, and welcome to our community! We require contributors to sign our Contributor License Agreement, and we don't seem to have the user(s) {{usersWithoutCLA}} on file. In order for us to review and merge your code, please follow the steps at the bottom of https://github.com/swapmyvote/swapmyvote/blob/master/README.md#license.  Thanks again!"
 }


### PR DESCRIPTION
This is to confirm that I am happy for any rights in my
contributions to the SwapMyVote code to be assigned to Forward
Democracy for the purposes of defending and promoting democracy.


Hi, I had to delete my previous fork, as I can't find a way to clear the
association with my day job user context (it kept mailing me at scentrics).

I'm starting over....