### PR TITLE
Add consent checkbox to sign-up/in screen

### DIFF
--- a/app/views/layouts/_login.html.haml
+++ b/app/views/layouts/_login.html.haml
@@ -24,8 +24,9 @@
         working on adding support for signing up with an email address. In
         the meantime, you can log in with Twitter.
     %p.text-center
-      %input#data-consent{type: "checkbox", name: "data-consent", required: true}
-      %label{for: "data-consent"}
+      %input{ type: "checkbox", id: "data-consent",
+              name: "data-consent", required: true }
+      %label{ for: "data-consent" }
         I consent to SwapMyVote processing my personal data
     %p.text-center.small.subdued
       We will share your voting preferences and the public link to your

--- a/app/views/layouts/_login.html.haml
+++ b/app/views/layouts/_login.html.haml
@@ -23,8 +23,17 @@
         We're still waiting for our Facebook app to be approved, and we're
         working on adding support for signing up with an email address. In
         the meantime, you can log in with Twitter.
+    %p.text-center
+      %input#data-consent{type: "checkbox", name: "data-consent", required: true}
+      %label{for: "data-consent"}
+        I consent to SwapMyVote processing my personal data
     %p.text-center.small.subdued
-      (We will never share anything with anyone about your voting preferences <br/> or post to your feed without your permission)
+      We will share your voting preferences and the public link to your
+      Facebook or Twitter account with your swaps, once confirmed, so they know
+      who you are. We may send this information by email or text message.
+    %p.text-center.small.subdued
+      We will never share anything with anyone else or post to your feed
+      without your permission.
     %p.text-center
       = link_to "/faq#login", class: "small", target: "_blank" do
         Why do I need to log in with

--- a/app/views/static_pages/faq.html.haml
+++ b/app/views/static_pages/faq.html.haml
@@ -27,13 +27,12 @@
     %a(name="trust")
     %h2 How do I know my partner will vote (for who I want)?
     %p
-
       We have integrated the Swap My Vote platform with two of the
       biggest public social networks used in the UK so that you see
       that there is a real person at the other end of the swap, and
       potentially make contact with your partner. We have also made verification
-       of a mobile phone number mandatory.The kinds of thoughts and articles
-       you share may help trust arise naturally.
+      of a mobile phone number mandatory. The kinds of thoughts and articles
+      you share may help trust arise naturally.
     %p
       If you do make contact with your vote partner, perhaps let each other know
       what the most important policies to you, what you would like your vote to


### PR DESCRIPTION
This is pretty quick and dirty, we only do this client-side and we use HTML5 form validation to do the work. It should be sufficient to get us up and running though.

Also fixed an issue in the FAQ I noticed when testing this.

fixes: #216