### PR TITLE
Issue #277 Offer better swaps

### DIFF
--- a/app/models/ons_constituency.rb
+++ b/app/models/ons_constituency.rb
@@ -6,4 +6,8 @@ class OnsConstituency < ApplicationRecord
   has_many :recommendations,
            primary_key: "ons_id",
            foreign_key: "constituency_ons_id"
+
+  def parties_by_marginal_score
+    polls.order(:marginal_score).map(&:party)
+  end
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -6,4 +6,18 @@ class Poll < ApplicationRecord
              inverse_of: "polls",
              optional: true
   belongs_to :party
+
+  class << self
+    def calculate_marginal_score
+      OnsConstituency.all.each do |constituency|
+        polls = constituency.polls
+
+        polls.each do |poll|
+          party_votes = poll.votes
+          max_votes = polls.select { |p| p.id != poll.id }.map{ |p| p.votes }.max
+          poll.update(marginal_score: (max_votes - party_votes).abs)
+        end
+      end
+    end
+  end
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -8,7 +8,7 @@ class Poll < ApplicationRecord
   belongs_to :party
 
   class << self
-    def calculate_marginal_score
+    def calculate_marginal_score(progress: false)
       OnsConstituency.all.each do |constituency|
         polls = constituency.polls
 
@@ -16,8 +16,10 @@ class Poll < ApplicationRecord
           party_votes = poll.votes
           max_votes = polls.select { |p| p.id != poll.id }.map{ |p| p.votes }.max
           poll.update(marginal_score: (max_votes - party_votes).abs)
+          print "." if progress
         end
       end
+      puts if progress
     end
   end
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -8,6 +8,22 @@ class Poll < ApplicationRecord
   belongs_to :party
 
   class << self
+    # For each combination of party and constituency we figure out how close that party is to tipping the balance
+    # in that constituency.
+    #
+    # Method: Take the party of interest, and find their predicted (by Electoral Calculus) vote share in that
+    # constituency.
+    # Then take the rest of the parties in that constituency and find the maximum vote share amongst them.
+    # Then find the difference and save it as an absolute value.
+    #
+    # Now we can offer voters an attractive constituency to swap with, by preferring constituencies where their
+    # preferred party has a low marginal score ... meaning the party either needs a bit of help getting over
+    # the line, or it needs its expected majority bolstering to safe levels. I'm proposing that when we offer
+    # potential swaps, 50% of those will be random, and 50% will be from marginals as defined above.
+    #
+    # Big marginal score implies the preferred party is either way out in front and a safe seat, or way behind
+    # without a chance
+    #
     def calculate_marginal_score(progress: false)
       OnsConstituency.all.each do |constituency|
         polls = constituency.polls

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -30,7 +30,7 @@ class Poll < ApplicationRecord
 
         polls.each do |poll|
           party_votes = poll.votes
-          max_votes = polls.select { |p| p.id != poll.id }.map{ |p| p.votes }.max
+          max_votes = polls.select { |p| p.id != poll.id }.map(&:votes).max
           poll.update(marginal_score: (max_votes - party_votes).abs)
           print "." if progress
         end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,7 +59,9 @@ class User < ApplicationRecord
   end
 
   def try_to_create_marginal_swap
-    swaps = complementary_voters.where({ constituency_ons_id: marginal_polls.map(&:constituency_ons_id) })
+    swaps = complementary_voters.where(
+      { constituency_ons_id: marginal_polls.map(&:constituency_ons_id) }
+    )
     return one_swap_from_possible_users(swaps)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -106,7 +106,7 @@ class User < ApplicationRecord
 
   private def one_swap_from_possible_users(user_query)
     offset = rand(user_query.count)
-    target_user = user_query.offset(offset).limit(1).first
+    target_user = user_query.offset(offset).take
     return nil unless target_user
     # We need emails to send confirmation emails
     return nil if target_user.email.blank?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -121,7 +121,7 @@ class User < ApplicationRecord
   end
 
   def marginal_polls
-    Poll.where(["marginal_score < ?", 1000]).where(party: preferred_party).order(:marginal_score)
+    Poll.where(["marginal_score < ?", 1000]).where(party: preferred_party)
   end
 
   def marginal_constituencies

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,14 +42,35 @@ class User < ApplicationRecord
     return swaps.map {|s| s.target_user}
   end
 
+  class ChooseSwapType
+    def initialize
+      @even_odd = 0
+    end
+
+    def swap
+      @even_odd += 1
+      return @even_odd.odd? ? :marginal : :random
+    end
+  end
+
   def create_potential_swaps(number = 5)
-    max_attempts = number * 2
+    chooser = ChooseSwapType.new
+    max_marginal_attempts = number * 2
+    max_random_attempts = number * 2
+
     while potential_swaps.reload.count < number
-      try_to_create_marginal_swap
-      max_attempts -= 1
-      try_to_create_potential_swap
-      max_attempts -= 1
-      break if max_attempts <= 0
+      if chooser.swap == :marginal
+        unless max_marginal_attempts <= 0
+          try_to_create_marginal_swap
+          max_marginal_attempts -= 1
+        end
+      else
+        unless max_random_attempts <= 0
+          try_to_create_potential_swap
+          max_random_attempts -= 1
+        end
+      end
+      break if max_random_attempts <= 0 && max_marginal_attempts <= 0
     end
   end
 

