### PR TITLE
Issue #337 retrospective email consent

### DIFF
--- a/app/controllers/user/swaps_controller.rb
+++ b/app/controllers/user/swaps_controller.rb
@@ -87,6 +87,11 @@ class User::SwapsController < ApplicationController
   end
 
   def swap_params
-    params.require(:swap).permit(:confirmed, :consent_share_email_chooser, :consent_share_email_chosen)
+    params.require(:swap).permit(
+      :confirmed,
+      :consent_share_email_chooser,
+      :consent_share_email_chosen,
+      :consent_share_email
+    )
   end
 end

--- a/app/controllers/user/swaps_controller.rb
+++ b/app/controllers/user/swaps_controller.rb
@@ -1,7 +1,8 @@
 class User::SwapsController < ApplicationController
   before_action :require_swapping_open, only: [:show, :new, :create]
   before_action :require_login
-  before_action :assert_incoming_swap_exists, only: [:update, :destroy]
+  before_action :assert_incoming_swap_exists, only: [:destroy]
+  before_action :assert_swap_exists, only: [:update]
   before_action :assert_parties_exist, only: [:show]
   before_action :assert_has_email, only: [:new, :create, :update]
   before_action :assert_has_constituency, only: [:new, :create, :update]
@@ -74,12 +75,18 @@ class User::SwapsController < ApplicationController
     redirect_to user_path
   end
 
+  def assert_swap_exists
+    return if @user.incoming_swap || @user.outgoing_swap
+    flash[:errors] = ["You don't have a swap!"]
+    redirect_to user_path
+  end
+
   def assert_parties_exist
     return if @user.willing_party && @user.preferred_party
     redirect_to edit_user_path
   end
 
   def swap_params
-    params.require(:swap).permit(:confirmed, :consent_share_email_chosen)
+    params.require(:swap).permit(:confirmed, :consent_share_email_chooser, :consent_share_email_chosen)
   end
 end

--- a/app/controllers/user/swaps_controller.rb
+++ b/app/controllers/user/swaps_controller.rb
@@ -33,6 +33,8 @@ class User::SwapsController < ApplicationController
   def update
     if swap_params[:confirmed] == "true"
       @user.confirm_swap(swap_params)
+    else
+      @user.update_swap(swap_params)
     end
 
     redirect_to user_path

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -17,8 +17,10 @@ class UserMailer < ApplicationMailer
     mail(to: @user.email, subject: "#{swap_with.redacted_name} would like to swap their vote with you!")
   end
 
-  def email_address_shared(user)
-    raise 'somebody should write me' # TODO
+  def email_address_shared(swap_with, user)
+    @user = user
+    @swap_with = swap_with
+    mail(to: @swap_with.email, subject: "#{user.redacted_name} has shared their email address with you!")
   end
 
   def swap_confirmed(user, swap_with, swap_with_email_consent)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -17,6 +17,10 @@ class UserMailer < ApplicationMailer
     mail(to: @user.email, subject: "#{swap_with.redacted_name} would like to swap their vote with you!")
   end
 
+  def email_address_shared(user)
+    raise 'somebody should write me' # TODO
+  end
+
   def swap_confirmed(user, swap_with, swap_with_email_consent)
     return nil if user.email.blank?
     @user = user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -233,6 +233,13 @@ class User < ApplicationRecord
     return false
   end
 
+  def my_email_consent?
+    # Check if I have given permission for swapper to see my email
+    return outgoing_swap.consent_share_email_chooser if outgoing_swap
+    return incoming_swap.consent_share_email_chosen if incoming_swap
+    return false
+  end
+
   def clear_swap
     if incoming_swap
       incoming_swap.destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -217,6 +217,7 @@ class User < ApplicationRecord
   def update_swap(swap_params)
     if incoming_swap
       incoming_swap.update(swap_params.slice(:consent_share_email_chosen))
