### PR TITLE
Try to handle ActionController::InvalidAuthenticityToken better

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,11 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  def handle_unverified_request
+    flash[:errors] = ["Something went wrong - please try that again."]
+    redirect_back fallback_location: root_path
+  end
+
   def url_except_param(url, param)
     uri = Addressable::URI.parse(url)
     uri.query_values = uri.query_values.except(param.to_s)


### PR DESCRIPTION
This seems to be the simplest thing we can do for better UX and to stop spamming Airbrake with errors.  I have no idea why this is happening but google suggests that it might be partially related to Webkit on some (mobile?) browsers:

- https://github.com/rails/rails/issues/%321948

and indeed Airbrake's aggregations suggest this is a pure Webkit issue.

It also seems to be at least partially related to caching e.g.

- https://www.fastly.com/blog/caching-uncacheable-csrf-security

and the issue above suggests:

    config.action_dispatch.default_headers.merge!('Cache-Control' => 'no-store, no-cache')

which we can try if this change doesn't work.

Fixes #251.