### PR TITLE
Validate constituency from postcode input

### DIFF
--- a/app/javascript/packs/postcodesHelper.js
+++ b/app/javascript/packs/postcodesHelper.js
@@ -1,28 +1,11 @@
 // Help with finding constituencies from postcodes
 
 $(document).ready(() => {
-  //display results on page
-  const displayData = postcode => {
-    var onsId = postcode.result.codes.parliamentary_constituency;
-    var name = postcode.result.parliamentary_constituency;
-
-    $("select#user_constituency_ons_id")
-      .val(onsId)
-      .change(); // this SHOULD change the dropdown
-    $(".constituency-autocomplete-input").val(name);
+  const clearPostcodeError = () => {
+    $("#error-postcode").html("");
   };
 
-  const postcodeButton = () => {
-    var input = $("#txt-postcode").val();
-    var url = "https://api.postcodes.io/postcodes/" + input;
-    if (input == "") {
-      $("#error-postcode").html("Please enter a postcode!");
-    } else {
-      post(url).done(displayData);
-    }
-  };
-
-  const ajaxError = (desc, _status, _err) => {
+  const handlePostcodeServiceError = (desc, _status, _err) => {
     if (desc.status == 404 || desc.status == 400) {
       $("#error-postcode").html(JSON.parse(desc.responseText).error);
     } else {
@@ -32,21 +15,46 @@ $(document).ready(() => {
     }
   };
 
-  const ajaxSuccess = () => {
-    $("#error-postcode").html("");
+  const handlePostcodeSubmit = () => {
+    const input = $("#txt-postcode").val();
+    const url = "https://api.postcodes.io/postcodes/" + input;
+    if (input == "") {
+      $("#error-postcode").html("Please enter a postcode!");
+    } else {
+      $.ajax({
+        url: url,
+        success: handlePostcodeLookup,
+        error: handlePostcodeServiceError
+      }); //.done(handlePostcodeLookup);
+    }
   };
 
-  //ajax call
-  const post = url => {
-    return $.ajax({
-      url: url,
-      success: ajaxSuccess,
-      error: ajaxError
-    });
+  const handlePostcodeLookup = postcode => {
+    const onsId = postcode.result.codes.parliamentary_constituency;
+    const name = postcode.result.parliamentary_constituency;
+
+    const hasOption = $('select#user_constituency_ons_id option[value="' + onsId + '"]');
+    if (hasOption.length == 0) {
+      $("#error-postcode").html('Postcode is not in one of the accepted constituencies');
+      // this only changes the hidden dropdown, not the auto-complete
+      // one
+      $("select#user_constituency_ons_id")
+        .val('')
+        .change();
+      $(".constituency-autocomplete-input").val('');
+    } else {
+      // this only changes the hidden dropdown, not the auto-complete
+      // one
+      clearPostcodeError();
+      $("select#user_constituency_ons_id")
+        .val(onsId)
+        .change(); // this SHOULD change the dropdown
+      $(".constituency-autocomplete-input").val(name);
+    }
   };
 
   // button event
-  $(document).on("click", "#btn-postcode", postcodeButton);
+  $(document).on("click", "#btn-postcode", handlePostcodeSubmit);
 
   // Make Enter key in postcode field simulate clicking the "Search"
   // button rather than submitting the form, since the user may not have


### PR DESCRIPTION
Partially fixes #443, but needs to be prettier and do backend validation too.

Could switch to using https://jqueryvalidation.org/jQuery.validator.addMethod/ for form validation.