+      UserMailer.email_address_shared(swapped_with).deliver_now if swap_confirmed?
     end
 
     # TODO: we need to deal with the outgoing swap case - tests first

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -218,12 +218,12 @@ class User < ApplicationRecord
   def update_swap(swap_params)
     if incoming_swap && swap_params[:consent_share_email_chosen]
       incoming_swap.update(swap_params.slice(:consent_share_email_chosen))
-      UserMailer.email_address_shared(swapped_with).deliver_now if swap_confirmed?
+      UserMailer.email_address_shared(swapped_with, self).deliver_now if swap_confirmed?
     end
     # rubocop:disable Style/GuardClause
     if outgoing_swap && swap_params[:consent_share_email_chooser]
       outgoing_swap.update(swap_params.slice(:consent_share_email_chooser))
-      UserMailer.email_address_shared(swapped_with).deliver_now if swap_confirmed?
+      UserMailer.email_address_shared(swapped_with, self).deliver_now if swap_confirmed?
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -216,14 +216,20 @@ class User < ApplicationRecord
   end
 
   def update_swap(swap_params)
-    if incoming_swap && swap_params[:consent_share_email_chosen]
-      incoming_swap.update!(swap_params.slice(:consent_share_email_chosen))
-      UserMailer.email_address_shared(swapped_with, self).deliver_now if swap_confirmed?
+    if incoming_swap
+      consent_given = swap_params[:consent_share_email_chosen] || swap_params[:consent_share_email]
+      if consent_given
+        incoming_swap.update!(consent_share_email_chosen: true)
+        UserMailer.email_address_shared(swapped_with, self).deliver_now if swap_confirmed?
+      end
     end
     # rubocop:disable Style/GuardClause
-    if outgoing_swap && swap_params[:consent_share_email_chooser]
-      outgoing_swap.update!(swap_params.slice(:consent_share_email_chooser))
-      UserMailer.email_address_shared(swapped_with, self).deliver_now if swap_confirmed?
+    if outgoing_swap
+      consent_given = swap_params[:consent_share_email_chooser] || swap_params[:consent_share_email]
+      if consent_given
+        outgoing_swap.update!(consent_share_email_chooser: true)
+        UserMailer.email_address_shared(swapped_with, self).deliver_now if swap_confirmed?
+      end
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -217,12 +217,12 @@ class User < ApplicationRecord
 
   def update_swap(swap_params)
     if incoming_swap && swap_params[:consent_share_email_chosen]
-      incoming_swap.update(swap_params.slice(:consent_share_email_chosen))
+      incoming_swap.update!(swap_params.slice(:consent_share_email_chosen))
       UserMailer.email_address_shared(swapped_with, self).deliver_now if swap_confirmed?
     end
     # rubocop:disable Style/GuardClause
     if outgoing_swap && swap_params[:consent_share_email_chooser]
-      outgoing_swap.update(swap_params.slice(:consent_share_email_chooser))
+      outgoing_swap.update!(swap_params.slice(:consent_share_email_chooser))
       UserMailer.email_address_shared(swapped_with, self).deliver_now if swap_confirmed?
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -220,6 +220,7 @@ class User < ApplicationRecord
       incoming_swap.update(swap_params.slice(:consent_share_email_chosen))
       UserMailer.email_address_shared(swapped_with).deliver_now if swap_confirmed?
     end
+    # rubocop:disable Style/GuardClause
     if outgoing_swap && swap_params[:consent_share_email_chooser]
       outgoing_swap.update(swap_params.slice(:consent_share_email_chooser))
       UserMailer.email_address_shared(swapped_with).deliver_now if swap_confirmed?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -215,6 +215,13 @@ class User < ApplicationRecord
     return false
   end
 
+  def my_email_consent?
+    # Check if I have given permission for swapper to see my email
+    return outgoing_swap.consent_share_email_chooser if outgoing_swap
+    return incoming_swap.consent_share_email_chosen if incoming_swap
+    return false
+  end
+
   def update_swap(swap_params)
     if incoming_swap
       consent_given = swap_params[:consent_share_email_chosen] || swap_params[:consent_share_email]
