### PR TITLE
Swap prevention with same party

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,6 +23,7 @@ class UsersController < ApplicationController
 
   def update
     @user.update(user_params) if params[:user]
+    
     if !phone_param.blank? && @user.mobile_number != phone_param
       begin
         @user.mobile_number = phone_param
@@ -31,12 +32,14 @@ class UsersController < ApplicationController
       end
     end
 
+    flash[:errors] = @user.errors.full_messages unless @user.valid?
+    
     redirect_to redirect_path
   end
 
   def redirect_path
     # If the user came from the edit path, and the mobile still needs verification, return there
-    return edit_user_path if params[:user] && mobile_set_but_not_verified?
+    return edit_user_path if params[:user] && mobile_set_but_not_verified? || !@user.valid?
     # Otherwise, return to the user path - user will see a verification prompt if needed
     user_path
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,7 +23,7 @@ class UsersController < ApplicationController
 
   def update
     @user.update(user_params) if params[:user]
-    
+
     if !phone_param.blank? && @user.mobile_number != phone_param
       begin
         @user.mobile_number = phone_param
@@ -33,7 +33,7 @@ class UsersController < ApplicationController
     end
 
     flash[:errors] = @user.errors.full_messages unless @user.valid?
-    
+
     redirect_to redirect_path
   end
 

--- a/app/models/concerns/distinct_parties_validator.rb
+++ b/app/models/concerns/distinct_parties_validator.rb
@@ -1,8 +1,8 @@
 class DistinctPartiesValidator < ActiveModel::Validator
   def validate(record)
-    if !record.preferred_party_id.nil? && !record.willing_party_id.nil? && 
+    if !record.preferred_party_id.nil? && !record.willing_party_id.nil? &&
         record.preferred_party_id == record.willing_party_id
-      record.errors.add(:preferred_party, 'and willing party cannot be the same')
+      record.errors.add(:preferred_party, "and willing party cannot be the same")
     end
   end
 end

--- a/app/models/concerns/distinct_parties_validator.rb
+++ b/app/models/concerns/distinct_parties_validator.rb
@@ -1,0 +1,8 @@
+class DistinctPartiesValidator < ActiveModel::Validator
+  def validate(record)
+    if !record.preferred_party_id.nil? && !record.willing_party_id.nil? && 
+        record.preferred_party_id == record.willing_party_id
+      record.errors.add(:preferred_party, 'and willing party cannot be the same')
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,9 @@
 class User < ApplicationRecord
   belongs_to :preferred_party, class_name: "Party", optional: true
   belongs_to :willing_party, class_name: "Party", optional: true
+
+  validates_with DistinctPartiesValidator
+
   has_one    :mobile_phone, dependent: :destroy
   belongs_to :constituency,
              class_name: "OnsConstituency",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -199,7 +199,7 @@ class User < ApplicationRecord
   end
 
   def image_url
-    identity&.image_url&.gsub('http://', '//')
+    identity&.image_url&.gsub("http://", "//")
   end
 
   def provider

--- a/app/views/home/_swaps_open.html.haml
+++ b/app/views/home/_swaps_open.html.haml
@@ -38,17 +38,27 @@
   function submit_modal() {
     preferred_party_id = $("select[name='user[preferred_party_id]']").val();
     willing_party_id = $("select[name='user[willing_party_id]']").val();
-    if (preferred_party_id !== null && willing_party_id !== null) {
-      showModal($('.js-login-modal'));
+    if (preferred_party_id == null || willing_party_id == null) {
+      showModal($('.js-blank-error-modal'));
+    } else if (preferred_party_id == willing_party_id) {
+      showModal($('.js-equal-party-error-modal'));
     } else {
-      showModal($('.js-error-modal'));
+      showModal($('.js-login-modal'));
     }
   }
 
-.modal.js-error-modal{style: "display: none;"}
+.modal.js-blank-error-modal{style: "display: none;"}
   .modal-dialog
     %i.fa.fa-times.subdued.modal-close
     %p.text-center
       Please choose both your preferred party and your willing party.
+    %p.text-center
+      %a.button.modal-close{href: "#"} OK
+
+.modal.js-equal-party-error-modal{style: "display: none;"}
+  .modal-dialog
+    %i.fa.fa-times.subdued.modal-close
+    %p.text-center
+      Your preferred party and your willing party cannot be the same.
     %p.text-center
       %a.button.modal-close{href: "#"} OK

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -60,6 +60,13 @@ RSpec.describe UsersController, type: :controller do
         post :update, params: { user: { constituency_ons_id: 2, email: "a@b.c" } }
         expect(response).to redirect_to(:user)
       end
+
+      it "redirects to #edit if user has same preferred party and willing party" do
+        post :update, params: { user: { preferred_party_id: 1, willing_party_id: 1 } }
+        expect(response).to redirect_to(edit_user_path)
+        expect(flash[:errors]).to be_present
+        expect(flash[:errors]).to include("Preferred party and willing party cannot be the same")
+      end
     end
 
     describe "DELETE #destroy" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,6 +2,14 @@ require "rails_helper"
 
 RSpec.describe User, type: :model do
   specify { expect(subject).to respond_to(:sent_emails) }
+  
+  context "when user have equal preferred_party_id and willing_party_id" do
+    let(:user) { User.new(name: "fred", id: 1, preferred_party_id: 3, willing_party_id: 3) }
+
+    it "is not expected to be valid" do
+      expect(user).not_to be_valid
+    end
+  end
 
   describe "#constituency" do
     context "with user with no constituency id" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe User, type: :model do
   specify { expect(subject).to respond_to(:sent_emails) }
-  
+
   context "when user have equal preferred_party_id and willing_party_id" do
     let(:user) { User.new(name: "fred", id: 1, preferred_party_id: 3, willing_party_id: 3) }
 


### PR DESCRIPTION
# Solves #70 

## Description:
Added validation to user to check if it has selected the same preferred party and willing party.
The steps where:
* Create the user model validator `DistinctPartiesValidator`
* Add tests to the validation
* Add front-end validation in the home page when user is not signed in

## Notes: 
I did not add front-end validation when the user is signed in because it already shows the error message with `flash[:errors]`

## How it was tested?
Running rspec and rubocop

## Screenshots
Back-end validation
![parties_validation](https://user-images.githubusercontent.com/33282336/70254291-98253d80-1763-11ea-8c03-104b7edda105.png)

Front-end validation
![js-validation](https://user-images.githubusercontent.com/33282336/70254334-ab380d80-1763-11ea-8b3e-a12071211b58.png)
