### PR TITLE
Automatically give consent for email login

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -6,7 +6,7 @@ module UsersHelper
   def contact_methods(user)
     methods = social_contact_methods(user)
 
-    if user.email.present? && user.email_consent?
+    if user.email.present? && (user.email_consent? || user.email_login?)
       methods << "by email at " + link_to(user.email, user.email_url)
     end
 

--- a/app/views/users/show/_swap_confirmed.html.haml
+++ b/app/views/users/show/_swap_confirmed.html.haml
@@ -30,6 +30,8 @@
     != methods.join " or "
 
     to get to know your swap partner.
+
   - else
-    Unfortunately #{@user.swapped_with.name} has not shared their email address or
-    social media profile.
+
+    Unfortunately #{@user.swapped_with.name} has not shared their
+    email address or social media profile.

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -27,8 +27,16 @@ RSpec.describe UsersHelper, type: :helper do
     shared_examples "contact methods" do
       let(:methods) { helper.contact_methods(user.swapped_with) }
 
-      it "returns no contact methods" do
-        expect(methods).to eq []
+      context "who has email login" do
+        it "has valid context" do
+          expect(other_user.email_login?).to be_truthy
+        end
+
+        it "returns email" do
+          expect(methods).to eq [
+            %(by email at <a href="mailto:bob%40example.com">bob@example.com</a>)
+          ]
+        end
       end
 
       def other_gives_consent


### PR DESCRIPTION
This is problematic because it currently asks for consent even
when email login is used.  I think this is a regression.