@@ -231,20 +238,6 @@ class User < ApplicationRecord
         UserMailer.email_address_shared(swapped_with, self).deliver_now if swap_confirmed?
       end
     end
-  end
-
-  def swap_email_consent?
-    # Check if our swapper has given permission for us to see their email
-    return outgoing_swap.consent_share_email_chosen if outgoing_swap
-    return incoming_swap.consent_share_email_chooser if incoming_swap
-    return false
-  end
-
-  def my_email_consent?
-    # Check if I have given permission for swapper to see my email
-    return outgoing_swap.consent_share_email_chooser if outgoing_swap
-    return incoming_swap.consent_share_email_chosen if incoming_swap
-    return false
   end
 
   def clear_swap

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -218,6 +218,9 @@ class User < ApplicationRecord
     if incoming_swap
       incoming_swap.update(swap_params.slice(:consent_share_email_chosen))
     end
+
+    # TODO: we need to deal with the outgoing swap case - tests first
+
   end
 
   def swap_email_consent?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -214,6 +214,19 @@ class User < ApplicationRecord
     return false
   end
 
+  def update_swap(swap_params)
+    if incoming_swap
+      incoming_swap.update(swap_params.slice(:consent_share_email_chosen))
+    end
+  end
+
+  def swap_email_consent?
+    # Check if our swapper has given permission for us to see their email
+    return outgoing_swap.consent_share_email_chosen if outgoing_swap
+    return incoming_swap.consent_share_email_chooser if incoming_swap
+    return false
+  end
+
   def clear_swap
     if incoming_swap
       incoming_swap.destroy

--- a/app/views/user_mailer/email_address_shared.html.haml
+++ b/app/views/user_mailer/email_address_shared.html.haml
@@ -1,0 +1,23 @@
+%p
+  Hi #{@user.name},
+%p
+  Good news! #{@swap_with.name} is going swap their vote with you.
+  They've now shared their email address with with you.
+  #{@swap_with.email}
+
+  Why not share Swap My Vote with your social networks so that more people can make their vote count?
+
+  <a href="https://twitter.com/intent/tweet?text=Join%20me%20in%20making%20our%20votes%20count%20more%20at%20https://swapmyvote.uk%20&#35;SwapmyVote">Tweet</a>
+  <a href="https://www.facebook.com/sharer/sharer.php?app_id=377810399053422&u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
+%p
+  To a better democracy!
+  %br
+  Swap My Vote Team
+%p
+  <a href="https://www.swapmyvote.uk/?utm_source=email&utm_medium=confirm_swap&utm_campaign=site">Swap My Vote</a>
+  %br
+  <a href="https://twitter.com/intent/follow?screen_name=swapmyvote">Follow us on Twitter</a>
+  %br
+  <a href="https://facebook.com/swapmyvote">Like us on Facebook</a>
+  %br
+  <a href="https://crowdfunder.co.uk/swapmyvote">Support us on Crowdfunder</a>

--- a/app/views/users/show/_confirm_outgoing_swap.html.haml
+++ b/app/views/users/show/_confirm_outgoing_swap.html.haml
@@ -33,6 +33,8 @@
   %p.text-center
     = form_tag user_swap_path, class: "form-inline", method: "put" do
       .form-check.mx-auto
+        %input{ type: "hidden", id: "swap_dummy",
+          name: "swap[dummy]", value: "dummy"}
         %input.form-check-input{ type: "checkbox", id: "swap_consent_share_email_chooser",
           name: "swap[consent_share_email_chooser]", value: "true"}
         %label.form-check-label{ for: "swap_consent_share_email_chooser" }

