### PR TITLE
Improve UX of postcode input

### DIFF
--- a/app/views/users/_postcode_field.html.haml
+++ b/app/views/users/_postcode_field.html.haml
@@ -1,6 +1,6 @@
 %p
   My postcode is
-  %input#txt-postcode{type: "text", size: 10}/
+  %input#txt-postcode{type: "text", size: 10, maxlength: 9, spellcheck: "false"}/
   %input#btn-postcode{type: "button", value: "Search"}/
 
   .text-error#error-postcode


### PR DESCRIPTION
- stops annoying squiggly line for spelling mistakes in postcodes
- setting maxlength is a good idea

(you could optionally also add minlength: 5