### PR TITLE
Handle unspecified constituencies

### DIFF
--- a/app/controllers/user/swaps_controller.rb
+++ b/app/controllers/user/swaps_controller.rb
@@ -4,6 +4,7 @@ class User::SwapsController < ApplicationController
   before_action :assert_incoming_swap_exists, only: [:update, :destroy]
   before_action :assert_parties_exist, only: [:show]
   before_action :assert_has_email, only: [:new, :create, :update]
+  before_action :assert_has_constituency, only: [:new, :create, :update]
   before_action :assert_mobile_phone_verified, only: [:new, :create, :update]
 
   include UsersHelper
@@ -55,6 +56,13 @@ class User::SwapsController < ApplicationController
     return unless @user.email.blank?
 
     flash[:errors] = ["Please enter your email address before you swap!"]
+    redirect_to edit_user_path
+  end
+
+  def assert_has_constituency
+    return unless @user.constituency_ons_id.blank?
+
+    flash[:errors] = ["Please enter your postcode or constituency before you swap!"]
     redirect_to edit_user_path
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,7 +55,7 @@ class User < ApplicationRecord
     swaps = User.where(
       preferred_party_id: willing_party_id,
       willing_party_id: preferred_party_id
-    ).where.not({ constituency_ons_id: nil })
+    ).where("constituency_ons_id like '_%'")
     offset = rand(swaps.count)
     target_user = swaps.offset(offset).limit(1).first
     return nil unless target_user

--- a/app/views/user/swaps/_double_check_constituency.html.haml
+++ b/app/views/user/swaps/_double_check_constituency.html.haml
@@ -5,5 +5,5 @@
   %br
   Please double check whether
   %a{href: "https://www.bbc.com/news/politics/constituencies", target: "blank"}
-    #{swap_with.willing_party.name} are running in #{swap_with.constituency.name}
-  \.
+    #{swap_with.willing_party.name} are running in
+    #{swap_with.constituency.name}.

--- a/spec/controllers/user/swaps_controller_spec.rb
+++ b/spec/controllers/user/swaps_controller_spec.rb
@@ -8,10 +8,6 @@ RSpec.describe User::SwapsController, type: :controller do
             email: "foo@bar.com")
     end
 
-    let(:mobile_phone) do
-      build(:mobile_phone, user_id: 121, number: "07400 123456", verified: true)
-    end
-
     let(:swap_user) do
       build(:user, id: 131,
             constituency: build(:ons_constituency, name: "Fareham", ons_id: "E131"),

--- a/spec/controllers/user/swaps_controller_spec.rb
+++ b/spec/controllers/user/swaps_controller_spec.rb
@@ -27,6 +27,29 @@ RSpec.describe User::SwapsController, type: :controller do
       allow(UserMailer).to receive(:swap_confirmed).and_return(an_email)
     end
 
+    context "and no constituency" do
+      describe "GET #new" do
+        it "redirects to user page" do
+          expect(new_user.swap).to be_nil
+
+          get :create, params: { user_id: swap_user.id }
+
+          expect(response).to redirect_to :edit_user
+        end
+      end
+
+      describe "POST #create" do
+        it "redirects to user page" do
+          expect(new_user.swap).to be_nil
+
+          post :create, params: { user_id: swap_user.id }
+
+          expect(response).to redirect_to :edit_user
+          expect(new_user.swap).to be_nil
+        end
+      end
+    end
+
     context "and constituency" do
       before do
         new_user.constituency = build(:ons_constituency, ons_id: "E121")

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :user do
     name { "John Doe" }
+    constituency_ons_id { nil }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -81,6 +81,13 @@ RSpec.describe User, type: :model do
         expect(ps).to be_nil
       end
 
+      it "creates no potential swap blank constituency" do
+        candidate.constituency_ons_id = ""
+        candidate.save!
+        ps = subject.try_to_create_potential_swap
+        expect(ps).to be_nil
+      end
+
       it "creates a potential swap" do
         candidate.constituency_ons_id = create(:ons_constituency).id
         candidate.save!

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,25 +28,38 @@ RSpec.describe User, type: :model do
     specify { expect { user.potential_swap_users(5) }.not_to raise_error }
   end
 
-  context "when user has no preferred party, willing party or constituency" do
+  context "when user has no preferred party, willing party or constituency," do
     let(:no_swap_user) { User.new(name: "fred", id: 1) }
 
-    context "setting constituency" do
-      let(:the_change) { -> { no_swap_user.constituency_ons_id = "some-fake-ons-id" } }
+    describe "#details_changed?" do
+      context "setting constituency" do
+        let(:the_change) {
+          -> { no_swap_user.constituency_ons_id = "some-fake-ons-id" }
+        }
 
-      specify { expect(&the_change).to change(no_swap_user, :details_changed?).from(false).to(true) }
-    end
+        specify {
+          expect(&the_change).to change(no_swap_user, :details_changed?)
+                                   .from(false).to(true)
+        }
+      end
 
-    context "setting preferred_party" do
-      let(:the_change) { -> { no_swap_user.preferred_party_id = 3 } }
+      context "setting preferred_party" do
+        let(:the_change) { -> { no_swap_user.preferred_party_id = 3 } }
 
-      specify { expect(&the_change).to change(no_swap_user, :details_changed?).from(false).to(true) }
-    end
+        specify {
+          expect(&the_change).to change(no_swap_user, :details_changed?)
+                                           .from(false).to(true)
+        }
+      end
 
-    context "setting willing_party" do
-      let(:the_change) { -> { no_swap_user.willing_party_id = 3 } }
+      context "setting willing_party" do
+        let(:the_change) { -> { no_swap_user.willing_party_id = 3 } }
 
-      specify { expect(&the_change).to change(no_swap_user, :details_changed?).from(false).to(true) }
+        specify {
+          expect(&the_change).to change(no_swap_user, :details_changed?)
+                                           .from(false).to(true)
+        }
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -63,6 +63,34 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#try_to_create_potential_swap" do
+    before do
+      subject.willing_party_id = 2
+      subject.preferred_party_id = 3
+      subject.save!
+    end
+
+    context "when there is a valid candidate" do
+      let(:candidate) {
+        create(:user, name: "candidate", email: "c@candidate.com",
+               willing_party_id: 3, preferred_party_id: 2)
+      }
+
+      it "creates no potential swap without constituency" do
+        ps = subject.try_to_create_potential_swap
+        expect(ps).to be_nil
+      end
+
+      it "creates a potential swap" do
+        candidate.constituency_ons_id = create(:ons_constituency).id
+        candidate.save!
+        ps = subject.try_to_create_potential_swap
+        expect(ps.source_user).to eq(subject)
+        expect(ps.target_user).to eq(candidate)
+      end
+    end
+  end
+
   describe "#name" do
     it "adds (test user)" do
       subject.name = "Ada Lovelace"


### PR DESCRIPTION
Somehow users are managing to attempt to swap before they've set a constituency, causing crashes as seen in #262.

- Don't show users without constituencies as potential swaps
- Require a user to have their constituency set before making a swap.
- Add corresponding specs.

Resolves #262.