--- a/app/views/users/show/_confirm_outgoing_swap.html.haml
+++ b/app/views/users/show/_confirm_outgoing_swap.html.haml
@@ -20,6 +20,28 @@
 
     When they do we'll send you an email.
 
+- if @user.my_email_consent?
+  %p.text-center
+    You have opted to share your email address
+    with #{@user.swapped_with.redacted_name}.
+    When they confirm the swap, they will be notified of your email address.
+- else
+  %p.text-center
+    We encourage you to share your email address
+    with #{@user.swapped_with.redacted_name}.
+    When they confirm the swap, they will be notified of your email address.
+  %p.text-center
+    = form_tag user_swap_path, class: "form-inline", method: "put" do
+      .form-check.mx-auto
+        %input.form-check-input{ type: "checkbox", id: "consent-check",
+                                name: "swap[consent_share_email_chooser]", value: "true"}
+        %label.form-check-label{ for: "consent-check" }
+          Share my email address with #{@user.swapped_with.redacted_name}
+
+      %p.text-center{style: "width: 100%"}
+        = button_tag "Share with #{@user.swapped_with.redacted_name}", class: 'btn btn-primary'
+
+
 %p.text-center
 
   If we don't hear back from them in #{swap_validity_hours} hours,

--- a/app/views/users/show/_confirm_outgoing_swap.html.haml
+++ b/app/views/users/show/_confirm_outgoing_swap.html.haml
@@ -33,9 +33,9 @@
   %p.text-center
     = form_tag user_swap_path, class: "form-inline", method: "put" do
       .form-check.mx-auto
-        %input.form-check-input{ type: "checkbox", id: "consent-check",
-                                name: "swap[consent_share_email_chooser]", value: "true"}
-        %label.form-check-label{ for: "consent-check" }
+        %input.form-check-input{ type: "checkbox", id: "swap_consent_share_email_chooser",
+          name: "swap[consent_share_email_chooser]", value: "true"}
+        %label.form-check-label{ for: "swap_consent_share_email_chooser" }
           Share my email address with #{@user.swapped_with.redacted_name}
 
       %p.text-center{style: "width: 100%"}

--- a/app/views/users/show/_swap_confirmed.html.haml
+++ b/app/views/users/show/_swap_confirmed.html.haml
@@ -20,6 +20,26 @@
   %i.fa.fa-fw.fa-check
   #{@user.swapped_with.name} has confirmed the swap. You're all set!
 
+- if @user.my_email_consent?
+  %p.text-center
+    You have shared your email address
+    with #{@user.swapped_with.name}.
+- else
+  %p.text-center
+    We encourage you to share your email address
+    with #{@user.swapped_with.name}.
+  %p.text-center
+    = form_tag user_swap_path, class: "form-inline", method: "put" do
+      .form-check.mx-auto
+        %input.form-check-input{ type: "checkbox", id: "consent-check",
+                                name: "swap[consent_share_email_chosen]", value: "true"}
+        %label.form-check-label{ for: "consent-check" }
+          Share my email address with #{@user.swapped_with.name}
+
+      %p.text-center{style: "width: 100%"}
+        = button_tag "Share with #{@user.swapped_with.name}", class: 'btn btn-primary'
+
+
 %p.text-center
   - methods = contact_methods(@user.swapped_with)
   - if methods.present?

--- a/app/views/users/show/_swap_confirmed.html.haml
+++ b/app/views/users/show/_swap_confirmed.html.haml
@@ -32,7 +32,7 @@
     = form_tag user_swap_path, class: "form-inline", method: "put" do
       .form-check.mx-auto
         %input.form-check-input{ type: "checkbox", id: "consent-check",
-                                name: "swap[consent_share_email_chosen]", value: "true"}
+                                name: "swap[consent_share_email]", value: "true"}
         %label.form-check-label{ for: "consent-check" }
           Share my email address with #{@user.swapped_with.name}
 

