### PR TITLE
Delete obsolete constituency model

### DIFF
--- a/app/models/constituency.rb
+++ b/app/models/constituency.rb
@@ -1,3 +1,0 @@
-class Constituency < ApplicationRecord
-  has_many :polls, dependent: :destroy
-end

--- a/db/migrate/20210613220725_drop_constituency_model.rb
+++ b/db/migrate/20210613220725_drop_constituency_model.rb
@@ -1,0 +1,5 @@
+class DropConstituencyModel < ActiveRecord::Migration[5.2]
+  def up
+    drop_table :constituencies
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_09_132125) do
-
-  create_table "constituencies", force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
+ActiveRecord::Schema.define(version: 2021_06_13_220725) do
 
   create_table "identities", force: :cascade do |t|
     t.integer "user_id"

--- a/spec/controllers/user/constituencies_controller_spec.rb
+++ b/spec/controllers/user/constituencies_controller_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe User::ConstituenciesController, type: :controller do
     end
 
     context "and user is logged in" do
-      let(:logged_in_user) { instance_double(User, constituency: :some_constituency, email: :some_email) }
+      let(:logged_in_user) {
+        instance_double(User,
+                        constituency_ons_id: 1,
+                        email: "user@fake.com")
+      }
 
       before do
         # Stub out authentication

--- a/spec/models/constituency_spec.rb
+++ b/spec/models/constituency_spec.rb
@@ -1,9 +1,0 @@
-require "rails_helper"
-
-RSpec.describe Constituency, type: :model do
-  subject { described_class.new(id: 1)}
-
-  describe "#polls" do
-    specify { expect {subject.polls}.not_to raise_error }
-  end
-end


### PR DESCRIPTION
The `Constituency` model was obsoleted by `OnsConstituency`. Looks like the only place it's still used is `db/fixtures/ons_constituency_lookup.rb`, so this PR needs to be amended to address that.
