### PR TITLE
Improve email address validation behaviour

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,9 @@ class User < ApplicationRecord
   after_save :send_welcome_email, if: :needs_welcome_email?
   before_destroy :clear_swap
 
+  # Additional validation for emails, :validatable has already added basic validation
   validate :email_uniqueness, on: :create
+
   validates :name, presence: true
 
   def omniauth_tokens(auth)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ApplicationRecord
   after_save :send_welcome_email, if: :needs_welcome_email?
   before_destroy :clear_swap
 
-  validate :email_uniqueness
+  validate :email_uniqueness, on: :create
   validates :name, presence: true
 
   def omniauth_tokens(auth)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -330,9 +330,9 @@ class User < ApplicationRecord
 
     if id
       # Ignore self in the uniqueness check
-      existing_user = User.where("lower(#{:email}) = ? and id <> ?", email.downcase, id).first
+      existing_user = User.find_by("lower(#{:email}) = ? and id <> ?", email.downcase, id)
     else
-      existing_user = User.where("lower(#{:email}) = ?", email.downcase).first
+      existing_user = User.find_by("lower(#{:email}) = ?", email.downcase)
     end
 
     return unless existing_user

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -397,6 +397,12 @@ RSpec.describe User, type: :model do
       expect{create(:user, name: subject.name, email: subject.email)}.to raise_error(ActiveRecord::RecordInvalid)
     end
 
+    it "prevents email from being changed to a duplicate" do
+      bob = create(:user, name: "bob")
+      bob.email = subject.email
+      expect{bob.save!}.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
     it "allows different emails to be being created" do
       expect{create(:user, name: "Bob")}.to_not raise_error
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -398,7 +398,7 @@ RSpec.describe User, type: :model do
     end
 
     it "allows different emails to be being created" do
-      expect{create(:user, name: "Bob")}.to_not raise_error(ActiveRecord::RecordInvalid)
+      expect{create(:user, name: "Bob")}.to_not raise_error
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -392,6 +392,16 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "email validation" do
+    it "prevents duplicate emails from being created" do
+        expect{create(:user, name: subject.name, email: subject.email)}.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it "allows different emails to be being created" do
+      expect{create(:user, name: "Bob")}.to_not raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
   context "when user has email login" do
     before do
       subject.email = "foo@example.com"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -394,7 +394,7 @@ RSpec.describe User, type: :model do
 
   describe "email validation" do
     it "prevents duplicate emails from being created" do
-        expect{create(:user, name: subject.name, email: subject.email)}.to raise_error(ActiveRecord::RecordInvalid)
+      expect{create(:user, name: subject.name, email: subject.email)}.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     it "allows different emails to be being created" do


### PR DESCRIPTION
This adds a custom validation message when trying to create an account if it already exists. We tell the user how the original account was created.

This should also fix a problem some users may have when trying to log in with FB or Twitter if there are duplicate email addresses in the system.

fixes: #353 

Looks a bit like this:

![Screenshot 2019-12-11 15 56 50](https://user-images.githubusercontent.com/5228091/70637292-e2f4f880-1c2e-11ea-886f-332bebfb9385.png)