--- a/spec/controllers/user/swaps_controller_spec.rb
+++ b/spec/controllers/user/swaps_controller_spec.rb
@@ -139,13 +139,15 @@ RSpec.describe User::SwapsController, type: :controller do
 
             context "with consent_share_email: true" do
               it "changes the swap to consent_share_email: true" do
-                allow(UserMailer).to receive(:email_address_shared).with(swap_user, new_user).and_return(double.as_null_object)
+                allow(UserMailer).to receive(:email_address_shared)
+                  .with(swap_user, new_user).and_return(double.as_null_object)
                 expect { put :update, params: { swap: { consent_share_email: true } } }
                   .to change(swap_user.swap, :consent_share_email_chosen).from(false).to(true)
               end
 
               it "does email the other voter with new consent" do
-                expect(UserMailer).to receive(:email_address_shared).with(swap_user, new_user).and_return(double.as_null_object)
+                expect(UserMailer).to receive(:email_address_shared)
+                  .with(swap_user, new_user).and_return(double.as_null_object)
                 put :update, params: { swap: { consent_share_email: true } }
               end
             end
@@ -225,13 +227,15 @@ RSpec.describe User::SwapsController, type: :controller do
 
             context "with consent_share_email: true" do
               it "changes the swap to consent_share_email: true" do
-                allow(UserMailer).to receive(:email_address_shared).with(swap_user, new_user).and_return(double.as_null_object)
+                allow(UserMailer).to receive(:email_address_shared)
+                  .with(swap_user, new_user).and_return(double.as_null_object)
                 expect { put :update, params: { swap: { consent_share_email: true } } }
                   .to change(swap_user.swap, :consent_share_email_chooser).from(false).to(true)
               end
 
               it "does email the other voter with new consent" do
-                expect(UserMailer).to receive(:email_address_shared).with(swap_user, new_user).and_return(double.as_null_object)
+                expect(UserMailer).to receive(:email_address_shared)
+                  .with(swap_user, new_user).and_return(double.as_null_object)
                 put :update, params: { swap: { consent_share_email: true } }
               end
             end

--- a/spec/controllers/user/swaps_controller_spec.rb
+++ b/spec/controllers/user/swaps_controller_spec.rb
@@ -95,6 +95,21 @@ RSpec.describe User::SwapsController, type: :controller do
               expect(flash[:errors]).to be_blank
               expect(swap_user.swap.confirmed).to be true
             end
+
+            context "AND with consent_share_email_chosen: true" do
+              it "changes the swap to consent_share_email_chosen: true" do
+                expect { put :update, params: { swap: { confirmed: true, consent_share_email_chosen: true } } }
+                  .to change(swap_user.swap, :consent_share_email_chosen).from(false).to(true)
+              end
+            end
+          end
+
+          context "with consent_share_email_chosen: true" do
+            it "changes the swap to consent_share_email_chosen: true" do
+              pending
+              expect { put :update, params: { swap: { consent_share_email_chosen: true } } }
+                .to change(swap_user.swap, :consent_share_email_chosen).from(false).to(true)
+            end
           end
         end
       end

--- a/spec/controllers/user/swaps_controller_spec.rb
+++ b/spec/controllers/user/swaps_controller_spec.rb
@@ -128,7 +128,8 @@ RSpec.describe User::SwapsController, type: :controller do
               end
 
               it "does NOT email the other voter with new consent" do
-                skip
+                expect(UserMailer).not_to receive(:email_address_shared)
+                put :update, params: { swap: { consent_share_email_chosen: true } }
               end
             end
           end
@@ -138,12 +139,14 @@ RSpec.describe User::SwapsController, type: :controller do
 
             context "with consent_share_email_chosen: true" do
               it "changes the swap to consent_share_email_chosen: true" do
+                allow(UserMailer).to receive(:email_address_shared).with(swap_user).and_return(double.as_null_object)
                 expect { put :update, params: { swap: { consent_share_email_chosen: true } } }
                   .to change(swap_user.swap, :consent_share_email_chosen).from(false).to(true)
               end
 
               it "does email the other voter with new consent" do
