### PR TITLE
Add more people to FAQ page

### DIFF
--- a/app/views/static_pages/faq.html.haml
+++ b/app/views/static_pages/faq.html.haml
@@ -237,14 +237,14 @@
 
       %li
 
-        <a href="http://adamspiers.org/">Adam Spiers</a> is our
+        <a target=_blank href="http://adamspiers.org/">Adam Spiers</a> is our
         project CTO; an expert in Free and Open Source Software he
         builds tech products that help democratic engagement in his
         spare time.
 
       %li
 
-        <a href="http://jpallen.net/">James Allen</a> is the a
+        <a target=_blank href="http://jpallen.net/">James Allen</a> is the a
         co-founder and led development of the project. He also
         co-founded <a
         href="https://www.sharelatex.com/">ShareLaTeX</a>, a
@@ -252,6 +252,14 @@
         Overleaf). He is interested in how technology can make people
         more efficient and enable new ways of communication and
         collaboration, like Swap My Vote.
+
+      %li
+
+        <a target=_blank href="https://www.linkedin.com/in/sarah-eggleston-34bb924/">Sarah
+        Eggleston</a> is an enthusiastic convert to Ruby on Rails after a long
+        career in Java. She is passionate about building software that is intuitive
+        to use and easy to configure, and is taking time out from her startup
+        <a target=_blank href="https://fflow.io">fflow</a> to support Swap My Vote.
 
     %p
 

--- a/app/views/static_pages/faq.html.haml
+++ b/app/views/static_pages/faq.html.haml
@@ -246,8 +246,7 @@
 
         <a target=_blank href="http://jpallen.net/">James Allen</a> is the a
         co-founder and led development of the project. He also
-        co-founded <a
-        href="https://www.sharelatex.com/">ShareLaTeX</a>, a
+        co-founded <a href="https://www.sharelatex.com/">ShareLaTeX</a>, a
         collaborative platform for scientists (now part of
         Overleaf). He is interested in how technology can make people
         more efficient and enable new ways of communication and
@@ -255,11 +254,13 @@
 
       %li
 
-        <a target=_blank href="https://www.linkedin.com/in/sarah-eggleston-34bb924/">Sarah
+        <a target=_blank
+        href="https://www.linkedin.com/in/sarah-eggleston-34bb924/">Sarah
         Eggleston</a> is an enthusiastic convert to Ruby on Rails after a long
-        career in Java. She is passionate about building software that is intuitive
-        to use and easy to configure, and is taking time out from her startup
-        <a target=_blank href="https://fflow.io">fflow</a> to support Swap My Vote.
+        career in Java. She is passionate about building software that is
+        intuitive to use and easy to configure, and is taking time out from
+        her startup <a target=_blank href="https://fflow.io">fflow</a> to
+        support Swap My Vote.
 
     %p
 

--- a/app/views/static_pages/faq.html.haml
+++ b/app/views/static_pages/faq.html.haml
@@ -245,12 +245,11 @@
       %li
 
         <a target=_blank href="http://jpallen.net/">James Allen</a> is the a
-        co-founder and led development of the project. He also
-        co-founded <a href="https://www.sharelatex.com/">ShareLaTeX</a>, a
-        collaborative platform for scientists (now part of
-        Overleaf). He is interested in how technology can make people
-        more efficient and enable new ways of communication and
-        collaboration, like Swap My Vote.
+        co-founder and led development of the project. He also co-founded
+        <a target=_blank href="https://www.sharelatex.com/">ShareLaTeX</a>, a
+        collaborative platform for scientists (now part of Overleaf). He is
+        interested in how technology can make people more efficient and enable
+        new ways of communication and collaboration, like Swap My Vote.
 
       %li
 

--- a/app/views/static_pages/faq.html.haml
+++ b/app/views/static_pages/faq.html.haml
@@ -262,6 +262,15 @@
         her startup <a target=_blank href="https://fflow.io">fflow</a> to
         support Swap My Vote.
 
+      %li
+
+        <a target=_blank href="http://kuamka.com/">Steve Baxter</a> is a
+        software engineer who has been involved in a wide range of products
+        and technologies, from life sciences to events management. He is
+        interested in the intersection between politics and technology and
+        wanted to do something positive instead of just shouting at the
+        television.
+
     %p
 
       Tom and James had the same idea for the platform at different


### PR DESCRIPTION
Add short bio for Sarah and Steve to the FAQ page.

If anyone else wants to send over their details, happy to add them. Or of course, help yourself to this branch.

I also changed the external links to open in new tab - I tend to use this for off-site links, happy to reverse it 
