### PR TITLE
Dynamic mobile number verification

### DIFF
--- a/app/controllers/mobile_phone_controller.rb
+++ b/app/controllers/mobile_phone_controller.rb
@@ -30,6 +30,9 @@ class MobilePhoneController < ApplicationController
     phone.save!
 
   rescue ActiveRecord::RecordInvalid
+    # We can get here if a the number is already in the DB. This can happen
+    # legitimately if a user has two accounts (eg twitter + email) and verifies
+    # the same number for both: to be improved when we enable multiple profiles
     rescue_error(phone.errors.full_messages)
   end
 
@@ -47,7 +50,7 @@ class MobilePhoneController < ApplicationController
     phone.verified = true
     phone.verify_id = nil
 
-    # Number will be saved if verification is outstanding
+    # Number will be saved even though we are still waiting for verification
     phone.save!
   end
 

--- a/app/controllers/mobile_phone_controller.rb
+++ b/app/controllers/mobile_phone_controller.rb
@@ -85,13 +85,10 @@ class MobilePhoneController < ApplicationController
     SwapMyVote::MessageBird.verify_token(phone.verify_id, params[:token])
     return true
   rescue MessageBird::ErrorException => ex
-    # We know the saved mobile phone number, but it may not be the same as the
-    # one the user tried to verify, so don't use it in this message in case
-    # it's misleading
     reason = verify_failure_reason(ex)
     if reason == :unknown
-      notify_error_exception(ex, "Verifying mobile number failed")
-      reason = "Something went wrong when verifying your mobile number."
+      notify_error_exception(ex, "Verifying number #{phone.number} failed")
+      reason = "Something went wrong when verifying number #{phone.number}."
     else
       reason += " Please use the code sent most recently."
     end

--- a/app/controllers/mobile_phone_controller.rb
+++ b/app/controllers/mobile_phone_controller.rb
@@ -16,7 +16,6 @@ class MobilePhoneController < ApplicationController
                  "verify_id: #{otp.id}"
 
     phone.save!
-
   rescue ActiveRecord::RecordInvalid
     # We can get here if a the number is already in the DB. This can happen
     # legitimately if a user has two accounts (eg twitter + email) and verifies

--- a/app/views/mobile_phone/verify_create.html.haml
+++ b/app/views/mobile_phone/verify_create.html.haml
@@ -23,7 +23,7 @@
 
       - else
         %p
-          A verification code was sent to #{current_user.mobile_number}.
+          A verification code was sent to #{@mobile_number}.
 
         %p
           Please enter the 6 digit code you received here:

--- a/app/views/mobile_phone/verify_create.html.haml
+++ b/app/views/mobile_phone/verify_create.html.haml
@@ -23,7 +23,7 @@
 
       - else
         %p
-          A verification code was sent to #{@mobile_number}.
+          A verification code was sent to #{current_user.mobile_number}.
 
         %p
           Please enter the 6 digit code you received here:


### PR DESCRIPTION
If the user updates the phone number in the UI, update it before sending verification

Also spotted a related issue where there was a messy failure if the phone number was duplicate, it will still fail but you should get a slightly more helpful error message now. A better fix should be along in https://github.com/swapmyvote/swapmyvote/issues/44