-                skip
+                expect(UserMailer).to receive(:email_address_shared).with(swap_user).and_return(double.as_null_object)
+                put :update, params: { swap: { consent_share_email_chosen: true } }
               end
             end
           end

--- a/spec/controllers/user/swaps_controller_spec.rb
+++ b/spec/controllers/user/swaps_controller_spec.rb
@@ -97,14 +97,20 @@ RSpec.describe User::SwapsController, type: :controller do
                 expect(swap_user.swap.confirmed).to be true
               end
 
-              it "emails both voters" do
-                skip
+              it "emails both voters with swap confirmation" do
+                expect(UserMailer).to receive(:swap_confirmed).twice
+                put :update, params: { swap: { confirmed: true } }
               end
 
               context "AND with consent_share_email_chosen: true" do
                 it "changes the swap to consent_share_email_chosen: true" do
                   expect { put :update, params: { swap: { confirmed: true, consent_share_email_chosen: true } } }
                     .to change(swap_user.swap, :consent_share_email_chosen).from(false).to(true)
+                end
+
+                it "emails both voters with swap confirmation" do
+                  expect(UserMailer).to receive(:swap_confirmed).twice
+                  put :update, params: { swap: { confirmed: true } }
                 end
               end
             end
@@ -115,7 +121,13 @@ RSpec.describe User::SwapsController, type: :controller do
                   .to change(swap_user.swap, :consent_share_email_chosen).from(false).to(true)
               end
 
-              it "does not email the other voter" do
+              it "does not email both voters with swap confirmation" do
+                expect(swap_user.swap.confirmed).to be nil
+                expect { put :update, params: { swap: { consent_share_email_chosen: true } } }
+                put :update, params: { swap: { confirmed: true } }
+              end
+
+              it "does NOT email the other voter with new consent" do
                 skip
               end
             end

--- a/spec/controllers/user/swaps_controller_spec.rb
+++ b/spec/controllers/user/swaps_controller_spec.rb
@@ -139,13 +139,13 @@ RSpec.describe User::SwapsController, type: :controller do
 
             context "with consent_share_email_chosen: true" do
               it "changes the swap to consent_share_email_chosen: true" do
-                allow(UserMailer).to receive(:email_address_shared).with(swap_user).and_return(double.as_null_object)
+                allow(UserMailer).to receive(:email_address_shared).with(swap_user, new_user).and_return(double.as_null_object)
                 expect { put :update, params: { swap: { consent_share_email_chosen: true } } }
                   .to change(swap_user.swap, :consent_share_email_chosen).from(false).to(true)
               end
 
               it "does email the other voter with new consent" do
-                expect(UserMailer).to receive(:email_address_shared).with(swap_user).and_return(double.as_null_object)
+                expect(UserMailer).to receive(:email_address_shared).with(swap_user, new_user).and_return(double.as_null_object)
                 put :update, params: { swap: { consent_share_email_chosen: true } }
               end
             end
@@ -225,13 +225,13 @@ RSpec.describe User::SwapsController, type: :controller do
 
             context "with consent_share_email_chooser: true" do
               it "changes the swap to consent_share_email_chooser: true" do
-                allow(UserMailer).to receive(:email_address_shared).with(swap_user).and_return(double.as_null_object)
+                allow(UserMailer).to receive(:email_address_shared).with(swap_user, new_user).and_return(double.as_null_object)
                 expect { put :update, params: { swap: { consent_share_email_chooser: true } } }
                   .to change(swap_user.swap, :consent_share_email_chooser).from(false).to(true)
               end
 
               it "does email the other voter with new consent" do
-                expect(UserMailer).to receive(:email_address_shared).with(swap_user).and_return(double.as_null_object)
+                expect(UserMailer).to receive(:email_address_shared).with(swap_user, new_user).and_return(double.as_null_object)
                 put :update, params: { swap: { consent_share_email_chooser: true } }
               end
             end