--- a/db/migrate/20191203223552_add_marginal_score_to_polls.rb
+++ b/db/migrate/20191203223552_add_marginal_score_to_polls.rb
@@ -1,0 +1,5 @@
+class AddMarginalScoreToPolls < ActiveRecord::Migration[5.2]
+  def change
+    add_column :polls, :marginal_score, :integer
+  end
+end

--- a/db/migrate/20191205084216_calculate_marginal_score.rb
+++ b/db/migrate/20191205084216_calculate_marginal_score.rb
@@ -1,0 +1,9 @@
+class CalculateMarginalScore < ActiveRecord::Migration[5.2]
+  def up
+    Poll.calculate_marginal_score(progress: true)
+  end
+
+  def down
+    # Nothing to do
+  end
+end

--- a/db/migrate/20191206111031_add_indexes_for_finding_swaps.rb
+++ b/db/migrate/20191206111031_add_indexes_for_finding_swaps.rb
@@ -1,0 +1,13 @@
+class AddIndexesForFindingSwaps < ActiveRecord::Migration[5.2]
+  def change
+    add_index :users, [
+        :preferred_party_id,
+        :willing_party_id,
+        :constituency_ons_id
+      ], name: "index_users_on_complementary_users"
+    add_index :polls, [
+        :party_id,
+        :marginal_score,
+      ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(version: 2019_12_06_161508) do
     t.datetime "updated_at", null: false
     t.string "constituency_ons_id"
     t.integer "marginal_score"
+    t.index ["party_id", "marginal_score"], name: "index_polls_on_party_id_and_marginal_score"
   end
 
   create_table "potential_swaps", force: :cascade do |t|
@@ -115,6 +116,7 @@ ActiveRecord::Schema.define(version: 2019_12_06_161508) do
     t.string "constituency_ons_id"
     t.integer "mobile_phone_id"
     t.index ["mobile_phone_id"], name: "index_users_on_mobile_phone_id", unique: true
+    t.index ["preferred_party_id", "willing_party_id", "constituency_ons_id"], name: "index_users_on_complementary_users"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 2019_12_06_161508) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "constituency_ons_id"
+    t.integer "marginal_score"
   end
 
   create_table "potential_swaps", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -71,4 +71,10 @@ puts "\n\nRecommendations aggregated by LiveFromBrexit\n\n"
 
 Recommendation.refresh_from_json(progress: true)
 
+# ---------------------------------------------------------------------------------
+
+puts "\n\nCalculate Marginal Score\n\n"
+
+Poll.calculate_marginal_score(progress: true)
+
 puts "\n\n"

--- a/db/seeds/development/users.seeds.rb
+++ b/db/seeds/development/users.seeds.rb
@@ -40,4 +40,13 @@ end
 
   create_random_user(i, 3, 1)
   create_random_user(i, 3, 2)
+
+  create_random_user(i, 4, 1)
+  create_random_user(i, 1, 4)
+
+  create_random_user(i, 4, 2)
+  create_random_user(i, 2, 4)
+
+  create_random_user(i, 4, 3)
+  create_random_user(i, 3, 4)
 end

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -19,4 +19,40 @@ RSpec.describe Poll, type: :model do
       end
     end
   end
+
+  describe ".calculate_marginal_score" do
+    it "finds all constituencies" do
+      expect(OnsConstituency).to receive(:all).and_return(double.as_null_object)
+      described_class.calculate_marginal_score
+    end
+
+    context "on a single constituency, split 32.56%, 27.31%, 19.43%" do
+      before { allow(OnsConstituency).to receive(:all).and_return(constituencies) }
+
+      let(:constituencies) { [constituency1] }
+      let(:constituency1) { build(:ons_constituency, polls: [poll1, poll2, poll3]) }
+      let(:poll1) { build(:poll, id: 12, votes: 3256) }
+      let(:poll2) { build(:poll, id: 13, votes: 2731) }
+      let(:poll3) { build(:poll, id: 14, votes: 1943) }
+
+      describe "poll with 3256 votes" do
+        specify do
+          expect(poll1).to receive(:update).with(marginal_score: (poll1.votes - poll2.votes))
+          described_class.calculate_marginal_score
+        end
+      end
+      describe "poll with 2731 votes" do
+        specify do
+          expect(poll2).to receive(:update).with(marginal_score: (poll1.votes - poll2.votes))
+          described_class.calculate_marginal_score
+        end
+      end
+      describe "poll with 1943 votes" do
+        specify do
+          expect(poll3).to receive(:update).with(marginal_score: (poll1.votes - poll3.votes))
+          described_class.calculate_marginal_score
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #277 

--------------------

For each combination of party and constituency we figure out how close that party is to tipping the balance in that constituency.

Method: Take the party of interest, and find their predicted (by EC) vote share in that constituency.
Then take the rest of the parties in that constituency and find the maximum vote share amongst them.
Then find the difference and save it as an absolute value. call it marginal score or something.

Now we can offer voters an attractive constituency to swap with, by preferring constituencies where their preferred party has a low marginal score ... meaning the party either needs a bit of help getting over the line, or it needs its expected majority bolstering to safe levels. I’m proposing that when we offer potential swaps, 50% of those will be random, and 50% will be from marginals as defined above.

big marginal score implies the preferred party is either way out in front and a safe seat, or way behind without a chance