### PR TITLE
Reintroduce linters to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 
 script:
   - bundle exec rails webpacker:compile
-  - bundle exec rails spec
+  - bundle exec rake
 
 notifications:
   slack:

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -196,7 +196,7 @@ class User < ApplicationRecord
   end
 
   def image_url
-    identity&.image_url&.gsub('http://', '//')
+    identity&.image_url&.gsub("http://", "//")
   end
 
   def provider


### PR DESCRIPTION
6e206f3791 from #162 accidentally stopped Travis running rake and
hence the linters.  Since then, linting errors have been slowly
creeping in and causing confusing with local Guard builds.  So
make Travis run the rake default tasks.