--- a/spec/controllers/user/swaps_controller_spec.rb
+++ b/spec/controllers/user/swaps_controller_spec.rb
@@ -106,7 +106,6 @@ RSpec.describe User::SwapsController, type: :controller do
 
           context "with consent_share_email_chosen: true" do
             it "changes the swap to consent_share_email_chosen: true" do
-              pending
               expect { put :update, params: { swap: { consent_share_email_chosen: true } } }
                 .to change(swap_user.swap, :consent_share_email_chosen).from(false).to(true)
             end

--- a/spec/controllers/user/swaps_controller_spec.rb
+++ b/spec/controllers/user/swaps_controller_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe User::SwapsController, type: :controller do
           context "but swap IS confirmed" do
             let(:swap)  { Swap.create(chosen_user_id: swap_user.id, confirmed: true) }
 
-            fcontext "with consent_share_email: true" do
+            context "with consent_share_email: true" do
               it "changes the swap to consent_share_email: true" do
                 allow(UserMailer).to receive(:email_address_shared).with(swap_user, new_user).and_return(double.as_null_object)
                 expect { put :update, params: { swap: { consent_share_email: true } } }
@@ -233,18 +233,6 @@ RSpec.describe User::SwapsController, type: :controller do
               it "does email the other voter with new consent" do
                 expect(UserMailer).to receive(:email_address_shared).with(swap_user, new_user).and_return(double.as_null_object)
                 put :update, params: { swap: { consent_share_email: true } }
-              end
-            end
-
-            context "with consent_share_email_chosen: true" do
-              it "DOES NOT change the swap to consent_share_email_chosen: true" do
-                expect { put :update, params: { swap: { consent_share_email_chosen: true } } }
-                  .to_not change(swap_user.swap, :consent_share_email_chosen).from(false)
-              end
-
-              it "does NOT email the other voter with new consent" do
-                expect(UserMailer).not_to receive(:email_address_shared)
-                put :update, params: { swap: { consent_share_email_chosen: true } }
               end
             end
           end

--- a/spec/controllers/user/swaps_controller_spec.rb
+++ b/spec/controllers/user/swaps_controller_spec.rb
@@ -137,16 +137,16 @@ RSpec.describe User::SwapsController, type: :controller do
           context "but swap IS confirmed" do
             let(:swap)  { Swap.create(chosen_user_id: swap_user.id, confirmed: true) }
 
-            context "with consent_share_email_chosen: true" do
-              it "changes the swap to consent_share_email_chosen: true" do
+            context "with consent_share_email: true" do
+              it "changes the swap to consent_share_email: true" do
                 allow(UserMailer).to receive(:email_address_shared).with(swap_user, new_user).and_return(double.as_null_object)
-                expect { put :update, params: { swap: { consent_share_email_chosen: true } } }
+                expect { put :update, params: { swap: { consent_share_email: true } } }
                   .to change(swap_user.swap, :consent_share_email_chosen).from(false).to(true)
               end
 
               it "does email the other voter with new consent" do
                 expect(UserMailer).to receive(:email_address_shared).with(swap_user, new_user).and_return(double.as_null_object)
-                put :update, params: { swap: { consent_share_email_chosen: true } }
+                put :update, params: { swap: { consent_share_email: true } }
               end
             end
           end
@@ -223,16 +223,16 @@ RSpec.describe User::SwapsController, type: :controller do
           context "but swap IS confirmed" do
             let(:swap)  { Swap.create(chosen_user_id: swap_user.id, confirmed: true) }
 
-            context "with consent_share_email_chooser: true" do
-              it "changes the swap to consent_share_email_chooser: true" do
+            fcontext "with consent_share_email: true" do
+              it "changes the swap to consent_share_email: true" do
                 allow(UserMailer).to receive(:email_address_shared).with(swap_user, new_user).and_return(double.as_null_object)
