### PR TITLE
Cancel swap no user

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,8 @@ Style/EmptyMethod:
   Enabled: false
 Style/IfUnlessModifier:
   Enabled: false
+Style/MultilineTernaryOperator:
+  Enabled: false
 Style/NumericLiterals:
   Enabled: false
 Style/RedundantReturn:

--- a/Guardfile
+++ b/Guardfile
@@ -105,6 +105,9 @@ group :all_plugins, halt_on_fail: true do
     watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
     watch(rails.views)           { "#{rspec.spec_dir}/views" }
 
+    watch(%r{^app/views/(.*_mailer)/.*\.haml$}) {
+                                   |m| "#{rspec.spec_dir}/mailers/#{m[1]}_spec.rb" }
+
     # # Capybara features specs
     # watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
     # watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -25,10 +25,13 @@ class UserMailer < ApplicationMailer
   end
 
   def swap_cancelled(user, swap_with)
-    return nil if user.email.blank?
+    return nil if user&.email.blank?
     @user = user
     @swap_with = swap_with
-    mail(to: @user.email, subject: "Your swapped vote with #{swap_with.name} has been cancelled.")
+    mail(to: @user.email,
+         subject: swap_with ?
+           "Your swapped vote with #{swap_with.name} has been cancelled."
+         : "Your swapped vote has been cancelled.")
   end
 
   def not_swapped_follow_up(user)

--- a/app/views/user_mailer/swap_cancelled.haml
+++ b/app/views/user_mailer/swap_cancelled.haml
@@ -1,21 +1,21 @@
 %p
-	Hi #{@user.name},
+  Hi #{@user.name},
 %p
-	I'm sorry to say that your swap with #{@swap_with.name} has been cancelled.
-	This could have happened if you or #{@swap_with.name} changed preferred parties, moved constituency,
-	declined the swap, or (most likely!) if the swap expired before being confirmed.
+  I'm sorry to say that your swap with #{@swap_with.name} has been cancelled.
+  This could have happened if you or #{@swap_with.name} changed preferred parties, moved constituency,
+  declined the swap, or (most likely!) if the swap expired before being confirmed.
 %p
-	= link_to "Find another vote swapping partner - log in to swapmyvote.uk now.", user_url(log_in_with: @user.provider)
-	Don't delay!
+  = link_to "Find another vote swapping partner - log in to swapmyvote.uk now.", user_url(log_in_with: @user.provider)
+  Don't delay!
 %p
-	All the best,
-	%br
-	Swap My Vote Team
+  All the best,
+  %br
+  Swap My Vote Team
 %p
-	<a href="https://www.swapmyvote.uk/?utm_source=email&utm_medium=swap_cancelled&utm_campaign=site">Swap My Vote</a>
-	%br
-	<a href="https://twitter.com/intent/follow?screen_name=swapmyvote">Follow us on Twitter</a>
-	%br
-	<a href="https://facebook.com/swapmyvote">Like us on Facebook</a>
-	%br
-	<a href="https://crowdfunder.co.uk/swapmyvote">Support us on Crowdfunder</a>
+  <a href="https://www.swapmyvote.uk/?utm_source=email&utm_medium=swap_cancelled&utm_campaign=site">Swap My Vote</a>
+  %br
+  <a href="https://twitter.com/intent/follow?screen_name=swapmyvote">Follow us on Twitter</a>
+  %br
+  <a href="https://facebook.com/swapmyvote">Like us on Facebook</a>
+  %br
+  <a href="https://crowdfunder.co.uk/swapmyvote">Support us on Crowdfunder</a>

--- a/app/views/user_mailer/swap_cancelled.haml
+++ b/app/views/user_mailer/swap_cancelled.haml
@@ -1,8 +1,13 @@
 %p
   Hi #{@user.name},
 %p
-  I'm sorry to say that your swap with #{@swap_with.name} has been cancelled.
-  This could have happened if you or #{@swap_with.name} changed preferred parties, moved constituency,
+  I'm sorry to say that your vote swap
+
+  - if @swap_with
+    with #{@swap_with.name}
+
+  has been cancelled.
+  This could have happened if either of you changed preferred parties, moved constituency,
   declined the swap, or (most likely!) if the swap expired before being confirmed.
 %p
   = link_to "Find another vote swapping partner - log in to swapmyvote.uk now.", user_url(log_in_with: @user.provider)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,6 +43,9 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Default mailer URL for test env only!
+  config.action_mailer.default_url_options = { host: "www.example.com" }
 end
 
 %w[

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe UserMailer do
+  describe "swap_cancelled" do
+    let(:user1) { create(:user, email: "swap_user1@foo.com") }
+    let(:user2) { create(:user, name: "Anne Doe", email: "swap_user2@foo.com") }
+
+    it "sends email if swap_with is not blank" do
+      user1.create_identity(provider: "twitter")
+      response = UserMailer.swap_cancelled(user1, user2)
+      expect(response.subject)
+        .to eq "Your swapped vote with #{user2.name} has been cancelled."
+    end
+
+    it "sends email if swap_with is blank" do
+      user1.create_identity(provider: "twitter")
+      response = UserMailer.swap_cancelled(user1, nil)
+      expect(response.subject).to eq "Your swapped vote has been cancelled."
+    end
+
+    it "fails cleanly if user is blank" do
+      response = UserMailer.swap_cancelled(nil, user2)
+      expect(response.to_json).to eq "null"
+    end
+  end
+end


### PR DESCRIPTION
Cancel swap was falling over in a heap if the user had gone away (~~I assume closed their account,~~ there may be other ways to get here **UPDATE: but we don't know how as per #288), resulting in airbrake errors.

Add tests for the cancel swap mailer
Tolerate null values for both ends of the swap.

Closes #266.