### PR TITLE
Fix crashes when authentication fails

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -72,7 +72,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     return user
   end
 
-  def retry
+  def failure
     flash[:errors] = ["Login failed! Please try again, or try logging in a different way."]
     destroy
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,6 +11,10 @@ module ApplicationHelper
     return !current_user.nil?
   end
 
+  def display_login_modal
+    return params[:log_in_with] ? "inherit" : "none"
+  end
+
   def swapping_open?
     return true if session[:sesame] == "open" # someone said the magic word
     return !ENV["SWAPS_CLOSED"]

--- a/app/views/layouts/_login.html.haml
+++ b/app/views/layouts/_login.html.haml
@@ -7,7 +7,8 @@
     .modal-content
       .modal-header
         %h2{ class: "h4 mb-0" } Log in
-        %button.close{ type: "button", :data => { dismiss: "modal" }, :aria => { label: "Close" } }
+        %button.close{ type: "button", data: { dismiss: "modal" },
+                       aria: { label: "Close" } }
           %i.fa.fa-times.subdued
       .modal-body
         - if flash[:alert]

--- a/app/views/layouts/_login.html.haml
+++ b/app/views/layouts/_login.html.haml
@@ -1,6 +1,8 @@
 %span.user
-  = link_to "Already been here? Log in", "#", class: "small subdued logout", onclick: "$('#js-login-modal').modal(); return false"
-.modal#js-login-modal{ tabindex: "-1", role: "dialog" }
+  = link_to "Already been here? Log in", "#", class: "small subdued logout",
+            onclick: "$('#js-login-modal').modal(); return false"
+.modal#js-login-modal{tabindex: "-1", role: "dialog",
+                       style: "display: %s;" % display_login_modal }
   .modal-dialog
     .modal-content
       .modal-header

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -309,4 +309,17 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
+
+  # Errors from authentication may crash because no Devise mapping is defined
+  # for the callback path. To work around this we manually set the failure
+  # callback to Users::OmniauthCallbacksController.failure().
+  #
+  # See https://github.com/plataformatec/devise/issues/2004#issuecomment-7466322
+  # for more information.
+  OmniAuth.config.on_failure = Proc.new do |env|
+    env['devise.mapping'] = Devise.mappings[:user]
+    controller_name  = ActiveSupport::Inflector.camelize(env['devise.mapping'].controllers[:omniauth_callbacks])
+    controller_klass = ActiveSupport::Inflector.constantize("#{controller_name}Controller")
+    controller_klass.action(:failure).call(env)
+  end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -316,9 +316,9 @@ Devise.setup do |config|
   #
   # See https://github.com/plataformatec/devise/issues/2004#issuecomment-7466322
   # for more information.
-  OmniAuth.config.on_failure = Proc.new do |env|
-    env['devise.mapping'] = Devise.mappings[:user]
-    controller_name  = ActiveSupport::Inflector.camelize(env['devise.mapping'].controllers[:omniauth_callbacks])
+  OmniAuth.config.on_failure = proc do |env|
+    env["devise.mapping"] = Devise.mappings[:user]
+    controller_name = ActiveSupport::Inflector.camelize(env["devise.mapping"].controllers[:omniauth_callbacks])
     controller_klass = ActiveSupport::Inflector.constantize("#{controller_name}Controller")
     controller_klass.action(:failure).call(env)
   end


### PR DESCRIPTION
We've been seeing crashes reported in Airbrake with `Could not find a valid mapping for path "/auth/xxxxxx/callback"`. This seems to happen when authentication fails, e.g.:

* CSRF detection on the FB (Oauth2) logins because the `omniauth.state` in the session doesn't match the state passed back in the callback
* Failed login, e.g. login using Twitter but the user cancels the login
* Cancelled FB/Twitter app permission, so the user decides not to give our app permission to access their account

The problem seems to be that Devise can't figure out the route in this situation. To fix this we add a custom `on_failure` callback to ensure the right thing gets called.

See https://github.com/plataformatec/devise/issues/2004#issuecomment-7466322 for more information.

fixes: #328 