-                expect { put :update, params: { swap: { consent_share_email_chooser: true } } }
+                expect { put :update, params: { swap: { consent_share_email: true } } }
                   .to change(swap_user.swap, :consent_share_email_chooser).from(false).to(true)
               end
 
               it "does email the other voter with new consent" do
                 expect(UserMailer).to receive(:email_address_shared).with(swap_user, new_user).and_return(double.as_null_object)
-                put :update, params: { swap: { consent_share_email_chooser: true } }
+                put :update, params: { swap: { consent_share_email: true } }
               end
             end
 

--- a/spec/controllers/user/swaps_controller_spec.rb
+++ b/spec/controllers/user/swaps_controller_spec.rb
@@ -185,7 +185,6 @@ RSpec.describe User::SwapsController, type: :controller do
 
             context "with consent_share_email_chooser: true" do
               it "changes the swap to consent_share_email_chooser: true" do
-                pending
                 expect { put :update, params: { swap: { consent_share_email_chooser: true } } }
                   .to change(swap_user.swap, :consent_share_email_chooser).from(false).to(true)
               end
@@ -226,14 +225,13 @@ RSpec.describe User::SwapsController, type: :controller do
 
             context "with consent_share_email_chooser: true" do
               it "changes the swap to consent_share_email_chooser: true" do
-                pending
+                allow(UserMailer).to receive(:email_address_shared).with(swap_user).and_return(double.as_null_object)
                 expect { put :update, params: { swap: { consent_share_email_chooser: true } } }
                   .to change(swap_user.swap, :consent_share_email_chooser).from(false).to(true)
               end
 
               it "does email the other voter with new consent" do
-                pending
-                expect(UserMailer).to receive(:email_address_shared).with(swap_user)
+                expect(UserMailer).to receive(:email_address_shared).with(swap_user).and_return(double.as_null_object)
                 put :update, params: { swap: { consent_share_email_chooser: true } }
               end
             end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -23,4 +23,10 @@ RSpec.describe UserMailer do
       expect(response.to_json).to eq "null"
     end
   end
+
+  describe "email_address_shared" do
+    specify do
+      expect { UserMailer.email_address_shared(:something) }.not_to raise_error
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -392,6 +392,44 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#my_email_consent?" do
+    it "is false by default" do
+      expect(subject.my_email_consent?).to be_falsey
+    end
+
+    it "swapper is chooser and has consented to share email" do
+      confirmed_swap = build(:swap, confirmed: true)
+      confirmed_swap.consent_share_email_chooser = true
+      subject.outgoing_swap = confirmed_swap
+
+      expect(subject.my_email_consent?).to be_truthy
+    end
+
+    it "swapper is chooser and has not consented to share email" do
+      confirmed_swap = build(:swap, confirmed: true)
+      confirmed_swap.consent_share_email_chooser = false
+      subject.outgoing_swap = confirmed_swap
+
+      expect(subject.my_email_consent?).to be_falsey
+    end
+
+    it "swapper is chosen and has consented to share email" do
+      confirmed_swap = build(:swap, confirmed: true)
+      confirmed_swap.consent_share_email_chosen = true
+      subject.incoming_swap = confirmed_swap
+
+      expect(subject.my_email_consent?).to be_truthy
+    end
+
+    it "swapper is chosen and has not consented to share email" do
+      confirmed_swap = build(:swap, confirmed: true)
+      confirmed_swap.consent_share_email_chosen = false
+      subject.incoming_swap = confirmed_swap
+
+      expect(subject.my_email_consent?).to be_falsey
+    end
+  end
+
   context "when user has email login" do
     before do
       subject.email = "foo@example.com"


### PR DESCRIPTION
Closes #337

Allows swappers with either an unconfirmed or confirmed swap to give consent to email sharing.
Email notification will be sent if the change is made after confirmation, otherwise the confirmation email covers it. 