### PR TITLE
redirect straight to swap page when there are swaps available

### DIFF
--- a/app/controllers/user/constituencies_controller.rb
+++ b/app/controllers/user/constituencies_controller.rb
@@ -10,7 +10,7 @@ class User::ConstituenciesController < ApplicationController
 
   def update
     @user.update(user_params)
-    redirect_to user_share_path
+    redirect_to user_swap_path
   end
 
   private

--- a/spec/controllers/user/constituencies_controller_spec.rb
+++ b/spec/controllers/user/constituencies_controller_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe User::ConstituenciesController, type: :controller do
 
         it "redirects to user share" do
           patch :update, params: { user: { constituency_ons_id: 2, email: "a@b.c" }   }
-          expect(response).to redirect_to(:user_share)
+          expect(response).to redirect_to(:user_swap)
         end
       end
     end


### PR DESCRIPTION
Closes #351 

Currently we go to the share via social page with a message that could make it look like there are no available swaps. 
We want to try dropping this page and going straight to the swap page when there are available swaps. 

I believe the change is as simple as this but may have missed something - can't test it locally as my db is not up to date. Would be great if someone could pull this branch as run through the flow.