### PR TITLE
Issue 491 duplicate and joint parties - Electoral Commission data

### DIFF
--- a/db/fixtures/electoral_commission_parties.csv
+++ b/db/fixtures/electoral_commission_parties.csv
@@ -1,0 +1,1111 @@
+﻿ECRef,RegulatedEntityName,RegulatedEntityTypeName,RegistrationStatusName,RegisterName,EntityStatusName,ReferendumName,DesignationStatusName,CompanyRegistrationNumber,ApprovedDate,FieldingCandidatesInEngland,FieldingCandidatesInScotland,FieldingCandidatesInWales,FieldingCandidatesMinorParty,ReferendumOutcome,CampaigningName,Description,DescriptionTranslation,DateDescriptionFirstApproved,FinancialYearEnd
+PP851,A Better Way to Govern,Political Party,Registered,Great Britain,,,,,26/03/2010,True,True,True,False,,,,,,31/12
+PPm12607,A Fresh Start for Sheringham,Minor Party,Registered,,,,,,22/10/2020,True,False,False,True,,,,,,
+PP6673,Abolish the Scottish Parliament Party,Political Party,Registered,Great Britain,,,,,31/01/2018,False,True,False,False,,,Abolish Scottish Parliament - Services not Salaries,,31/01/2018 12:13:53,31/12
+PP6673,Abolish the Scottish Parliament Party,Political Party,Registered,Great Britain,,,,,31/01/2018,False,True,False,False,,,Abolish Scottish Parliament - Maintain the Union,,31/01/2018 12:13:53,31/12
+PP6673,Abolish the Scottish Parliament Party,Political Party,Registered,Great Britain,,,,,31/01/2018,False,True,False,False,,,Abolish Scottish Parliament - No Second Referendum,,31/01/2018 12:13:53,31/12
+PP6673,Abolish the Scottish Parliament Party,Political Party,Registered,Great Britain,,,,,31/01/2018,False,True,False,False,,,Abolish Scottish Parliament - We've Had Enough,,31/01/2018 12:13:53,31/12
+PP6673,Abolish the Scottish Parliament Party,Political Party,Registered,Great Britain,,,,,31/01/2018,False,True,False,False,,,Abolish Scottish Parliament Party - Abolish Holyrood,,08/07/2020 12:44:11,31/12
+PP6673,Abolish the Scottish Parliament Party,Political Party,Registered,Great Britain,,,,,31/01/2018,False,True,False,False,,,Abolish Holyrood - Abolish Scottish Parliament Party,,08/07/2020 12:44:11,31/12
+PP6673,Abolish the Scottish Parliament Party,Political Party,Registered,Great Britain,,,,,31/01/2018,False,True,False,False,,,Abolish Scottish Parliament Party - Scrap Holyrood,,08/07/2020 12:44:11,31/12
+PP6673,Abolish the Scottish Parliament Party,Political Party,Registered,Great Britain,,,,,31/01/2018,False,True,False,False,,,Abolish Scottish Parliament Party - Dissolve Holyrood,,08/07/2020 12:44:11,31/12
+PP6673,Abolish the Scottish Parliament Party,Political Party,Registered,Great Britain,,,,,31/01/2018,False,True,False,False,,,Abolish Scottish Parliament - No More Referendums,,08/07/2020 12:44:11,31/12
+PP6673,Abolish the Scottish Parliament Party,Political Party,Registered,Great Britain,,,,,31/01/2018,False,True,False,False,,,Abolish Scottish Parliament Party - Scrap Devolution,,08/07/2020 12:44:11,31/12
+PP6673,Abolish the Scottish Parliament Party,Political Party,Registered,Great Britain,,,,,31/01/2018,False,True,False,False,,,Abolish Scottish Parliament Party - Abolish Devolution,,08/07/2020 12:44:11,31/12
+PP6673,Abolish the Scottish Parliament Party,Political Party,Registered,Great Britain,,,,,31/01/2018,False,True,False,False,,,"Abolish Scottish Parliament – Save £100,000,000 Yearly",,28/10/2020 12:33:48,31/12
+PP6745,Abolish the TV Licence Party,Political Party,Registered,Great Britain,,,,,29/03/2018,True,False,False,False,,,Abolish the TV Licence,,25/05/2021 18:02:35,31/12
+PP6745,Abolish the TV Licence Party,Political Party,Registered,Great Britain,,,,,29/03/2018,True,False,False,False,,,Abolish the BBC TV Licence,,25/05/2021 18:02:35,31/12
+PP6745,Abolish the TV Licence Party,Political Party,Registered,Great Britain,,,,,29/03/2018,True,False,False,False,,,Abolish the Television Broadcast Receiving Licence,,25/05/2021 18:02:35,31/12
+PP6745,Abolish the TV Licence Party,Political Party,Registered,Great Britain,,,,,29/03/2018,True,False,False,False,,,Abolish the Television Licence,,25/05/2021 18:02:35,31/12
+PP6745,Abolish the TV Licence Party,Political Party,Registered,Great Britain,,,,,29/03/2018,True,False,False,False,,,Abolish the BBC Television Licence,,25/05/2021 18:02:35,31/12
+PP6745,Abolish the TV Licence Party,Political Party,Registered,Great Britain,,,,,29/03/2018,True,False,False,False,,,Abolish the TV Broadcast Receiving Licence,,25/05/2021 18:02:35,31/12
+PP12653,Abolish The Welsh Assembly Party,Political Party,Registered,Great Britain,,,,,06/01/2021,True,False,True,False,,,,,,31/12
+PPm7927,Act for Cuxton Together,Minor Party,Registered,,,,,,14/01/2019,True,False,False,True,,,,,,
+PP654,Action To Save St.John's Hospital,Political Party,Registered,Great Britain,,,,,19/03/2007,False,True,False,False,,,,,,31/12
+PP6795,Active For Plymouth,Political Party,Registered,Great Britain,,,,,25/06/2018,True,False,False,False,,,,,,31/12
+PP12700,Alba Party,Political Party,Registered,Great Britain,,,,,08/02/2021,False,True,False,False,,,,,,31/12
+PP12579,All For Unity,Political Party,Registered,Great Britain,,,,,04/02/2021,False,True,False,False,,,All for Unity - No to Separatism,,04/02/2021 10:59:52,31/12
+PP12579,All For Unity,Political Party,Registered,Great Britain,,,,,04/02/2021,False,True,False,False,,,All 4 Unity - No to Separatism,,04/02/2021 10:59:52,31/12
+PP12579,All For Unity,Political Party,Registered,Great Britain,,,,,04/02/2021,False,True,False,False,,,All 4 Unity,,04/02/2021 10:59:52,31/12
+PP12579,All For Unity,Political Party,Registered,Great Britain,,,,,04/02/2021,False,True,False,False,,,All for Unity (A4U),,25/05/2021 18:06:05,31/12
+PP12579,All For Unity,Political Party,Registered,Great Britain,,,,,04/02/2021,False,True,False,False,,,All 4 Unity (A4U),,25/05/2021 18:06:05,31/12
+PP103,Alliance - Alliance Party of Northern Ireland,Political Party,Registered,Northern Ireland,,,,,25/02/1999,False,False,False,False,,,Alliance,,02/02/2001 00:00:00,31/12
+PP103,Alliance - Alliance Party of Northern Ireland,Political Party,Registered,Northern Ireland,,,,,25/02/1999,False,False,False,False,,,Alliance Party,,02/02/2001 00:00:00,31/12
+PP103,Alliance - Alliance Party of Northern Ireland,Political Party,Registered,Northern Ireland,,,,,25/02/1999,False,False,False,False,,,The Alliance Party,,02/02/2001 00:00:00,31/12
+PP103,Alliance - Alliance Party of Northern Ireland,Political Party,Registered,Northern Ireland,,,,,25/02/1999,False,False,False,False,,,Alliance Party of Northern Ireland,,02/02/2001 00:00:00,31/12
+PP103,Alliance - Alliance Party of Northern Ireland,Political Party,Registered,Northern Ireland,,,,,25/02/1999,False,False,False,False,,,The Alliance Party of Northern Ireland,,02/02/2001 00:00:00,31/12
+PP103,Alliance - Alliance Party of Northern Ireland,Political Party,Registered,Northern Ireland,,,,,25/02/1999,False,False,False,False,,,Alliance Works - Tribal Politics Doesn't,,02/02/2001 00:00:00,31/12
+PP103,Alliance - Alliance Party of Northern Ireland,Political Party,Registered,Northern Ireland,,,,,25/02/1999,False,False,False,False,,,Alliance Party - Shared Future,,02/02/2001 00:00:00,31/12
+PP103,Alliance - Alliance Party of Northern Ireland,Political Party,Registered,Northern Ireland,,,,,25/02/1999,False,False,False,False,,,Alliance Party First Candidate,,02/02/2001 00:00:00,31/12
+PP103,Alliance - Alliance Party of Northern Ireland,Political Party,Registered,Northern Ireland,,,,,25/02/1999,False,False,False,False,,,Alliance Party Second Candidate,,02/02/2001 00:00:00,31/12
+PP103,Alliance - Alliance Party of Northern Ireland,Political Party,Registered,Northern Ireland,,,,,25/02/1999,False,False,False,False,,,Alliance Party Third Candidate,,02/02/2001 00:00:00,31/12
+PP103,Alliance - Alliance Party of Northern Ireland,Political Party,Registered,Northern Ireland,,,,,25/02/1999,False,False,False,False,,,Cross-Community Alliance Party,,02/02/2001 00:00:00,31/12
+PP1952,Alliance EPP (European People’s Party) UK,Political Party,Registered,Great Britain,,,,,10/10/2012,True,True,True,False,,,EPP: European People’s Party,,19/03/2015 18:01:39,31/12
+PP10288,Alliance for Democracy and Freedom,Political Party,Registered,Great Britain,,,,,20/08/2020,True,True,True,False,,,Alliance for Democracy and Freedom ADF,,23/03/2021 14:14:10,31/12
+PP10288,Alliance for Democracy and Freedom,Political Party,Registered,Great Britain,,,,,20/08/2020,True,True,True,False,,,Alliance for Democracy and Freedom Bradford,,23/03/2021 14:14:10,31/12
+PP10288,Alliance for Democracy and Freedom,Political Party,Registered,Great Britain,,,,,20/08/2020,True,True,True,False,,,Alliance for Democracy and Freedom Doncaster,,23/03/2021 14:14:10,31/12
+PP10288,Alliance for Democracy and Freedom,Political Party,Registered,Great Britain,,,,,20/08/2020,True,True,True,False,,,Alliance for Democracy and Freedom Durham,,23/03/2021 14:14:10,31/12
+PP10288,Alliance for Democracy and Freedom,Political Party,Registered,Great Britain,,,,,20/08/2020,True,True,True,False,,,Alliance for Democracy and Freedom Hartlepool,,23/03/2021 14:14:10,31/12
+PP10288,Alliance for Democracy and Freedom,Political Party,Registered,Great Britain,,,,,20/08/2020,True,True,True,False,,,Alliance for Democracy and Freedom Herefordshire,,23/03/2021 14:14:10,31/12
+PP10288,Alliance for Democracy and Freedom,Political Party,Registered,Great Britain,,,,,20/08/2020,True,True,True,False,,,Alliance for Democracy and Freedom Hull,,23/03/2021 14:14:10,31/12
+PP10288,Alliance for Democracy and Freedom,Political Party,Registered,Great Britain,,,,,20/08/2020,True,True,True,False,,,Alliance for Democracy and Freedom Lincolnshire,,23/03/2021 14:14:10,31/12
+PP10288,Alliance for Democracy and Freedom,Political Party,Registered,Great Britain,,,,,20/08/2020,True,True,True,False,,,Alliance for Democracy and Freedom Salford,,23/03/2021 14:14:10,31/12
+PP10288,Alliance for Democracy and Freedom,Political Party,Registered,Great Britain,,,,,20/08/2020,True,True,True,False,,,Alliance for Democracy and Freedom Sedgefield,,23/03/2021 14:14:10,31/12
+PP10288,Alliance for Democracy and Freedom,Political Party,Registered,Great Britain,,,,,20/08/2020,True,True,True,False,,,Alliance for Democracy and Freedom Warrington,,23/03/2021 14:14:10,31/12
+PP10288,Alliance for Democracy and Freedom,Political Party,Registered,Great Britain,,,,,20/08/2020,True,True,True,False,,,Alliance for Democracy and Freedom Wakefield,,23/03/2021 14:14:10,31/12
+PP5260,Alliance for Europe,Political Party,Registered,Great Britain,,,,,24/08/2016,True,True,True,False,,,Alliance for Europe in Wales,Cynghrair dros Ewrop yng Nghymru,24/08/2016 16:41:57,31/12
+PP5260,Alliance for Europe,Political Party,Registered,Great Britain,,,,,24/08/2016,True,True,True,False,,,The Alliance for Europe Candidate,,24/08/2016 16:41:57,31/12
+PP67,Alliance For Green Socialism,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Alliance For Green Socialism - Save NHS,,02/02/2001 00:00:00,31/12
+PP67,Alliance For Green Socialism,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Alliance for Green Socialism - Save Homes,,02/02/2001 00:00:00,31/12
+PP67,Alliance For Green Socialism,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Alliance For Green Socialism - Save Schools,,02/02/2001 00:00:00,31/12
+PP67,Alliance For Green Socialism,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Green Socialists,,02/02/2001 00:00:00,31/12
+PP67,Alliance For Green Socialism,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Alliance for Green Socialism - LGBT,,23/03/2021 15:34:03,31/12
+PP67,Alliance For Green Socialism,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Alliance for Green Socialism - Environmental Socialists,,23/03/2021 15:34:03,31/12
+PP67,Alliance For Green Socialism,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Alliance for Green Socialism and Environment,,23/03/2021 15:34:03,31/12
+PP67,Alliance For Green Socialism,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Alliance for Green Socialism - Ecological Socialists,,23/03/2021 15:34:03,31/12
+PP67,Alliance For Green Socialism,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Green Socialists - The Left Green Alliance,,23/03/2021 15:34:03,31/12
+PP67,Alliance For Green Socialism,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Green Socialists - Fighting for the Planet,,23/03/2021 15:34:03,31/12
+PP67,Alliance For Green Socialism,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Green Socialists - Build more Council Houses,,23/03/2021 15:34:03,31/12
+PP7997,Alliance For Local Living (ALL),Political Party,Registered,Great Britain,,,,,01/04/2019,True,False,False,False,,,Alliance for Local Living Independent Candidate.,,01/04/2019 12:07:44,31/12
+PP2658,Alliance for London,Political Party,Registered,Great Britain,,,,,01/04/2015,True,False,False,False,,,Alliance for London: Londoners First,,15/12/2020 18:21:13,31/12
+PP2658,Alliance for London,Political Party,Registered,Great Britain,,,,,01/04/2015,True,False,False,False,,,Alliance for London: the Londoners' Party,,15/12/2020 18:21:13,31/12
+PP2658,Alliance for London,Political Party,Registered,Great Britain,,,,,01/04/2015,True,False,False,False,,,Alliance for London: the London Party,,15/12/2020 18:21:13,31/12
+PP2658,Alliance for London,Political Party,Registered,Great Britain,,,,,01/04/2015,True,False,False,False,,,Alliance for London: London in Europe,,15/12/2020 18:21:13,31/12
+PP2658,Alliance for London,Political Party,Registered,Great Britain,,,,,01/04/2015,True,False,False,False,,,Alliance for London: Londoners in Europe,,15/12/2020 18:21:13,31/12
+PP2658,Alliance for London,Political Party,Registered,Great Britain,,,,,01/04/2015,True,False,False,False,,,Alliance for London: all Londoners Together,,15/12/2020 18:21:13,31/12
+PP12661,Andover Alliance,Political Party,Registered,Great Britain,,,,,13/01/2021,True,False,False,False,,,,,,31/12
+PP9225,Andover Independents Party,Political Party,Registered,Great Britain,,,,,02/09/2019,True,False,False,False,,,Andover Independents,,02/09/2019 11:26:37,31/12
+PP9225,Andover Independents Party,Political Party,Registered,Great Britain,,,,,02/09/2019,True,False,False,False,,,The Andover Independents,,02/09/2019 11:26:37,31/12
+PP4041,Animal Welfare Party,Political Party,Registered,Northern Ireland,,,,,06/04/2016,False,False,False,False,,,"Animal Welfare Party - People, Animals, Environment",,15/04/2019 12:01:00,31/12
+PP616,Animal Welfare Party,Political Party,Registered,Great Britain,,,,,22/01/2007,True,True,True,False,,,"Animal Welfare Party - People, Animals, Environment",,15/04/2019 12:11:35,31/12
+PP7968,Aontú,Political Party,Registered,Northern Ireland,,,,,25/03/2019,False,False,False,False,,,"Aontú for Life, Unity, Economic Justice",,06/01/2020 16:05:26,31/12
+PP845,Apolitical Democrats,Political Party,Registered,Great Britain,,,,,22/03/2010,True,True,True,False,,,,,,31/12
+PP3902,Ashfield Independents,Political Party,Registered,Great Britain,,,,,28/07/2016,True,False,False,False,,,Ashfield Independents Working All Year Round,,28/07/2016 11:57:40,31/12
+PP3902,Ashfield Independents,Political Party,Registered,Great Britain,,,,,28/07/2016,True,False,False,False,,,Ashfield Independents Putting Sutton First,,28/07/2016 11:57:40,31/12
+PP3902,Ashfield Independents,Political Party,Registered,Great Britain,,,,,28/07/2016,True,False,False,False,,,Ashfield Independents Putting Hucknall First,,28/07/2016 11:57:40,31/12
+PP3902,Ashfield Independents,Political Party,Registered,Great Britain,,,,,28/07/2016,True,False,False,False,,,Ashfield Independents Putting Selston First,,28/07/2016 11:57:40,31/12
+PP3902,Ashfield Independents,Political Party,Registered,Great Britain,,,,,28/07/2016,True,False,False,False,,,Ashfield Independents Putting People Before Politics,,28/07/2016 11:57:40,31/12
+PP3902,Ashfield Independents,Political Party,Registered,Great Britain,,,,,28/07/2016,True,False,False,False,,,Ashfield Independents Putting Kirkby First,,02/10/2019 16:48:34,31/12
+PP3902,Ashfield Independents,Political Party,Registered,Great Britain,,,,,28/07/2016,True,False,False,False,,,Ashfield Independents Working Hard For You,,02/10/2019 16:48:34,31/12
+PP3902,Ashfield Independents,Political Party,Registered,Great Britain,,,,,28/07/2016,True,False,False,False,,,Ashfield Independents £1million More For Roads,,26/05/2021 14:00:38,31/12
+PP291,Ashford Independent,Political Party,Registered,Great Britain,,,,,06/03/2003,True,False,False,False,,,,,,31/12
+PP625,Ashtead Independents,Political Party,Registered,Great Britain,,,,,05/03/2007,True,False,False,False,,,"Ashtead Independents, working with Ashtead Residents",,05/03/2007 00:00:00,31/12
+PP625,Ashtead Independents,Political Party,Registered,Great Britain,,,,,05/03/2007,True,False,False,False,,,"Ashtead Independents, working for Ashtead Residents",,05/03/2007 00:00:00,31/12
+PP625,Ashtead Independents,Political Party,Registered,Great Britain,,,,,05/03/2007,True,False,False,False,,,"Ashtead Independent, working with Ashtead Residents",,05/03/2007 00:00:00,31/12
+PP625,Ashtead Independents,Political Party,Registered,Great Britain,,,,,05/03/2007,True,False,False,False,,,"Ashtead Independent, working for Ashtead Residents",,05/03/2007 00:00:00,31/12
+PP625,Ashtead Independents,Political Party,Registered,Great Britain,,,,,05/03/2007,True,False,False,False,,,"Ashtead Independents - local people, local issues",,05/03/2007 00:00:00,31/12
+PP625,Ashtead Independents,Political Party,Registered,Great Britain,,,,,05/03/2007,True,False,False,False,,,"Ashtead Independent - local resident, local issues",,05/03/2007 00:00:00,31/12
+PP625,Ashtead Independents,Political Party,Registered,Great Britain,,,,,05/03/2007,True,False,False,False,,,Ashtead Independent,,05/03/2007 00:00:00,31/12
+PP6713,Aspire,Political Party,Registered,Great Britain,,,,,26/01/2018,True,False,False,False,,,,,,31/12
+PP2567,Atomist,Political Party,Registered,Great Britain,,,,,27/02/2015,True,True,True,False,,,Atomist - Making life simple,,12/06/2015 15:16:44,31/12
+PP2567,Atomist,Political Party,Registered,Great Britain,,,,,27/02/2015,True,True,True,False,,,Atomist - Intelligent Revolution,,15/04/2019 11:00:24,31/12
+PP530,Barnsley Independent Group,Political Party,Registered,Great Britain,,,,,14/02/2006,True,False,False,False,,,Barnsley Independent Group The Barnsley Party,,12/02/2020 11:31:05,31/12
+PP530,Barnsley Independent Group,Political Party,Registered,Great Britain,,,,,14/02/2006,True,False,False,False,,,Barnsley Independent Group Putting Barnsley First,,12/02/2020 11:31:05,31/12
+PP530,Barnsley Independent Group,Political Party,Registered,Great Britain,,,,,14/02/2006,True,False,False,False,,,Barnsley Independent Group Taking Back Control,,12/02/2020 11:31:05,31/12
+PP530,Barnsley Independent Group,Political Party,Registered,Great Britain,,,,,14/02/2006,True,False,False,False,,,Barnsley Independent Group your Community Candidate,,12/02/2020 11:31:05,31/12
+PP530,Barnsley Independent Group,Political Party,Registered,Great Britain,,,,,14/02/2006,True,False,False,False,,,Barnsley Independent Group Reforming Barnsley,,12/02/2020 11:31:05,31/12
+PP530,Barnsley Independent Group,Political Party,Registered,Great Britain,,,,,14/02/2006,True,False,False,False,,,Barnsley Independent Group for Direct Democracy,,12/02/2020 11:31:05,31/12
+PP12751,Basildon Community Residents Party,Political Party,Registered,Great Britain,,,,,18/03/2021,True,False,False,False,,,,,,31/12
+PP10225,Basingstoke & Deane Independents,Political Party,Registered,Great Britain,,,,,20/01/2020,True,False,False,False,,,Basingstoke Independents,,20/01/2020 15:53:32,31/12
+PP6709,Birmingham Worker,Political Party,Registered,Great Britain,,,,,07/03/2018,True,False,False,False,,,The Birmingham Worker,,07/03/2018 13:54:31,31/12
+PP6709,Birmingham Worker,Political Party,Registered,Great Britain,,,,,07/03/2018,True,False,False,False,,,Birmingham Worker candidate,,07/03/2018 13:54:31,31/12
+PP6709,Birmingham Worker,Political Party,Registered,Great Britain,,,,,07/03/2018,True,False,False,False,,,Birmingham Worker: against the cuts,,07/03/2018 13:54:31,31/12
+PP6709,Birmingham Worker,Political Party,Registered,Great Britain,,,,,07/03/2018,True,False,False,False,,,a Birmingham Worker,,07/03/2018 13:54:31,31/12
+PP11456,Black Country Party,Political Party,Registered,Great Britain,,,,,10/01/2020,True,False,False,False,,,,,,31/12
+PP6342,Blue Revolution,Political Party,Registered,Great Britain,,,,,16/03/2017,True,False,False,False,,,Blue Revolution means Change through Challenge,,16/03/2017 15:23:31,31/12
+PP6342,Blue Revolution,Political Party,Registered,Great Britain,,,,,16/03/2017,True,False,False,False,,,Blue Revolution : Contract Choice and Consent,,16/03/2017 15:23:31,31/12
+PP6342,Blue Revolution,Political Party,Registered,Great Britain,,,,,16/03/2017,True,False,False,False,,,Blue Revolution the real Workers Revolution,,16/03/2017 15:23:31,31/12
+PP2676,BollingtonFirst,Political Party,Registered,Great Britain,,,,,27/02/2015,True,False,False,False,,,Bollington First,,27/02/2015 18:10:16,31/12
+PP11460,Bolton For Change,Political Party,Registered,Great Britain,,,,,26/02/2020,True,False,False,False,,,Bolton For Change Breightmet,,26/02/2020 13:57:35,31/12
+PP11460,Bolton For Change,Political Party,Registered,Great Britain,,,,,26/02/2020,True,False,False,False,,,Bolton For Change Tonge with Haulgh,,26/02/2020 13:57:35,31/12
+PP11460,Bolton For Change,Political Party,Registered,Great Britain,,,,,26/02/2020,True,False,False,False,,,Bolton For Change Horwich & Blackrod,,26/02/2020 13:57:35,31/12
+PP11460,Bolton For Change,Political Party,Registered,Great Britain,,,,,26/02/2020,True,False,False,False,,,Bolton For Change Halliwell,,26/02/2020 13:57:35,31/12
+PP11460,Bolton For Change,Political Party,Registered,Great Britain,,,,,26/02/2020,True,False,False,False,,,Bolton For Change Astley Bridge,,26/02/2020 13:57:35,31/12
+PP11460,Bolton For Change,Political Party,Registered,Great Britain,,,,,26/02/2020,True,False,False,False,,,Bolton For Change Crompton,,26/02/2020 13:57:35,31/12
+PP11460,Bolton For Change,Political Party,Registered,Great Britain,,,,,26/02/2020,True,False,False,False,,,Bolton For Change Smithills,,26/02/2020 13:57:35,31/12
+PP11460,Bolton For Change,Political Party,Registered,Great Britain,,,,,26/02/2020,True,False,False,False,,,Bolton For Change Farnworth & Kearsley,,26/02/2020 13:57:35,31/12
+PP11460,Bolton For Change,Political Party,Registered,Great Britain,,,,,26/02/2020,True,False,False,False,,,Bolton For Change Horwich North East,,26/02/2020 13:57:35,31/12
+PP11460,Bolton For Change,Political Party,Registered,Great Britain,,,,,26/02/2020,True,False,False,False,,,Bolton For Change Bromley Cross,,26/02/2020 13:57:35,31/12
+PP11460,Bolton For Change,Political Party,Registered,Great Britain,,,,,26/02/2020,True,False,False,False,,,Bolton For Change Bradshaw,,26/02/2020 13:57:35,31/12
+PP11460,Bolton For Change,Political Party,Registered,Great Britain,,,,,26/02/2020,True,False,False,False,,,Bolton For Change Darcy/Little Lever,,26/02/2020 13:57:35,31/12
+PP6885,Both Unions Party,Political Party,Registered,Great Britain,,,,,12/12/2018,True,True,True,False,,,Scotland for Both Unions: UK Europe,,12/12/2018 12:00:26,31/12
+PP6844,Both Unions Party of Northern Ireland,Political Party,Registered,Northern Ireland,,,,,10/09/2018,False,False,False,False,,,Northern Ireland Both Unions UK Europe,,28/09/2018 17:22:55,31/12
+PP12596,Breakthrough Party,Political Party,Registered,Great Britain,,,,,26/01/2021,True,True,True,False,,,,,,31/12
+PP1765,British Democratic Party,Political Party,Registered,Great Britain,,,,,23/05/2011,True,True,True,False,,,British Democrats,,23/05/2011 10:31:05,31/12
+PP1765,British Democratic Party,Political Party,Registered,Great Britain,,,,,23/05/2011,True,True,True,False,,,Brit Dems,,28/03/2013 17:25:06,31/12
+PP1765,British Democratic Party,Political Party,Registered,Great Britain,,,,,23/05/2011,True,True,True,False,,,Brit Dems stop immigration leave EU,,28/03/2013 17:25:06,31/12
+PP1765,British Democratic Party,Political Party,Registered,Great Britain,,,,,23/05/2011,True,True,True,False,,,British Democrats stop immigration leave EU,,28/03/2013 17:25:06,31/12
+PP1765,British Democratic Party,Political Party,Registered,Great Britain,,,,,23/05/2011,True,True,True,False,,,Plaid Democratiadd Prydeinig,British Democratic Party,28/03/2013 17:25:06,31/12
+PP1765,British Democratic Party,Political Party,Registered,Great Britain,,,,,23/05/2011,True,True,True,False,,,Democrataidd Prydeinig,British Democrats,28/03/2013 17:25:06,31/12
+PP2165,British Independents,Political Party,Registered,Great Britain,,,,,28/11/2013,True,True,True,False,,,,,,31/12
+PP10282,British Liberal Provident Party,Political Party,Registered,Great Britain,,,,,13/01/2020,True,True,True,False,,,,,,31/12
+PP3960,British National Party,Political Party,Registered,Great Britain,,,,,10/02/2016,True,True,True,False,,,British National Party Local People First,,10/02/2016 16:33:56,31/12
+PP3960,British National Party,Political Party,Registered,Great Britain,,,,,10/02/2016,True,True,True,False,,,People like you - Voting BNP,,10/02/2016 16:33:56,31/12
+PP3960,British National Party,Political Party,Registered,Great Britain,,,,,10/02/2016,True,True,True,False,,,British National Party - Plaid Genedlaethol Brydeinig,,10/02/2016 16:33:56,31/12
+PP3938,British Resistance,Political Party,Registered,Great Britain,,,,,14/03/2016,True,False,False,False,,,,,,31/12
+PP2834,British Unionist Party - B.U.P.,Political Party,Registered,Great Britain,,,,,21/08/2015,True,True,True,False,,,,,,31/12
+PP9076,Bucks Residents Association,Political Party,Registered,Great Britain,,,,,25/03/2019,True,False,False,False,,,,,,31/12
+PPm12774,Bucks Together,Minor Party,Registered,,,,,,24/03/2021,True,False,False,True,,,,,,
+PP6725,Burnley and Padiham independent Party,Political Party,Registered,Great Britain,,,,,26/02/2018,True,False,False,False,,,,,,31/12
+PP6735,Campaign Against Pedestrianisation of Oxford Street,Political Party,Registered,Great Britain,,,,,05/03/2018,True,False,False,False,,,,,,31/12
+PPm12696,Canvey First,Minor Party,Registered,,,,,,09/02/2021,True,False,False,True,,,,,,
+PP381,Canvey Island Independent Party,Political Party,Registered,Great Britain,,,,,22/04/2004,True,False,False,False,,,,,,31/12
+PP478,Centreground Party,Political Party,Registered,Great Britain,,,,,12/04/2005,True,True,True,False,,,,,,31/12
+PP10322,Charford Residents' Association,Political Party,Registered,Great Britain,,,,,21/01/2020,True,False,False,False,,,,,,31/12
+PP12557,Chase Community Independents Group,Political Party,Registered,Great Britain,,,,,02/09/2020,True,False,False,False,,,Chase Community Independents Group: Hednesford First,,08/02/2021 12:03:23,31/12
+PP12557,Chase Community Independents Group,Political Party,Registered,Great Britain,,,,,02/09/2020,True,False,False,False,,,Chase Community Independents Group: Rugeley First,,08/02/2021 12:03:23,31/12
+PP12557,Chase Community Independents Group,Political Party,Registered,Great Britain,,,,,02/09/2020,True,False,False,False,,,Chase Community Independents Group: Staffordshire First,,08/02/2021 12:03:23,31/12
+PP12557,Chase Community Independents Group,Political Party,Registered,Great Britain,,,,,02/09/2020,True,False,False,False,,,Chase Community Independents Group: Cannock Together,,08/02/2021 12:03:23,31/12
+PP12557,Chase Community Independents Group,Political Party,Registered,Great Britain,,,,,02/09/2020,True,False,False,False,,,Chase Community Independents Group: Hednesford Together,,08/02/2021 12:03:23,31/12
+PP12557,Chase Community Independents Group,Political Party,Registered,Great Britain,,,,,02/09/2020,True,False,False,False,,,Chase Community Independents Group: Rugeley Together,,08/02/2021 12:03:23,31/12
+PP12557,Chase Community Independents Group,Political Party,Registered,Great Britain,,,,,02/09/2020,True,False,False,False,,,Chase Community Independents Group: Staffordshire Together,,08/02/2021 12:03:23,31/12
+PP12557,Chase Community Independents Group,Political Party,Registered,Great Britain,,,,,02/09/2020,True,False,False,False,,,Chase Community Independents People Before Politics,,08/02/2021 12:03:23,31/12
+PP12557,Chase Community Independents Group,Political Party,Registered,Great Britain,,,,,02/09/2020,True,False,False,False,,,Chase Community Independents Councillor,,08/02/2021 12:03:23,31/12
+PP12557,Chase Community Independents Group,Political Party,Registered,Great Britain,,,,,02/09/2020,True,False,False,False,,,Chase Community Independents Group: Cannock First,,08/02/2021 12:03:23,31/12
+PP2883,Chesterfield And North Derbyshire Independents (CANDI),Political Party,Registered,Great Britain,,,,,18/02/2016,True,False,False,False,,,Chesterfield Independents,,18/02/2016 16:05:45,31/12
+PP12681,Chichester and Harbour Independents,Political Party,Registered,Great Britain,,,,,10/03/2021,True,False,False,False,,,,,,31/12
+PP12591,Christchurch Independents,Political Party,Registered,Great Britain,,,,,08/02/2021,True,False,False,False,,,The Christchurch Independents Party,,08/02/2021 17:00:35,31/12
+PP2302,Christian Democratic Party,Political Party,Registered,Great Britain,,,,,03/04/2014,True,True,True,False,,,,,,31/12
+PP2893,"Christian Party ""Proclaiming Christ's Lordship""",Political Party,Registered,Great Britain,,,,,15/12/2015,True,True,True,False,,,The Christian Party,,15/12/2015 15:27:33,31/12
+PP2893,"Christian Party ""Proclaiming Christ's Lordship""",Political Party,Registered,Great Britain,,,,,15/12/2015,True,True,True,False,,,"English Christian Party ""Proclaiming Christ's Lordship""",,15/12/2015 15:27:33,31/12
+PP2893,"Christian Party ""Proclaiming Christ's Lordship""",Political Party,Registered,Great Britain,,,,,15/12/2015,True,True,True,False,,,Scottish Christian Party,,15/12/2015 15:27:33,31/12
+PP2893,"Christian Party ""Proclaiming Christ's Lordship""",Political Party,Registered,Great Britain,,,,,15/12/2015,True,True,True,False,,,"Scottish Christian Party ""Proclaiming Christ's Lordship""",,15/12/2015 15:27:33,31/12
+PP2893,"Christian Party ""Proclaiming Christ's Lordship""",Political Party,Registered,Great Britain,,,,,15/12/2015,True,True,True,False,,,Welsh Christian Party,Plaid Gristnogol Cymru,15/12/2015 15:27:33,31/12
+PP2893,"Christian Party ""Proclaiming Christ's Lordship""",Political Party,Registered,Great Britain,,,,,15/12/2015,True,True,True,False,,,"Welsh Christian Party ""Proclaiming Christ's Lordship""","Plaid Gristnogol Cymru ""Datgan Arglwyddiaeth Crist""",15/12/2015 15:27:33,31/12
+PP79,Christian Peoples Alliance,Political Party,Registered,Great Britain,,,,,24/03/1999,True,True,True,False,,,Cynghrair Pobl Gristnogol,,02/02/2001 00:00:00,31/12
+PP79,Christian Peoples Alliance,Political Party,Registered,Great Britain,,,,,24/03/1999,True,True,True,False,,,Christian Peoples Alliance - Cynghrair Pobl Gristnogol,,02/02/2001 00:00:00,31/12
+PP79,Christian Peoples Alliance,Political Party,Registered,Great Britain,,,,,24/03/1999,True,True,True,False,,,Christian Peoples Alliance - Supporting Traditional Marriage,,21/03/2012 17:35:39,31/12
+PP843,Church of the Militant Elvis,Political Party,Registered,Great Britain,,,,,17/03/2010,True,False,False,False,,,Militant Elvis Anti-Tesco Popular Front,,17/03/2010 00:00:00,31/12
+PP843,Church of the Militant Elvis,Political Party,Registered,Great Britain,,,,,17/03/2010,True,False,False,False,,,Militant Elvis Anti HS2,,09/05/2013 09:34:25,31/12
+PP843,Church of the Militant Elvis,Political Party,Registered,Great Britain,,,,,17/03/2010,True,False,False,False,,,Militant Bus-Pass Elvis Party,,17/05/2021 12:25:19,31/12
+PP843,Church of the Militant Elvis,Political Party,Registered,Great Britain,,,,,17/03/2010,True,False,False,False,,,Militant Elvis and the Yeti Party,,17/05/2021 12:25:19,31/12
+PP6337,Citizens Action Party,Political Party,Registered,Great Britain,,,,,25/04/2017,True,True,True,False,,,Merseyside Citizens Action,,25/04/2017 10:34:37,31/12
+PP6337,Citizens Action Party,Political Party,Registered,Great Britain,,,,,25/04/2017,True,True,True,False,,,Cheshire Citizens Action,,25/04/2017 10:34:37,31/12
+PP6337,Citizens Action Party,Political Party,Registered,Great Britain,,,,,25/04/2017,True,True,True,False,,,Wigan Citizens Action,,25/04/2017 10:34:37,31/12
+PP6337,Citizens Action Party,Political Party,Registered,Great Britain,,,,,25/04/2017,True,True,True,False,,,Leigh Citizens Action,,25/04/2017 10:34:37,31/12
+PP6337,Citizens Action Party,Political Party,Registered,Great Britain,,,,,25/04/2017,True,True,True,False,,,Golborne and Lowton Citizens Action,,25/04/2017 10:34:37,31/12
+PP6337,Citizens Action Party,Political Party,Registered,Great Britain,,,,,25/04/2017,True,True,True,False,,,Ashton and Bryn Citizens Action,,25/04/2017 10:34:37,31/12
+PP6337,Citizens Action Party,Political Party,Registered,Great Britain,,,,,25/04/2017,True,True,True,False,,,Winstanley Citizens Action,,25/04/2017 10:34:37,31/12
+PP6337,Citizens Action Party,Political Party,Registered,Great Britain,,,,,25/04/2017,True,True,True,False,,,Hindley Citizens Action,,25/04/2017 10:34:37,31/12
+PP6337,Citizens Action Party,Political Party,Registered,Great Britain,,,,,25/04/2017,True,True,True,False,,,Atherton and Tyldesley Citizens Action,,25/04/2017 10:34:37,31/12
+PP6337,Citizens Action Party,Political Party,Registered,Great Britain,,,,,25/04/2017,True,True,True,False,,,Stockport Citizens Action,,25/04/2017 10:34:37,31/12
+PP1891,Citizens First,Political Party,Registered,Great Britain,,,,,22/03/2012,False,True,False,False,,,,,,31/12
+PP396,City Independents,Political Party,Registered,Great Britain,,,,,16/06/2004,True,False,False,False,,,,,,31/12
+PP119,Co-operative Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Labour and Co-operative Party (Joint Description with Labour Party),Llafur a’r Blaid Gydweithredol,02/02/2001 00:00:00,31/12
+PP119,Co-operative Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,The Co-operative Party,,14/03/2011 11:04:19,31/12
+PP119,Co-operative Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Co-operative Party,,14/03/2011 11:04:19,31/12
+PP119,Co-operative Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,The Co-operative Party Candidate,,14/03/2011 11:04:19,31/12
+PP119,Co-operative Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Co-operative Party Candidate,,14/03/2011 11:04:19,31/12
+PP119,Co-operative Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,The Scottish Co-operative Party,,14/03/2011 11:04:19,31/12
+PP119,Co-operative Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Scottish Co-operative Party,,14/03/2011 11:04:19,31/12
+PP119,Co-operative Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Scottish Co-operative Party Candidate,,14/03/2011 11:04:19,31/12
+PP119,Co-operative Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,The Scottish Co-operative Party Candidate,,14/03/2011 11:04:19,31/12
+PP119,Co-operative Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Welsh Co-operative Party,,14/03/2011 11:04:19,31/12
+PP119,Co-operative Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,The Welsh Co-operative Party,,14/03/2011 11:04:19,31/12
+PP119,Co-operative Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Welsh Co-operative Party Candidate,,14/03/2011 11:04:19,31/12
+PP376,Common Good,Political Party,Registered,Northern Ireland,,,,,01/04/2004,False,False,False,False,,,,,,31/12
+PP375,Common Good,Political Party,Registered,Great Britain,,,,,01/04/2004,True,True,True,False,,,Common Good: Remain In The EU,,05/06/2018 14:00:40,31/12
+PP2730,Common Sense Party,Political Party,Registered,Great Britain,,,,,07/04/2015,True,True,True,False,,,,,,31/12
+PP78,Communist Party of Britain,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Communist Party of Great Britain,Plaid Gomiwnyddol Prydain Fawr,02/02/2001 00:00:00,31/12
+PP78,Communist Party of Britain,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Britain's Communist Party,Plaid Gomiwnyddol Prydain,02/02/2001 00:00:00,31/12
+PP78,Communist Party of Britain,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,The British Communist Party,Y Blaid Gomiwnyddol Brydeinig,02/02/2001 00:00:00,31/12
+PP844,Communities United Party,Political Party,Registered,Great Britain,,,,,17/03/2010,True,False,False,False,,,,,,31/12
+PP367,Community Campaign (Hart),Political Party,Registered,Great Britain,,,,,27/02/2004,True,True,True,False,,,,,,31/12
+PP751,Community First,Political Party,Registered,Great Britain,,,,,01/04/2009,True,False,False,False,,,Community First. Serving Only You,,01/04/2009 00:00:00,31/3
+PP51,Conservative and Unionist Party,Political Party,Registered,Northern Ireland,,,,,16/02/2001,False,False,False,False,,,Conservatives,,17/03/2014 15:13:36,31/12
+PP51,Conservative and Unionist Party,Political Party,Registered,Northern Ireland,,,,,16/02/2001,False,False,False,False,,,NI Conservatives,,17/03/2014 15:13:36,31/12
+PP51,Conservative and Unionist Party,Political Party,Registered,Northern Ireland,,,,,16/02/2001,False,False,False,False,,,Northern Ireland Conservatives,,17/03/2014 15:13:36,31/12
+PP52,Conservative and Unionist Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Scottish Conservative and Unionist,,02/02/2001 00:00:00,31/12
+PP52,Conservative and Unionist Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Ceidwadwyr Cymreig,Welsh Conservatives,02/02/2001 00:00:00,31/12
+PP52,Conservative and Unionist Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,The Conservative Party Candidate,,02/02/2001 00:00:00,31/12
+PP52,Conservative and Unionist Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Conservative Party Candidate,,02/02/2001 00:00:00,31/12
+PP52,Conservative and Unionist Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Welsh Conservative Party Candidate,Ymgeisydd Plaid Geidwadol Cymru,02/02/2001 00:00:00,31/12
+PP52,Conservative and Unionist Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,The Conservative and Unionist Party,,25/04/2017 11:30:21,31/12
+PP52,Conservative and Unionist Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Conservatives,,25/04/2017 11:30:21,31/12
+PP52,Conservative and Unionist Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Scottish Conservative Party Candidate,,25/04/2017 11:30:21,31/12
+PP52,Conservative and Unionist Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Local Conservatives,,04/02/2019 15:03:29,31/12
+PP52,Conservative and Unionist Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,"Conservative Candidate – More Police, Safer Streets",,24/03/2021 15:30:30,31/12
+PP8001,Core Independents,Political Party,Registered,Great Britain,,,,,14/10/2019,True,True,True,False,,,,,,31/12
+PP10238,Cornerstone,Political Party,Registered,Great Britain,,,,,07/11/2019,True,True,True,False,,,,,,31/12
+PP12685,Count Binface Party,Political Party,Registered,Great Britain,,,,,18/03/2021,True,False,False,False,,,Count Binface for Mayor of London,,18/03/2021 13:04:49,31/12
+PP9224,Coventry Citizens Party,Political Party,Registered,Great Britain,,,,,24/10/2019,True,False,False,False,,,,,,31/12
+PPm12673,Cranford Residents,Minor Party,Registered,,,,,,17/03/2021,True,False,False,True,,,,,,
+PP4037,Cross-Community Labour Alternative,Political Party,Registered,Northern Ireland,,,,,14/03/2016,False,False,False,False,,,,,,31/12
+PP7918,CumbriaFirst,Political Party,Registered,Great Britain,,,,,14/01/2019,True,True,True,False,,,Cumbria First,,14/01/2019 16:05:22,31/12
+PP7918,CumbriaFirst,Political Party,Registered,Great Britain,,,,,14/01/2019,True,True,True,False,,,PuttingCumbriaFirst,,14/01/2019 16:05:22,31/12
+PP7918,CumbriaFirst,Political Party,Registered,Great Britain,,,,,14/01/2019,True,True,True,False,,,Putting CumbriaFirst,,14/01/2019 16:05:22,31/12
+PP7918,CumbriaFirst,Political Party,Registered,Great Britain,,,,,14/01/2019,True,True,True,False,,,Putting Cumbria First,,14/01/2019 16:05:22,31/12
+PP70,Democratic Unionist Party - D.U.P.,Political Party,Registered,Northern Ireland,,,,,14/01/1999,False,False,False,False,,,,,,31/12
+PP6664,Democrats and Veterans Direct Democracy Party,Political Party,Registered,Northern Ireland,,,,,12/02/2018,False,False,False,False,,,,,,31/12
+PP147,Derwentside Independents,Political Party,Registered,Great Britain,,,,,18/04/2001,True,False,False,False,,,,,,31/12
+PP249,Devizes Guardians,Political Party,Registered,Great Britain,,,,,19/06/2002,True,False,False,False,,,,,,30/9
+PP667,Direct Democracy (Communist) Party,Political Party,Registered,Great Britain,,,,,06/06/2007,True,True,True,False,,,,,,31/12
+PP6335,Drug Law Reform Party,Political Party,Registered,Northern Ireland,,,,,01/02/2017,False,False,False,False,,,,,,31/12
+PP12,East Cleveland Independent,Political Party,Registered,Great Britain,,,,,25/02/1999,True,False,False,False,,,,,,31/12
+PP2684,East Devon Alliance,Political Party,Registered,Great Britain,,,,,12/03/2015,True,False,False,False,,,Independent East Devon Alliance,,12/03/2015 09:20:29,31/12
+PP2684,East Devon Alliance,Political Party,Registered,Great Britain,,,,,12/03/2015,True,False,False,False,,,East Devon Alliance of Independents,,12/03/2015 09:20:29,31/12
+PP2684,East Devon Alliance,Political Party,Registered,Great Britain,,,,,12/03/2015,True,False,False,False,,,East Devon Independent Alliance,,12/03/2015 09:20:29,31/12
+PP2684,East Devon Alliance,Political Party,Registered,Great Britain,,,,,12/03/2015,True,False,False,False,,,Alliance of East Devon Independents,,12/03/2015 09:20:29,31/12
+PP2684,East Devon Alliance,Political Party,Registered,Great Britain,,,,,12/03/2015,True,False,False,False,,,East Devon Alliance: Working for you,,12/03/2015 09:20:29,31/12
+PP646,East Lindsey Independent Group,Political Party,Registered,Great Britain,,,,,19/03/2007,True,False,False,False,,,,,,31/12
+PPm7983,Ecclesfield Parish Independent Councillors,Minor Party,Registered,,,,,,14/01/2019,True,False,False,True,,,Ecclesfield Parish Independent Councillors - Ecclesfield Ward,,14/01/2019 14:56:32,
+PPm7983,Ecclesfield Parish Independent Councillors,Minor Party,Registered,,,,,,14/01/2019,True,False,False,True,,,Ecclesfield Parish Independent Councillors - Grenoside Ward,,14/01/2019 14:56:32,
+PPm7983,Ecclesfield Parish Independent Councillors,Minor Party,Registered,,,,,,14/01/2019,True,False,False,True,,,Ecclesfield Parish Independent Councillors - Thorncliffe Ward,,14/01/2019 14:56:32,
+PPm7983,Ecclesfield Parish Independent Councillors,Minor Party,Registered,,,,,,14/01/2019,True,False,False,True,,,Ecclesfield Parish Independent Councillors - Burncross Ward,,14/01/2019 14:56:32,
+PPm7983,Ecclesfield Parish Independent Councillors,Minor Party,Registered,,,,,,14/01/2019,True,False,False,True,,,Ecclesfield Parish Independent Councillors - Chapeltown Ward,,14/01/2019 14:56:32,
+PP12564,Edlington and Warmsworth First,Political Party,Registered,Great Britain,,,,,15/12/2020,True,False,False,False,,,Edlington and Warmsworth Residents First,,15/12/2020 11:59:54,31/12
+PP675,Elm Park Residents' Association,Political Party,Registered,Great Britain,,,,,25/06/2007,True,False,False,False,,,,,,31/12
+PP17,English Democrats,Political Party,Registered,Great Britain,,,,,15/11/1999,True,False,True,False,,,"English Democrats - ""England's National Party!""",,02/02/2001 00:00:00,31/12
+PP17,English Democrats,Political Party,Registered,Great Britain,,,,,15/11/1999,True,False,True,False,,,"English Democrats - ""A Parliament for England!""",,02/02/2001 00:00:00,31/12
+PP17,English Democrats,Political Party,Registered,Great Britain,,,,,15/11/1999,True,False,True,False,,,"English Democrats - ""Putting England First!""",,02/02/2001 00:00:00,31/12
+PP17,English Democrats,Political Party,Registered,Great Britain,,,,,15/11/1999,True,False,True,False,,,"The English Democrats - ""Putting England First!""",,02/02/2001 00:00:00,31/12
+PP17,English Democrats,Political Party,Registered,Great Britain,,,,,15/11/1999,True,False,True,False,,,English Democrats - Letting Monmouthshire Decide,,22/03/2011 10:06:54,31/12
+PP17,English Democrats,Political Party,Registered,Great Britain,,,,,15/11/1999,True,False,True,False,,,English Democrats Love England - Leave EU!,,21/03/2012 16:06:05,31/12
+PP17,English Democrats,Political Party,Registered,Great Britain,,,,,15/11/1999,True,False,True,False,,,English Democrats - For an Independent England!,,26/02/2013 16:32:29,31/12
+PP17,English Democrats,Political Party,Registered,Great Britain,,,,,15/11/1999,True,False,True,False,,,English Democrats – “More Police – catching criminals!”,,21/11/2014 13:57:50,31/12
+PP17,English Democrats,Political Party,Registered,Great Britain,,,,,15/11/1999,True,False,True,False,,,"English Democrats - ""Protect Our Borders""",,30/03/2016 11:23:06,31/12
+PP17,English Democrats,Political Party,Registered,Great Britain,,,,,15/11/1999,True,False,True,False,,,"English Democrats - ""Stronger For England""",,30/03/2016 11:23:06,31/12
+PP17,English Democrats,Political Party,Registered,Great Britain,,,,,15/11/1999,True,False,True,False,,,"English Democrats - ""Believe In England""",,30/03/2016 11:23:06,31/12
+PP258,English National Party,Political Party,Registered,Great Britain,,,,,18/09/2002,True,True,True,False,,,,,,31/12
+PP195,English Parliamentary Party,Political Party,Registered,Great Britain,,,,,25/07/2001,True,False,False,False,,,,,,31/12
+PP59,Esher Residents Association,Political Party,Registered,Great Britain,,,,,28/02/2000,True,False,False,False,,,Esher and Molesey Residents' Associations (Joint Description with Molesey Residents Association),,02/02/2001 00:00:00,31/3
+PP12565,Essex Independence,Political Party,Registered,Great Britain,,,,,03/09/2020,True,False,False,False,,,Essex Independence Ltd,,03/09/2020 14:39:09,31/12
+PP12565,Essex Independence,Political Party,Registered,Great Britain,,,,,03/09/2020,True,False,False,False,,,The Essex Independence Party,,03/09/2020 14:39:09,31/12
+PP230,Ewell Court Residents' Association,Political Party,Registered,Great Britain,,,,,20/03/2002,True,False,False,False,,,,,,31/12
+PP10251,Failsworth Independent Party,Political Party,Registered,Great Britain,,,,,02/09/2019,True,False,False,False,,,Failsworth Independents,,02/09/2019 13:27:46,31/12
+PP2663,Farnham Residents,Political Party,Registered,Great Britain,,,,,01/04/2015,True,False,False,False,,,,,,31/12
+PP6572,Farnworth and Kearsley First Party,Political Party,Registered,Great Britain,,,,,13/09/2017,True,False,False,False,,,,,,31/12
+PP6384,Federalist Party of the United Kingdom,Political Party,Registered,Great Britain,,,,,27/03/2017,True,True,True,False,,,Federalist Party,,27/03/2017 11:20:43,31/12
+PP689,Fianna Fáil - The Republican Party,Political Party,Registered,Northern Ireland,,,,,10/12/2007,False,False,False,False,,,,,,31/12
+PP6662,Five Star Direct Democracy Party,Political Party,Registered,Great Britain,,,,,12/02/2018,True,True,True,False,,,,,,31/12
+PP2299,Formby Residents Action Group,Political Party,Registered,Great Britain,,,,,03/04/2014,True,False,False,False,,,,,,31/12
+PP9139,Forward,Political Party,Registered,Great Britain,,,,,02/05/2019,True,True,True,False,,,,,,31/12
+PP6742,Foundation Party,Political Party,Registered,Great Britain,,,,,29/03/2018,True,True,True,False,,,Foundation Party - We work for you,,06/03/2019 11:42:01,31/12
+PP6742,Foundation Party,Political Party,Registered,Great Britain,,,,,29/03/2018,True,True,True,False,,,"Foundation Party - Your Concerns, Our Priorities",,06/03/2019 11:42:01,31/12
+PP6742,Foundation Party,Political Party,Registered,Great Britain,,,,,29/03/2018,True,True,True,False,,,Foundation Party - Openness and common sense,,06/03/2019 11:42:01,31/12
+PP6742,Foundation Party,Political Party,Registered,Great Britain,,,,,29/03/2018,True,True,True,False,,,Foundation Party - Cleaning up politics,,06/03/2019 11:42:01,31/12
+PP6742,Foundation Party,Political Party,Registered,Great Britain,,,,,29/03/2018,True,True,True,False,,,Foundation Party - Holding politicians to account,,06/03/2019 11:42:01,31/12
+PP6742,Foundation Party,Political Party,Registered,Great Britain,,,,,29/03/2018,True,True,True,False,,,Foundation Party - Brexit Without Delay,,06/03/2019 11:42:01,31/12
+PP6742,Foundation Party,Political Party,Registered,Great Britain,,,,,29/03/2018,True,True,True,False,,,Foundation Party - No Brexit Betrayal,,06/03/2019 11:42:01,31/12
+PP6742,Foundation Party,Political Party,Registered,Great Britain,,,,,29/03/2018,True,True,True,False,,,Foundation Party - The Pro-Brexit Party,,06/03/2019 11:42:01,31/12
+PP12667,"Freedom Alliance- Integrity, Society, Economy",Political Party,Registered,Great Britain,,,,,16/03/2021,True,True,True,False,,,Freedom Alliance. Dignity and Democracy,,16/03/2021 10:35:03,31/12
+PP12667,"Freedom Alliance- Integrity, Society, Economy",Political Party,Registered,Great Britain,,,,,16/03/2021,True,True,True,False,,,Freedom Alliance. The Real Alternative,,16/03/2021 10:35:03,31/12
+PP12667,"Freedom Alliance- Integrity, Society, Economy",Political Party,Registered,Great Britain,,,,,16/03/2021,True,True,True,False,,,Freedom Alliance. Make Britain Free.,,16/03/2021 10:35:03,31/12
+PP12667,"Freedom Alliance- Integrity, Society, Economy",Political Party,Registered,Great Britain,,,,,16/03/2021,True,True,True,False,,,Freedom Alliance. Supporting Medical Freedom.,,16/03/2021 10:35:03,31/12
+PP12667,"Freedom Alliance- Integrity, Society, Economy",Political Party,Registered,Great Britain,,,,,16/03/2021,True,True,True,False,,,Freedom Alliance. No Lockdowns. No Curfews.,,16/03/2021 10:35:03,31/12
+PP12667,"Freedom Alliance- Integrity, Society, Economy",Political Party,Registered,Great Britain,,,,,16/03/2021,True,True,True,False,,,Freedom Alliance. Supporting Personal Freedom,,16/03/2021 10:35:03,31/12
+PP12667,"Freedom Alliance- Integrity, Society, Economy",Political Party,Registered,Great Britain,,,,,16/03/2021,True,True,True,False,,,Freedom Alliance. Independent Britain.,,16/03/2021 10:35:03,31/12
+PP12667,"Freedom Alliance- Integrity, Society, Economy",Political Party,Registered,Great Britain,,,,,16/03/2021,True,True,True,False,,,Freedom Alliance. Personal Liberty and Freedom,,16/03/2021 10:35:03,31/12
+PP12667,"Freedom Alliance- Integrity, Society, Economy",Political Party,Registered,Great Britain,,,,,16/03/2021,True,True,True,False,,,Freedom Alliance. Make Scotland Free,,16/03/2021 10:35:03,31/12
+PP12667,"Freedom Alliance- Integrity, Society, Economy",Political Party,Registered,Great Britain,,,,,16/03/2021,True,True,True,False,,,Freedom Alliance. People Matter,,16/03/2021 10:35:03,31/12
+PP12667,"Freedom Alliance- Integrity, Society, Economy",Political Party,Registered,Great Britain,,,,,16/03/2021,True,True,True,False,,,"Freedom Alliance. Liberty, Equality and Justice",,16/03/2021 10:35:03,31/12
+PP12667,"Freedom Alliance- Integrity, Society, Economy",Political Party,Registered,Great Britain,,,,,16/03/2021,True,True,True,False,,,Freedom Alliance. Scotland's Opposition to Lockdown,,16/03/2021 10:35:03,31/12
+PP3971,Freedom Party,Political Party,Registered,Great Britain,,,,,23/03/2016,True,True,True,False,,,Freedom Party Candidate,,23/03/2016 16:28:49,31/12
+PP3971,Freedom Party,Political Party,Registered,Great Britain,,,,,23/03/2016,True,True,True,False,,,UK Freedom Party,,23/03/2016 16:28:49,31/12
+PPm6907,Future Shepton,Minor Party,Registered,,,,,,22/10/2018,True,False,False,True,,,Future Shepton - Working together for Shepton,,10/12/2018 09:29:32,
+PPm6907,Future Shepton,Minor Party,Registered,,,,,,22/10/2018,True,False,False,True,,,A fresh approach with Future Shepton,,10/12/2018 09:29:32,
+PPm6907,Future Shepton,Minor Party,Registered,,,,,,22/10/2018,True,False,False,True,,,Future Shepton - a new approach,,10/12/2018 09:29:32,
+PPm6907,Future Shepton,Minor Party,Registered,,,,,,22/10/2018,True,False,False,True,,,Putting Shepton first with Future Shepton,,10/12/2018 09:29:32,
+PPm6907,Future Shepton,Minor Party,Registered,,,,,,22/10/2018,True,False,False,True,,,Future Shepton - Putting Shepton First,,10/12/2018 09:29:32,
+PPm6907,Future Shepton,Minor Party,Registered,,,,,,22/10/2018,True,False,False,True,,,Future Shepton - better ways of working,,10/12/2018 09:29:32,
+PP6528,Garforth and Swillington Independents Party,Political Party,Registered,Great Britain,,,,,13/09/2017,True,False,False,False,,,,,,31/12
+PP609,Get Snouts Out The Trough,Political Party,Registered,Great Britain,,,,,11/12/2006,True,False,False,False,,,,,,31/12
+PP63,Green Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,False,True,False,,,Green Party first choice candidate,Ymgeisydd dewis cyntaf y Blaid Werdd,02/02/2001 00:00:00,31/12
+PP63,Green Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,False,True,False,,,Green Party second choice candidate,Ymgeisydd ail dewis y Blaid Werdd,02/02/2001 00:00:00,31/12
+PP63,Green Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,False,True,False,,,Green Party third choice candidate,Ymgeisydd trydydd dewis y Blaid Werdd,02/02/2001 00:00:00,31/12
+PP63,Green Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,False,True,False,,,Green Party lead candidate,Prif ymgeisydd y Blaid Werdd,02/02/2001 00:00:00,31/12
+PP63,Green Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,False,True,False,,,The Green Party,Plaid Werdd,02/02/2001 00:00:00,31/12
+PP63,Green Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,False,True,False,,,Green Party Stop Fracking Now,,02/02/2001 00:00:00,31/12
+PP63,Green Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,False,True,False,,,Green Party candidate,Ymgeisydd Plaid Werdd,02/02/2001 00:00:00,31/12
+PP63,Green Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,False,True,False,,,The Green Party candidate,Ymgeisydd y Blaid Werdd,02/02/2001 00:00:00,31/12
+PP63,Green Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,False,True,False,,,Wales Green Party,Plaid Werdd Cymru,18/03/2015 16:43:14,31/12
+PP63,Green Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,False,True,False,,,Green Party Councillor,Cynghorydd Plaid Werdd,02/03/2018 12:41:24,31/12
+PP63,Green Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,False,True,False,,,Green Party - Save Our Green Space,Plaid Werdd – Achubwch Ein Mannau Gwyrdd,02/03/2018 12:41:24,31/12
+PP305,Green Party,Political Party,Registered,Northern Ireland,,,,,10/04/2003,False,False,False,False,,,Green Party,Pairti Glas,10/04/2003 00:00:00,31/12
+PP305,Green Party,Political Party,Registered,Northern Ireland,,,,,10/04/2003,False,False,False,False,,,The Green Party in N.I.,An Pairti Glas I dT.E.,10/04/2003 00:00:00,31/12
+PP305,Green Party,Political Party,Registered,Northern Ireland,,,,,10/04/2003,False,False,False,False,,,Green Party - Comhaontas Glas,,04/02/2019 09:28:35,31/12
+PP305,Green Party,Political Party,Registered,Northern Ireland,,,,,10/04/2003,False,False,False,False,,,Green Party Northern Ireland,,04/02/2019 09:28:35,31/12
+PP305,Green Party,Political Party,Registered,Northern Ireland,,,,,10/04/2003,False,False,False,False,,,Comhontas Glas / The Green Party,,04/02/2019 09:28:35,31/12
+PP2535,Guildford Greenbelt Group,Political Party,Registered,Great Britain,,,,,07/11/2014,True,False,False,False,,,,,,31/12
+PP6851,Gwlad,Political Party,Registered,Great Britain,,,,,18/02/2019,False,False,True,False,,,Gwlad – Plaid Diddymu San Steffan,Gwlad – The Abolish Westminster Party,24/03/2020 12:08:12,31/3
+PP6851,Gwlad,Political Party,Registered,Great Britain,,,,,18/02/2019,False,False,True,False,,,Gwlad – Plaid Annibyniaeth Cymru,Gwlad – The Welsh Independence Party,24/03/2020 12:08:12,31/3
+PP6851,Gwlad,Political Party,Registered,Great Britain,,,,,18/02/2019,False,False,True,False,,,Gwlad – Annibyniaeth i Gymru,Gwlad – Independence for Wales,24/03/2020 12:08:12,31/3
+PP6851,Gwlad,Political Party,Registered,Great Britain,,,,,18/02/2019,False,False,True,False,,,Gwlad – Yn Paratoi am Annibyniaeth,Gwlad – Preparing for Independence,24/03/2020 12:08:12,31/3
+PPm8029,Hadleigh Together,Minor Party,Registered,,,,,,18/02/2019,True,False,False,True,,,,,,
+PP251,Halstead Residents' Association,Political Party,Registered,Great Britain,,,,,10/07/2002,True,False,False,False,,,,,,31/12
+PP10327,Hampshire Independents,Political Party,Registered,Great Britain,,,,,25/02/2020,True,False,False,False,,,,,,31/12
+PP96,Handforth 'Ratepayers' Association (Independent),Political Party,Registered,Great Britain,,,,,02/03/2000,True,False,False,False,,,,,,31/12
+PP6415,Harlow Alliance Party,Political Party,Registered,Great Britain,,,,,22/08/2017,True,False,False,False,,,The Harlow Alliance Party,,22/08/2017 16:58:45,31/12
+PP6415,Harlow Alliance Party,Political Party,Registered,Great Britain,,,,,22/08/2017,True,False,False,False,,,Alliance Party of Harlow,,22/08/2017 16:58:45,31/12
+PP6415,Harlow Alliance Party,Political Party,Registered,Great Britain,,,,,22/08/2017,True,False,False,False,,,The Alliance Party of Harlow,,22/08/2017 16:58:45,31/12
+PP6415,Harlow Alliance Party,Political Party,Registered,Great Britain,,,,,22/08/2017,True,False,False,False,,,Harlow Alliance Party (People's Initiative),,22/08/2017 16:58:45,31/12
+PP6415,Harlow Alliance Party,Political Party,Registered,Great Britain,,,,,22/08/2017,True,False,False,False,,,Harlow Residents Alliance Party,,22/08/2017 16:58:45,31/12
+PP6415,Harlow Alliance Party,Political Party,Registered,Great Britain,,,,,22/08/2017,True,False,False,False,,,Harlow Action Alliance Party,,22/08/2017 16:58:45,31/12
+PP6415,Harlow Alliance Party,Political Party,Registered,Great Britain,,,,,22/08/2017,True,False,False,False,,,Alliance Party For Harlow,,22/08/2017 16:58:45,31/12
+PP6415,Harlow Alliance Party,Political Party,Registered,Great Britain,,,,,22/08/2017,True,False,False,False,,,The Alliance Party For Harlow,,22/08/2017 16:58:45,31/12
+PP6415,Harlow Alliance Party,Political Party,Registered,Great Britain,,,,,22/08/2017,True,False,False,False,,,Harlow Alliance Party People's Initiative (H.A.P.P.I.),,22/08/2017 16:58:45,31/12
+PP12732,Harmony Party UK,Political Party,Registered,Great Britain,,,,,17/03/2021,True,True,True,False,,,,,,31/12
+PP784,Harold Wood Hill Park Residents Association,Political Party,Registered,Great Britain,,,,,09/11/2009,True,False,False,False,,,Independent Harold Hill Residents Association Gooshays,,22/05/2019 15:34:56,31/12
+PP784,Harold Wood Hill Park Residents Association,Political Party,Registered,Great Britain,,,,,09/11/2009,True,False,False,False,,,Independent Harold Hill Residents Association Heaton,,22/05/2019 15:34:56,31/12
+PP784,Harold Wood Hill Park Residents Association,Political Party,Registered,Great Britain,,,,,09/11/2009,True,False,False,False,,,Independent Harold Wood Residents Association,,22/05/2019 15:34:56,31/12
+PP12668,Hatfield DN7 First,Political Party,Registered,Great Britain,,,,,04/05/2021,True,False,False,False,,,Hatfield First Bringing DN7 Community Together,,04/05/2021 17:43:26,31/12
+PP38,Havering Residents Association,Political Party,Registered,Great Britain,,,,,16/03/2000,True,False,False,False,,,Havering Residents Association Emerson Park Ward,,01/04/2014 17:34:47,30/6
+PP38,Havering Residents Association,Political Party,Registered,Great Britain,,,,,16/03/2000,True,False,False,False,,,Havering Residents Association Romford Town Ward,,01/04/2014 17:34:47,30/6
+PP38,Havering Residents Association,Political Party,Registered,Great Britain,,,,,16/03/2000,True,False,False,False,,,Havering Residents Association Rainham Ward,,01/04/2014 17:34:47,30/6
+PP38,Havering Residents Association,Political Party,Registered,Great Britain,,,,,16/03/2000,True,False,False,False,,,Havering Residents Association Brooklands Ward,,01/04/2014 17:34:47,30/6
+PP38,Havering Residents Association,Political Party,Registered,Great Britain,,,,,16/03/2000,True,False,False,False,,,Havering Residents Association Squirrels Heath Ward,,01/04/2014 17:34:47,30/6
+PP38,Havering Residents Association,Political Party,Registered,Great Britain,,,,,16/03/2000,True,False,False,False,,,"Havering Residents Association Mawney, Havering Park",,01/04/2014 17:34:47,30/6
+PP38,Havering Residents Association,Political Party,Registered,Great Britain,,,,,16/03/2000,True,False,False,False,,,Havering Residents Association Heaton and Gooshays,,01/04/2014 17:34:47,30/6
+PP6453,Heavy Woollen District Independents,Political Party,Registered,Great Britain,,,,,13/09/2017,True,False,False,False,,,Dewsbury Borough Independents — Heavy Woollen District,,14/09/2017 10:20:56,31/12
+PP6453,Heavy Woollen District Independents,Political Party,Registered,Great Britain,,,,,13/09/2017,True,False,False,False,,,Batley Borough Independents — Heavy Woollen District,,14/09/2017 10:20:56,31/12
+PP6453,Heavy Woollen District Independents,Political Party,Registered,Great Britain,,,,,13/09/2017,True,False,False,False,,,Spen Valley Independents — Heavy Woollen District,,14/09/2017 10:20:56,31/12
+PP6453,Heavy Woollen District Independents,Political Party,Registered,Great Britain,,,,,13/09/2017,True,False,False,False,,,Mirfield Independents — Heavy Woollen District,,14/09/2017 10:20:56,31/12
+PP6453,Heavy Woollen District Independents,Political Party,Registered,Great Britain,,,,,13/09/2017,True,False,False,False,,,Cleckheaton Independents — Heavy Woollen District,,14/09/2017 10:20:56,31/12
+PP6453,Heavy Woollen District Independents,Political Party,Registered,Great Britain,,,,,13/09/2017,True,False,False,False,,,Liversedge and Gomersal Independents (Heavy Woollen),,14/09/2017 10:20:56,31/12
+PP6453,Heavy Woollen District Independents,Political Party,Registered,Great Britain,,,,,13/09/2017,True,False,False,False,,,Birstall and Birkenshaw Independents (Heavy Woollen),,14/09/2017 10:20:56,31/12
+PP6453,Heavy Woollen District Independents,Political Party,Registered,Great Britain,,,,,13/09/2017,True,False,False,False,,,Heavy Woollen Independents — your local choice,,14/09/2017 10:20:56,31/12
+PP6453,Heavy Woollen District Independents,Political Party,Registered,Great Britain,,,,,13/09/2017,True,False,False,False,,,The Local Heavy Woollen Independents,,14/09/2017 10:20:56,31/12
+PP6453,Heavy Woollen District Independents,Political Party,Registered,Great Britain,,,,,13/09/2017,True,False,False,False,,,Local Heavy Woollen Independent for MP,,14/09/2017 10:20:56,31/12
+PP6453,Heavy Woollen District Independents,Political Party,Registered,Great Britain,,,,,13/09/2017,True,False,False,False,,,Heckmondwike and Norristhorpe Independents (Heavy Woollen),,02/10/2017 12:00:24,31/12
+PP6453,Heavy Woollen District Independents,Political Party,Registered,Great Britain,,,,,13/09/2017,True,False,False,False,,,Batley and Spen — Heavy Woollen Independents,,07/05/2020 12:28:55,31/12
+PP199,Henley Residents Group,Political Party,Registered,Great Britain,,,,,05/09/2001,True,False,False,False,,,,,,31/3
+PP12550,Heritage Party,Political Party,Registered,Great Britain,,,,,21/10/2020,True,True,True,False,,,Heritage Party - Make London Great Again,,21/10/2020 11:00:50,31/12
+PP12550,Heritage Party,Political Party,Registered,Great Britain,,,,,21/10/2020,True,True,True,False,,,Heritage Party - Make London Safe Again,,21/10/2020 11:00:50,31/12
+PP12550,Heritage Party,Political Party,Registered,Great Britain,,,,,21/10/2020,True,True,True,False,,,Heritage Party - Traditional Family Values,,21/10/2020 11:00:50,31/12
+PP12550,Heritage Party,Political Party,Registered,Great Britain,,,,,21/10/2020,True,True,True,False,,,Heritage Party - Social Conservatism,,21/10/2020 11:00:50,31/12
+PP12550,Heritage Party,Political Party,Registered,Great Britain,,,,,21/10/2020,True,True,True,False,,,Heritage Party - Keep Our Countryside Green,,21/10/2020 11:00:50,31/12
+PP12550,Heritage Party,Political Party,Registered,Great Britain,,,,,21/10/2020,True,True,True,False,,,Heritage Party - End Mass Immigration,,21/10/2020 11:00:50,31/12
+PP12550,Heritage Party,Political Party,Registered,Great Britain,,,,,21/10/2020,True,True,True,False,,,Heritage Party - Make Britain Safe Again,,21/10/2020 11:00:50,31/12
+PP12550,Heritage Party,Political Party,Registered,Great Britain,,,,,21/10/2020,True,True,True,False,,,Heritage Party - Free Speech and Liberty,,21/10/2020 11:00:50,31/12
+PP12550,Heritage Party,Political Party,Registered,Great Britain,,,,,21/10/2020,True,True,True,False,,,Heritage Party - Scrap HS2,,21/10/2020 11:00:50,31/12
+PP12550,Heritage Party,Political Party,Registered,Great Britain,,,,,21/10/2020,True,True,True,False,,,Heritage Party - Make Britain Great Again,,22/02/2021 15:17:10,31/12
+PP1874,Hersham Village Society,Political Party,Registered,Great Britain,,,,,21/02/2012,True,False,False,False,,,,,,31/12
+PP308,Hextable Independent,Political Party,Registered,Great Britain,,,,,20/03/2003,True,False,False,False,,,,,,31/12
+PP15,Hinchley Wood Residents Association,Political Party,Registered,Great Britain,,,,,17/02/2000,True,False,False,False,,,Hinchley Wood / Weston Green Residents' Associations (Joint description withThames Ditton / Weston Green Residents’ Association),,23/03/2016 17:49:37,31/12
+PP6638,Holland On Sea & Eastcliff Matters,Political Party,Registered,Great Britain,,,,,31/10/2017,True,False,False,False,,,Holland On Sea & Eastcliff Residents,,14/04/2020 12:01:53,31/12
+PP6638,Holland On Sea & Eastcliff Matters,Political Party,Registered,Great Britain,,,,,31/10/2017,True,False,False,False,,,Holland On Sea Residents,,14/04/2020 12:01:53,31/12
+PP12585,Hornchurch and Upminster Independents,Political Party,Registered,Great Britain,,,,,14/12/2020,True,False,False,False,,,Hornchurch and Upminster Independents Cranham,,14/12/2020 12:21:30,31/12
+PP12585,Hornchurch and Upminster Independents,Political Party,Registered,Great Britain,,,,,14/12/2020,True,False,False,False,,,Hornchurch and Upminster Independents Elm Park,,14/12/2020 12:21:30,31/12
+PP12585,Hornchurch and Upminster Independents,Political Party,Registered,Great Britain,,,,,14/12/2020,True,False,False,False,,,Hornchurch and Upminster Independents Hacton,,14/12/2020 12:21:30,31/12
+PP12585,Hornchurch and Upminster Independents,Political Party,Registered,Great Britain,,,,,14/12/2020,True,False,False,False,,,Hornchurch and Upminster Independents South Hornchurch,,14/12/2020 12:21:30,31/12
+PP12585,Hornchurch and Upminster Independents,Political Party,Registered,Great Britain,,,,,14/12/2020,True,False,False,False,,,Hornchurch and Upminster Independents St Andrew's,,14/12/2020 12:21:30,31/12
+PP12585,Hornchurch and Upminster Independents,Political Party,Registered,Great Britain,,,,,14/12/2020,True,False,False,False,,,Hornchurch and Upminster Independents Upminster,,14/12/2020 12:21:30,31/12
+PP12585,Hornchurch and Upminster Independents,Political Party,Registered,Great Britain,,,,,14/12/2020,True,False,False,False,,,Hornchurch and Upminster Independents Emerson Park,,14/12/2020 12:21:30,31/12
+PP12585,Hornchurch and Upminster Independents,Political Party,Registered,Great Britain,,,,,14/12/2020,True,False,False,False,,,Hornchurch and Upminster Independents St George's,,14/12/2020 12:21:30,31/12
+PP12585,Hornchurch and Upminster Independents,Political Party,Registered,Great Britain,,,,,14/12/2020,True,False,False,False,,,Hornchurch and Upminster Independents Beam Park,,14/12/2020 12:21:30,31/12
+PP207,Hornchurch Residents Association,Political Party,Registered,Great Britain,,,,,30/10/2001,True,False,False,False,,,Hornchurch Residents' Association Hacton Ward,,30/10/2001 00:00:00,31/12
+PP207,Hornchurch Residents Association,Political Party,Registered,Great Britain,,,,,30/10/2001,True,False,False,False,,,Hornchurch Residents' Association Hylands Ward,,30/10/2001 00:00:00,31/12
+PP207,Hornchurch Residents Association,Political Party,Registered,Great Britain,,,,,30/10/2001,True,False,False,False,,,Hornchurch Residents' Association St Andrews Ward,,30/10/2001 00:00:00,31/12
+PP8024,Horwich & Blackrod First Independents,Political Party,Registered,Great Britain,,,,,08/02/2019,True,False,False,False,,,Horwich First Independents,,08/02/2019 10:18:02,31/12
+PP8024,Horwich & Blackrod First Independents,Political Party,Registered,Great Britain,,,,,08/02/2019,True,False,False,False,,,Blackrod First Independents,,08/02/2019 10:18:02,31/12
+PP834,Humanity,Political Party,Registered,Great Britain,,,,,12/03/2010,True,True,True,False,,,,,,31/12
+PPm9047,Ideal Bradford,Minor Party,Registered,,,,,,15/04/2019,True,False,False,True,,,,,,
+PP11433,Independence for Scotland Party,Political Party,Registered,Great Britain,,,,,07/05/2020,False,True,False,False,,,,,,31/12
+PP6839,Independent Alliance (Kent),Political Party,Registered,Great Britain,,,,,26/07/2018,True,False,False,False,,,,,,31/12
+PPm11464,Independent Alliance – South Tyneside,Minor Party,Registered,,,,,,28/01/2020,True,False,False,True,,,,,,
+PP293,Independent Green Voice,Political Party,Registered,Great Britain,,,,,14/03/2003,True,True,True,False,,,Independent Green Voice - (Convenor: Alistair McConnachie),,14/03/2003 00:00:00,31/12
+PP293,Independent Green Voice,Political Party,Registered,Great Britain,,,,,14/03/2003,True,True,True,False,,,Independent Green Voice - Localism Not Globalism,,14/03/2003 00:00:00,31/12
+PP293,Independent Green Voice,Political Party,Registered,Great Britain,,,,,14/03/2003,True,True,True,False,,,"Independent Green Voice - Ecology, Solidarity, Democracy",,14/03/2003 00:00:00,31/12
+PP293,Independent Green Voice,Political Party,Registered,Great Britain,,,,,14/03/2003,True,True,True,False,,,"Independent Green Voice - Ecology, Localism, Democracy",,14/03/2003 00:00:00,31/12
+PP293,Independent Green Voice,Political Party,Registered,Great Britain,,,,,14/03/2003,True,True,True,False,,,"Independent Green Voice - Democracy, Localism, Nature",,14/03/2003 00:00:00,31/12
+PP293,Independent Green Voice,Political Party,Registered,Great Britain,,,,,14/03/2003,True,True,True,False,,,Independent Green Voice - Organic Green Scotland,,14/03/2003 00:00:00,31/12
+PP293,Independent Green Voice,Political Party,Registered,Great Britain,,,,,14/03/2003,True,True,True,False,,,Independent Green Voice - The Natural Alternative,,14/03/2003 00:00:00,31/12
+PP293,Independent Green Voice,Political Party,Registered,Great Britain,,,,,14/03/2003,True,True,True,False,,,"Independent Green Voice - Sustainability, Solidarity, Security",,14/03/2003 00:00:00,31/12
+PP293,Independent Green Voice,Political Party,Registered,Great Britain,,,,,14/03/2003,True,True,True,False,,,Independent Green Voice - For Monetary Reform,,14/03/2003 00:00:00,31/12
+PP293,Independent Green Voice,Political Party,Registered,Great Britain,,,,,14/03/2003,True,True,True,False,,,Independent Green Voice - For Democratic Money,,14/03/2003 00:00:00,31/12
+PP293,Independent Green Voice,Political Party,Registered,Great Britain,,,,,14/03/2003,True,True,True,False,,,Independent Green Voice - For Ethical Politics,,14/03/2003 00:00:00,31/12
+PP293,Independent Green Voice,Political Party,Registered,Great Britain,,,,,14/03/2003,True,True,True,False,,,"Independent Green Voice - Organic, Local, Democratic",,23/03/2021 13:50:12,31/12
+PP44,Independent Kidderminster Hospital and Health Concern,Political Party,Registered,Great Britain,,,,,27/01/2000,True,False,False,False,,,Independent Health Concern,,02/02/2001 00:00:00,31/12
+PP44,Independent Kidderminster Hospital and Health Concern,Political Party,Registered,Great Britain,,,,,27/01/2000,True,False,False,False,,,Health Concern,,02/02/2001 00:00:00,31/12
+PP128,Independent Loughton Residents Association,Political Party,Registered,Great Britain,,,,,15/03/2001,True,False,False,False,,,,,,31/12
+PP4072,Independent Network,Political Party,Registered,Northern Ireland,,,,,06/04/2016,False,False,False,False,,,Independent Network of Ireland,,06/04/2016 13:15:41,31/12
+PP1951,Independent Network,Political Party,Registered,Great Britain,,,,,05/12/2012,True,True,True,False,,,North East Independent Network,,06/04/2016 12:55:28,31/12
+PP1951,Independent Network,Political Party,Registered,Great Britain,,,,,05/12/2012,True,True,True,False,,,North West Independent Network,,06/04/2016 12:55:28,31/12
+PP1951,Independent Network,Political Party,Registered,Great Britain,,,,,05/12/2012,True,True,True,False,,,West Midlands Independent Network,,06/04/2016 12:55:28,31/12
+PP1951,Independent Network,Political Party,Registered,Great Britain,,,,,05/12/2012,True,True,True,False,,,East of England Independent Network,,06/04/2016 12:55:28,31/12
+PP1951,Independent Network,Political Party,Registered,Great Britain,,,,,05/12/2012,True,True,True,False,,,London Independent Network,,06/04/2016 12:55:28,31/12
+PP1951,Independent Network,Political Party,Registered,Great Britain,,,,,05/12/2012,True,True,True,False,,,South East Independent Network,,06/04/2016 12:55:28,31/12
+PP1951,Independent Network,Political Party,Registered,Great Britain,,,,,05/12/2012,True,True,True,False,,,South West Independent Network,,06/04/2016 12:55:28,31/12
+PP1951,Independent Network,Political Party,Registered,Great Britain,,,,,05/12/2012,True,True,True,False,,,Wales Independent Network,Rhwydwaith Annibynnol Cymru,06/04/2016 12:55:28,31/12
+PP1951,Independent Network,Political Party,Registered,Great Britain,,,,,05/12/2012,True,True,True,False,,,Scotland Independent Network,,06/04/2016 12:55:28,31/12
+PP1951,Independent Network,Political Party,Registered,Great Britain,,,,,05/12/2012,True,True,True,False,,,Island Independent Network,,30/10/2018 16:24:39,31/12
+PP1951,Independent Network,Political Party,Registered,Great Britain,,,,,05/12/2012,True,True,True,False,,,Independent Network (Buckinghamshire),,02/09/2019 12:13:42,31/12
+PP2575,Independent Sovereign Democratic Britain,Political Party,Registered,Great Britain,,,,,01/04/2015,True,True,True,False,,,,,,31/12
+PP7984,Independent Union,Political Party,Registered,Great Britain,,,,,18/02/2019,True,False,False,False,,,Hartlepool Independent Union,,03/02/2020 16:34:23,31/12
+PP7984,Independent Union,Political Party,Registered,Great Britain,,,,,18/02/2019,True,False,False,False,,,Independent Union - Hartlepool Independents,,03/02/2020 16:34:23,31/12
+PP7984,Independent Union,Political Party,Registered,Great Britain,,,,,18/02/2019,True,False,False,False,,,Independent Union - Putting Seaton First,,03/02/2020 16:34:23,31/12
+PP7984,Independent Union,Political Party,Registered,Great Britain,,,,,18/02/2019,True,False,False,False,,,Independent Union - Putting Hartlepool First,,03/02/2020 16:34:23,31/12
+PP7984,Independent Union,Political Party,Registered,Great Britain,,,,,18/02/2019,True,False,False,False,,,Independent Union - Hartlepool,,03/02/2020 16:34:23,31/12
+PP7984,Independent Union,Political Party,Registered,Great Britain,,,,,18/02/2019,True,False,False,False,,,Independent Union - Hartlepool First,,03/02/2020 16:34:23,31/12
+PP252,Independents @ Swansea,Political Party,Registered,Great Britain,,,,,21/06/2002,False,False,True,False,,,The official Independents@Swansea candidate,,21/06/2002 00:00:00,31/12
+PP252,Independents @ Swansea,Political Party,Registered,Great Britain,,,,,21/06/2002,False,False,True,False,,,The official Independents at Swansea candidate,,21/06/2002 00:00:00,31/12
+PP252,Independents @ Swansea,Political Party,Registered,Great Britain,,,,,21/06/2002,False,False,True,False,,,An official Independents@Swansea candidate,,21/06/2002 00:00:00,31/12
+PP252,Independents @ Swansea,Political Party,Registered,Great Britain,,,,,21/06/2002,False,False,True,False,,,An official Independents at Swansea candidate,,21/06/2002 00:00:00,31/12
+PP252,Independents @ Swansea,Political Party,Registered,Great Britain,,,,,21/06/2002,False,False,True,False,,,The Independents@Swansea official candidate,,21/06/2002 00:00:00,31/12
+PP252,Independents @ Swansea,Political Party,Registered,Great Britain,,,,,21/06/2002,False,False,True,False,,,The Independents at Swansea official candidate,,21/06/2002 00:00:00,31/12
+PP252,Independents @ Swansea,Political Party,Registered,Great Britain,,,,,21/06/2002,False,False,True,False,,,An Independents@Swansea official candidate,,21/06/2002 00:00:00,31/12
+PP252,Independents @ Swansea,Political Party,Registered,Great Britain,,,,,21/06/2002,False,False,True,False,,,An Independents at Swansea official candidate,,21/06/2002 00:00:00,31/12
+PPm6886,Independents for Frome,Minor Party,Registered,,,,,,09/11/2018,True,False,False,True,,,,,,
+PPm12648,Independents for Rame and Maker (INFORM),Minor Party,Registered,,,,,,08/01/2021,True,False,False,True,,,,,,
+PP11472,Ingleby Barwick Independent Society,Political Party,Registered,Great Britain,,,,,03/02/2020,True,False,False,False,,,,,,31/12
+PP2152,Interactive Democracy,Political Party,Registered,Great Britain,,,,,10/01/2014,True,True,True,False,,,Interactive Democracy – Distributed Ledger Technology,,30/09/2019 16:07:45,31/12
+PP2152,Interactive Democracy,Political Party,Registered,Great Britain,,,,,10/01/2014,True,True,True,False,,,Interactive Democracy - Blockchain,,30/09/2019 16:07:45,31/12
+PP2152,Interactive Democracy,Political Party,Registered,Great Britain,,,,,10/01/2014,True,True,True,False,,,Interactive Democracy – Consensus Multiperson Decision Making,,30/09/2019 16:07:45,31/12
+PP2152,Interactive Democracy,Political Party,Registered,Great Britain,,,,,10/01/2014,True,True,True,False,,,Interactive Democracy – Behavioural Analytics,,30/09/2019 16:07:45,31/12
+PP2152,Interactive Democracy,Political Party,Registered,Great Britain,,,,,10/01/2014,True,True,True,False,,,Interactive Democracy - Decentralised,,30/09/2019 16:07:45,31/12
+PP2152,Interactive Democracy,Political Party,Registered,Great Britain,,,,,10/01/2014,True,True,True,False,,,Digital Interactive Democracy,,30/09/2019 16:07:45,31/12
+PP2152,Interactive Democracy,Political Party,Registered,Great Britain,,,,,10/01/2014,True,True,True,False,,,Interactive Democracy - Social Network,,23/03/2021 12:44:18,31/12
+PP2152,Interactive Democracy,Political Party,Registered,Great Britain,,,,,10/01/2014,True,True,True,False,,,Interactive Democracy - Real Time Decision Making,,23/03/2021 12:44:18,31/12
+PP2152,Interactive Democracy,Political Party,Registered,Great Britain,,,,,10/01/2014,True,True,True,False,,,Interactive Democracy - Crypto,,23/03/2021 12:44:18,31/12
+PP2152,Interactive Democracy,Political Party,Registered,Great Britain,,,,,10/01/2014,True,True,True,False,,,Interactive Democracy - Public Network,,23/03/2021 12:44:18,31/12
+PP2152,Interactive Democracy,Political Party,Registered,Great Britain,,,,,10/01/2014,True,True,True,False,,,Interactive Democracy - Cryptocurrency,,23/03/2021 12:44:18,31/12
+PP883,It's Our County (Herefordshire),Political Party,Registered,Great Britain,,,,,25/08/2010,True,False,False,False,,,It's Our County: Independent Organised Capable,,01/02/2019 14:29:44,31/12
+PP883,It's Our County (Herefordshire),Political Party,Registered,Great Britain,,,,,25/08/2010,True,False,False,False,,,It's Our County: Here for Herefordshire,,01/02/2019 14:29:44,31/12
+PP883,It's Our County (Herefordshire),Political Party,Registered,Great Britain,,,,,25/08/2010,True,False,False,False,,,It's Our County with Herefordshire Independents,,01/02/2019 14:29:44,31/12
+PP1888,iXDemocracy,Political Party,Registered,Great Britain,,,,,21/03/2012,True,True,True,False,,,,,,31/12
+PP340,Joint Communities,Political Party,Registered,Great Britain,,,,,01/07/2003,True,True,True,False,,,,,,31/12
+PP2034,Justice For Men & Boys,Political Party,Registered,Great Britain,,,,,21/02/2013,True,True,True,False,,,,,,31/12
+PP157,Justice Party,Political Party,Registered,Great Britain,,,,,26/04/2001,True,False,False,False,,,,,,31/12
+PP12717,Keep Equality Safe Party,Political Party,Registered,Great Britain,,,,,19/03/2021,True,False,False,False,,,,,,31/12
+PP6302,Kingston Independent Residents Group,Political Party,Registered,Great Britain,,,,,16/02/2017,True,False,False,False,,,Your Kingston Independent Residents Group candidate,,16/02/2017 11:17:44,31/12
+PP6302,Kingston Independent Residents Group,Political Party,Registered,Great Britain,,,,,16/02/2017,True,False,False,False,,,Kingston Independent Residents Group - Kingston Matters,,24/03/2021 17:32:27,31/12
+PP6302,Kingston Independent Residents Group,Political Party,Registered,Great Britain,,,,,16/02/2017,True,False,False,False,,,Kingston Independent Residents Group - Malden Matters,,24/03/2021 17:32:27,31/12
+PP6302,Kingston Independent Residents Group,Political Party,Registered,Great Britain,,,,,16/02/2017,True,False,False,False,,,Kingston Independent Residents Group - Surbiton Matters,,24/03/2021 17:32:27,31/12
+PP6302,Kingston Independent Residents Group,Political Party,Registered,Great Britain,,,,,16/02/2017,True,False,False,False,,,Chessington Matters - Kingston Independent Residents Group,,24/03/2021 17:32:27,31/12
+PP6302,Kingston Independent Residents Group,Political Party,Registered,Great Britain,,,,,16/02/2017,True,False,False,False,,,Kingston Independent Residents Group - Norbiton Matters,,24/03/2021 17:32:27,31/12
+PP6302,Kingston Independent Residents Group,Political Party,Registered,Great Britain,,,,,16/02/2017,True,False,False,False,,,Kingston Independent Residents Group - Tolworth Matters,,24/03/2021 17:32:27,31/12
+PP6302,Kingston Independent Residents Group,Political Party,Registered,Great Britain,,,,,16/02/2017,True,False,False,False,,,Kingston Independent Residents Group (KIRG),,24/03/2021 17:32:27,31/12
+PP6302,Kingston Independent Residents Group,Political Party,Registered,Great Britain,,,,,16/02/2017,True,False,False,False,,,Kingston Independent Residents Group - Berrylands Matters,,24/03/2021 17:32:27,31/12
+PP6302,Kingston Independent Residents Group,Political Party,Registered,Great Britain,,,,,16/02/2017,True,False,False,False,,,Kingston Independent Residents - No to Overdevelopment,,07/04/2021 12:25:02,31/12
+PP6302,Kingston Independent Residents Group,Political Party,Registered,Great Britain,,,,,16/02/2017,True,False,False,False,,,Kingston Independent Residents - Unlock Chessington's Potential,,07/04/2021 12:25:02,31/12
+PP53,Labour Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,The Labour Party Candidate,,02/02/2001 00:00:00,31/12
+PP53,Labour Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Labour Party Candidate,Ymgeisydd Plaid Lafur,02/02/2001 00:00:00,31/12
+PP53,Labour Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Scottish Labour Party Candidate,,02/02/2001 00:00:00,31/12
+PP53,Labour Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Labour Party Candidate,,02/02/2001 00:00:00,31/12
+PP53,Labour Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Scottish Labour Party,,02/02/2001 00:00:00,31/12
+PP53,Labour Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Labour and Co-operative Party (Joint Description with Co-operative Party),Llafur a’r Blaid Gydweithredol,02/02/2001 00:00:00,31/12
+PP53,Labour Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Welsh Labour,Llafur Cymru,16/03/2011 11:07:36,31/12
+PP53,Labour Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Welsh Labour Candidate,Ymgeisydd Llafur Cymru,16/03/2011 11:07:36,31/12
+PP53,Labour Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Welsh Labour Party Candidate,Ymgeisydd Plaid Llafur Cymru,16/03/2011 11:07:36,31/12
+PP53,Labour Party,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Glasgow Labour,,14/02/2012 17:09:34,31/12
+PPm12775,Leckhampton Green Land Action Group,Minor Party,Registered,,,,,,24/03/2021,True,False,False,True,,,,,,
+PP2045,Left Unity,Political Party,Registered,Great Britain,,,,,26/03/2013,True,True,True,False,,,Left Unity Party,,23/04/2013 15:41:10,31/12
+PP2045,Left Unity,Political Party,Registered,Great Britain,,,,,26/03/2013,True,True,True,False,,,Left Unity - Trade Unionists and Socialists (Joint Descriptions with Trade Unionist and Socialist Coalition),,23/02/2015 21:40:05,31/12
+PP7919,"Leigh, Atherton & Tyldesley Together",Political Party,Registered,Great Britain,,,,,16/11/2018,True,False,False,False,,,,,,31/12
+PP12768,Let London Live,Political Party,Registered,Great Britain,,,,,17/03/2021,True,False,False,False,,,,,,31/12
+PP789,Lewisham People Before Profit,Political Party,Registered,Great Britain,,,,,04/12/2009,True,False,False,False,,,,,,31/12
+PP90,Liberal Democrats,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Welsh Liberal Democrats - Democratiaid Rhyddfrydol Cymru,,02/02/2001 00:00:00,31/12
+PP90,Liberal Democrats,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Scottish Liberal Democrats,,02/02/2001 00:00:00,31/12
+PP90,Liberal Democrats,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Welsh Liberal Democrats,Democratiaid Rhyddfrydol Cymru,02/02/2001 00:00:00,31/12
+PP90,Liberal Democrats,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Liberal Democrat Focus Team,Tîm Ffocws y Democratiaid Rhyddfrydol,02/02/2001 00:00:00,31/12
+PP90,Liberal Democrats,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Scottish Liberal Democrat Focus Team,,02/02/2001 00:00:00,31/12
+PP90,Liberal Democrats,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Liberal Democrat,Democratiaid Rhyddfrydol,02/02/2001 00:00:00,31/12
+PP90,Liberal Democrats,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Focus Team,Tîm Ffocws,02/02/2001 00:00:00,31/12
+PP90,Liberal Democrats,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Welsh Liberal Democrats Focus team,Tîm Ffocws Democratiaid Rhyddfrydol Cymru,11/03/2015 00:16:54,31/12
+PP90,Liberal Democrats,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Scottish Liberal Democrats - Put Recovery First,,16/03/2021 16:19:17,31/12
+PP90,Liberal Democrats,Political Party,Registered,Great Britain,,,,,14/01/1999,True,True,True,False,,,Welsh Liberal Democrats – Put Recovery First,Democratiaid Rhyddfrydol Cymru - Adfywio yw'r flaenoriaeth,16/03/2021 16:19:17,31/12
+PP684,Libertarian Party,Political Party,Registered,Great Britain,,,,,21/11/2007,True,False,True,False,,,Libertarian Party UK,,21/11/2007 00:00:00,31/12
+PP685,Libertarian Party,Political Party,Registered,Northern Ireland,,,,,21/11/2007,False,False,False,False,,,Libertarian Party UK,,21/11/2007 00:00:00,31/12
+PP1986,Life,Political Party,Registered,Great Britain,,,,,05/03/2013,True,True,True,False,,,The Life Party,,05/03/2013 15:57:59,31/12
+PP1986,Life,Political Party,Registered,Great Britain,,,,,05/03/2013,True,True,True,False,,,UK Life,,05/03/2013 15:57:59,31/12
+PP1986,Life,Political Party,Registered,Great Britain,,,,,05/03/2013,True,True,True,False,,,The UK Life Party,,05/03/2013 15:57:59,31/12
+PP733,Lincolnshire Independents Lincolnshire First,Political Party,Registered,Great Britain,,,,,19/12/2008,True,False,False,False,,,Lincolnshire Independents,,19/12/2008 00:00:00,31/12
+PP733,Lincolnshire Independents Lincolnshire First,Political Party,Registered,Great Britain,,,,,19/12/2008,True,False,False,False,,,"Lincolnshire Independents, putting Lincolnshire People First",,19/12/2008 00:00:00,31/12
+PP733,Lincolnshire Independents Lincolnshire First,Political Party,Registered,Great Britain,,,,,19/12/2008,True,False,False,False,,,Lincolnshire Independents - Lincoln,,19/12/2008 00:00:00,31/12
+PP733,Lincolnshire Independents Lincolnshire First,Political Party,Registered,Great Britain,,,,,19/12/2008,True,False,False,False,,,Lincolnshire Independents - Giving Boston a Voice,,19/12/2008 00:00:00,31/12
+PP733,Lincolnshire Independents Lincolnshire First,Political Party,Registered,Great Britain,,,,,19/12/2008,True,False,False,False,,,Lincolnshire Independents - Sleaford,,19/12/2008 00:00:00,31/12
+PP733,Lincolnshire Independents Lincolnshire First,Political Party,Registered,Great Britain,,,,,19/12/2008,True,False,False,False,,,"Lincolnshire Independent, Lincolnshire First",,19/12/2008 00:00:00,31/12
+PP733,Lincolnshire Independents Lincolnshire First,Political Party,Registered,Great Britain,,,,,19/12/2008,True,False,False,False,,,Lincolnshire Independents - South Holland,,19/12/2008 00:00:00,31/12
+PP733,Lincolnshire Independents Lincolnshire First,Political Party,Registered,Great Britain,,,,,19/12/2008,True,False,False,False,,,Lincolnshire Independents - North Kesteven,,22/08/2014 17:44:57,31/12
+PP733,Lincolnshire Independents Lincolnshire First,Political Party,Registered,Great Britain,,,,,19/12/2008,True,False,False,False,,,Lincolnshire Independents - South Kesteven,,22/08/2014 17:44:57,31/12
+PP733,Lincolnshire Independents Lincolnshire First,Political Party,Registered,Great Britain,,,,,19/12/2008,True,False,False,False,,,Lincolnshire First Lincolnshire Independent,,23/03/2021 15:06:16,31/12
+PP4038,Link Party,Political Party,Registered,Great Britain,,,,,14/03/2016,True,True,True,False,,,,,,31/12
+PP702,Llais Gwynedd - The Voice of Gwynedd,Political Party,Registered,Great Britain,,,,,19/03/2008,False,False,True,False,,,,,,31/12
+PP6405,Llantwit First Independents,Political Party,Registered,Great Britain,,,,,20/03/2017,False,False,True,False,,,,,,31/12
+PP7960,Local Alliance,Political Party,Registered,Great Britain,,,,,05/02/2019,True,False,False,False,,,,,,31/12
+PPm12809,Local Independents for Tiverton,Minor Party,Registered,,,,,,25/05/2021,True,False,False,True,,,,,,
+PP9095,Londependence,Political Party,Registered,Great Britain,,,,,21/06/2019,True,False,False,False,,,The Londependence Party,,21/06/2019 10:58:02,31/12
+PP9095,Londependence,Political Party,Registered,Great Britain,,,,,21/06/2019,True,False,False,False,,,Londependence Party,,21/06/2019 10:58:02,31/12
+PP9095,Londependence,Political Party,Registered,Great Britain,,,,,21/06/2019,True,False,False,False,,,Londependence – for London Independence,,21/06/2019 10:58:02,31/12
+PP9095,Londependence,Political Party,Registered,Great Britain,,,,,21/06/2019,True,False,False,False,,,Londependence – the party for London,,21/06/2019 10:58:02,31/12
+PP9095,Londependence,Political Party,Registered,Great Britain,,,,,21/06/2019,True,False,False,False,,,Londependence – the London Independence Party,,21/06/2019 10:58:02,31/12
+PP12772,London Real Party,Political Party,Registered,Great Britain,,,,,16/03/2021,True,False,False,False,,,London Real Party – Transform London,,16/03/2021 17:21:49,31/12
+PP149,Lytham St Annes Independents,Political Party,Registered,Great Britain,,,,,18/04/2001,True,False,False,False,,,,,,30/9
+PP492,Mainstream,Political Party,Registered,Great Britain,,,,,14/04/2005,True,True,True,False,,,,,,31/12
+PP504,Mansfield Independents,Political Party,Registered,Great Britain,,,,,14/07/2005,True,False,False,False,,,Mansfield Independents Putting People before Politics,,07/08/2019 12:16:54,31/12
+PP504,Mansfield Independents,Political Party,Registered,Great Britain,,,,,14/07/2005,True,False,False,False,,,Mansfield Independents – The Community Champions,,07/08/2019 12:16:54,31/12
+PP504,Mansfield Independents,Political Party,Registered,Great Britain,,,,,14/07/2005,True,False,False,False,,,Mansfield Independents Putting Local People First,,07/08/2019 12:16:54,31/12
+PP504,Mansfield Independents,Political Party,Registered,Great Britain,,,,,14/07/2005,True,False,False,False,,,Mansfield Independents – keeping you informed,,07/08/2019 12:16:54,31/12
+PP504,Mansfield Independents,Political Party,Registered,Great Britain,,,,,14/07/2005,True,False,False,False,,,Think Local – Think Mansfield Independents,,07/08/2019 12:16:54,31/12
+PP504,Mansfield Independents,Political Party,Registered,Great Britain,,,,,14/07/2005,True,False,False,False,,,Mansfield Independents – putting local residents first,,07/08/2019 12:16:54,31/12
+PP504,Mansfield Independents,Political Party,Registered,Great Britain,,,,,14/07/2005,True,False,False,False,,,Mansfield Independents – Warsop Voice,,07/08/2019 12:16:54,31/12
+PP504,Mansfield Independents,Political Party,Registered,Great Britain,,,,,14/07/2005,True,False,False,False,,,Mansfield Independents – Mansfield Woodhouse Voice,,07/08/2019 12:16:54,31/12
+PP876,Matriarchal Party United Kingdom Great Britain,Political Party,Registered,Great Britain,,,,,15/04/2010,True,True,True,False,,,,,,31/12
+PP58,Mebyon Kernow - The Party for Cornwall,Political Party,Registered,Great Britain,,,,,25/02/1999,True,False,False,False,,,,,,31/3
+PP659,Mercian Party,Political Party,Registered,Great Britain,,,,,26/03/2007,True,False,False,False,,,,,,31/12
+PP202,Merton Park Ward Independent Residents,Political Party,Registered,Great Britain,,,,,04/10/2001,True,False,False,False,,,,,,31/12
+PP2287,Mexborough First,Political Party,Registered,Great Britain,,,,,17/03/2014,True,False,False,False,,,Put Mexborough First the Forgotten Town,,31/03/2015 19:01:54,31/12
+PP2287,Mexborough First,Political Party,Registered,Great Britain,,,,,17/03/2014,True,False,False,False,,,Always putting Mexborough First,,31/03/2015 19:01:54,31/12
+PP2287,Mexborough First,Political Party,Registered,Great Britain,,,,,17/03/2014,True,False,False,False,,,Mexborough First for The Forgotten Town,,31/03/2015 19:01:54,31/12
+PP6387,Money Free Party,Political Party,Registered,Great Britain,,,,,27/03/2017,True,True,True,False,,,Money Free Party intelligent resource management,,27/03/2017 11:33:42,31/12
+PP6387,Money Free Party,Political Party,Registered,Great Britain,,,,,27/03/2017,True,True,True,False,,,Money Free Party resources shared equitably,,27/03/2017 11:33:42,31/12
+PP6387,Money Free Party,Political Party,Registered,Great Britain,,,,,27/03/2017,True,True,True,False,,,Societal advancement with Money Free Party,,27/03/2017 11:33:42,31/12
+PP23,Morecambe Bay Independents,Political Party,Registered,Great Britain,,,,,24/03/1999,True,False,False,False,,,,,,31/12
+PP356,Morley Borough Independents,Political Party,Registered,Great Britain,,,,,07/01/2004,True,False,False,False,,,,,,31/12
+PP9162,Motherworld Party,Political Party,Registered,Great Britain,,,,,07/08/2019,True,True,True,False,,,,,,31/1
+PP481,Movement for Active Democracy (M.A.D.),Political Party,Registered,Great Britain,,,,,12/04/2005,True,True,True,False,,,Movement for Active Democracy,,25/03/2015 18:13:53,31/12
+PP6805,National Equality Party,Political Party,Registered,Great Britain,,,,,03/07/2018,True,True,True,False,,,,,,31/12
+PP1713,National Flood Prevention Party,Political Party,Registered,Great Britain,,,,,24/03/2011,True,False,False,False,,,,,,31/12
+PP2708,National Front,Political Party,Registered,Northern Ireland,,,,,07/04/2015,False,False,False,False,,,,,,31/12
+PP2707,National Front,Political Party,Registered,Great Britain,,,,,26/03/2015,True,True,True,False,,,,,,31/12
+PP1931,National Health Action Party,Political Party,Registered,Great Britain,,,,,11/07/2012,True,True,True,False,,,,,,31/12
+PP32,National Liberal Party - True Liberalism,Political Party,Registered,Great Britain,,,,,25/03/1999,True,True,True,False,,,National Liberal Party - Independence For Ulster,,02/02/2001 00:00:00,31/12
+PP32,National Liberal Party - True Liberalism,Political Party,Registered,Great Britain,,,,,25/03/1999,True,True,True,False,,,"National Liberal Party - Liberty, Independence, Democracy",,02/02/2001 00:00:00,31/12
+PP32,National Liberal Party - True Liberalism,Political Party,Registered,Great Britain,,,,,25/03/1999,True,True,True,False,,,"National Liberal Party - Land, People, Environment",,02/02/2001 00:00:00,31/12
+PP32,National Liberal Party - True Liberalism,Political Party,Registered,Great Britain,,,,,25/03/1999,True,True,True,False,,,National Liberal Party - The Radical Centre,,02/02/2001 00:00:00,31/12
+PP32,National Liberal Party - True Liberalism,Political Party,Registered,Great Britain,,,,,25/03/1999,True,True,True,False,,,National Liberal Party (Cuffley Courier Team),,02/02/2001 00:00:00,31/12
+PP32,National Liberal Party - True Liberalism,Political Party,Registered,Great Britain,,,,,25/03/1999,True,True,True,False,,,National Liberal Party (Harold Voice Team),,02/02/2001 00:00:00,31/12
+PP32,National Liberal Party - True Liberalism,Political Party,Registered,Great Britain,,,,,25/03/1999,True,True,True,False,,,National Liberal Party (Elm Park Voice),,02/02/2001 00:00:00,31/12
+PP32,National Liberal Party - True Liberalism,Political Party,Registered,Great Britain,,,,,25/03/1999,True,True,True,False,,,National Liberal Party (Local Voice Team),,02/02/2001 00:00:00,31/12
+PP32,National Liberal Party - True Liberalism,Political Party,Registered,Great Britain,,,,,25/03/1999,True,True,True,False,,,National Liberal Party - No To Overdevelopment,,02/02/2001 00:00:00,31/12
+PP32,National Liberal Party - True Liberalism,Political Party,Registered,Great Britain,,,,,25/03/1999,True,True,True,False,,,National Liberal Party - Self-determination for all!,,02/05/2013 16:34:07,31/12
+PP6791,Net Tax Payers Consent Party,Political Party,Registered,Great Britain,,,,,11/12/2018,True,True,True,False,,,,,,31/12
+PP2645,New Parliament Party,Political Party,Registered,Great Britain,,,,,23/02/2015,True,True,True,False,,,,,,31/12
+PP905,Newcastle Independents,Political Party,Registered,Great Britain,,,,,18/02/2011,True,False,False,False,,,Newcastle Independent Candidate,,21/06/2019 12:49:33,31/12
+PP905,Newcastle Independents,Political Party,Registered,Great Britain,,,,,18/02/2011,True,False,False,False,,,Newcastle Independent Community Candidate,,21/06/2019 12:49:33,31/12
+PP905,Newcastle Independents,Political Party,Registered,Great Britain,,,,,18/02/2011,True,False,False,False,,,Newcastle Independents - Putting Denton Westerhope First,,21/06/2019 12:49:33,31/12
+PP905,Newcastle Independents,Political Party,Registered,Great Britain,,,,,18/02/2011,True,False,False,False,,,Newcastle Independents - The Newcastle Party,,21/06/2019 12:49:33,31/12
+PP905,Newcastle Independents,Political Party,Registered,Great Britain,,,,,18/02/2011,True,False,False,False,,,Newcastle Independents - Putting Newcastle First,,21/06/2019 12:49:33,31/12
+PP905,Newcastle Independents,Political Party,Registered,Great Britain,,,,,18/02/2011,True,False,False,False,,,Newcastle Independents - Local Community Candidate,,21/06/2019 12:49:33,31/12
+PP905,Newcastle Independents,Political Party,Registered,Great Britain,,,,,18/02/2011,True,False,False,False,,,Newcastle Independents - People Before Politics Always,,21/06/2019 12:49:33,31/12
+PP905,Newcastle Independents,Political Party,Registered,Great Britain,,,,,18/02/2011,True,False,False,False,,,Newcastle Independents - Putting Lemington Ward First,,19/08/2019 16:37:50,31/12
+PP905,Newcastle Independents,Political Party,Registered,Great Britain,,,,,18/02/2011,True,False,False,False,,,Newcastle Independents - Putting Callerton Throckley First,,19/08/2019 16:37:50,31/12
+PP905,Newcastle Independents,Political Party,Registered,Great Britain,,,,,18/02/2011,True,False,False,False,,,Newcastle Independents - Putting Tyneside First,,19/08/2019 16:37:50,31/12
+PP905,Newcastle Independents,Political Party,Registered,Great Britain,,,,,18/02/2011,True,False,False,False,,,Newcastle Independents - Fix Our Broken Politics,,19/08/2019 16:37:50,31/12
+PP905,Newcastle Independents,Political Party,Registered,Great Britain,,,,,18/02/2011,True,False,False,False,,,Newcastle Independents - Always Putting Newcastle First,,19/08/2019 16:37:50,31/12
+PP867,Newclear Outline (NO),Political Party,Registered,Great Britain,,,,,13/04/2010,True,True,True,False,,,Newclear Outline small footprint Beautiful Horizons,,23/02/2015 21:27:30,31/12
+PP867,Newclear Outline (NO),Political Party,Registered,Great Britain,,,,,13/04/2010,True,True,True,False,,,Newclear Outline Beautiful Future,,23/02/2015 21:27:30,31/12
+PP867,Newclear Outline (NO),Political Party,Registered,Great Britain,,,,,13/04/2010,True,True,True,False,,,Newclear Outline Not Big Ugly Renewables,,23/02/2015 21:27:30,31/12
+PP867,Newclear Outline (NO),Political Party,Registered,Great Britain,,,,,13/04/2010,True,True,True,False,,,Newclear Outline Not Big Blade Ugly,,23/02/2015 21:27:30,31/12
+PP867,Newclear Outline (NO),Political Party,Registered,Great Britain,,,,,13/04/2010,True,True,True,False,,,Newclear Outline Not Vast Solar Ugly,,23/02/2015 21:27:30,31/12
+PP867,Newclear Outline (NO),Political Party,Registered,Great Britain,,,,,13/04/2010,True,True,True,False,,,Newclear Outline Not Establishment Supporting Renewables,,23/02/2015 21:27:30,31/12
+PP867,Newclear Outline (NO),Political Party,Registered,Great Britain,,,,,13/04/2010,True,True,True,False,,,Newclear Outline Not Grid Parasitic Renewables,,23/02/2015 21:27:30,31/12
+PP867,Newclear Outline (NO),Political Party,Registered,Great Britain,,,,,13/04/2010,True,True,True,False,,,Newclear Outline Not Luddite Renewables Decline,,23/02/2015 21:27:30,31/12
+PP867,Newclear Outline (NO),Political Party,Registered,Great Britain,,,,,13/04/2010,True,True,True,False,,,Newclear Outline Not Useless Renewables,,23/02/2015 21:27:30,31/12
+PP867,Newclear Outline (NO),Political Party,Registered,Great Britain,,,,,13/04/2010,True,True,True,False,,,Newclear Outline Expanding Horizons,,23/02/2015 21:27:30,31/12
+PP6367,Newport Independents Party,Political Party,Registered,Great Britain,,,,,16/03/2017,False,False,True,False,,,,,,31/12
+PP4048,No More Lockdowns,Political Party,Registered,Great Britain,,,,,24/03/2016,False,False,True,False,,,No More lockdowns For Wales,Dim Mwy O Gloi Lawr i Gymru,12/03/2021 11:18:03,31/12
+PP4048,No More Lockdowns,Political Party,Registered,Great Britain,,,,,24/03/2016,False,False,True,False,,,A Sovereign Wales In The World,Cymru Sofran Yn Y Byd,16/03/2021 14:51:49,31/12
+PP138,Nork Residents' Association,Political Party,Registered,Great Britain,,,,,29/03/2001,True,False,False,False,,,Nork & Tattenhams Residents' Associations (joint description with Tattenhams' Residents' Association),,17/04/2014 16:48:03,31/12
+PP756,Northampton - Save Our Public Services,Political Party,Registered,Great Britain,,,,,20/04/2009,True,False,False,False,,,Northampton -Save our Services,,20/04/2009 00:00:00,31/12
+PP6656,Northamptonshire Independents,Political Party,Registered,Great Britain,,,,,25/01/2018,True,False,False,False,,,Northamptonshire Independents working for Billing,,25/01/2018 14:52:57,31/12
+PP6656,Northamptonshire Independents,Political Party,Registered,Great Britain,,,,,25/01/2018,True,False,False,False,,,Northamptonshire Independents working for Brookside,,25/01/2018 14:52:57,31/12
+PP6656,Northamptonshire Independents,Political Party,Registered,Great Britain,,,,,25/01/2018,True,False,False,False,,,Northamptonshire Independents working for Eastfield,,25/01/2018 14:52:57,31/12
+PP6656,Northamptonshire Independents,Political Party,Registered,Great Britain,,,,,25/01/2018,True,False,False,False,,,Northamptonshire Independents working for Headlands,,25/01/2018 14:52:57,31/12
+PP6656,Northamptonshire Independents,Political Party,Registered,Great Britain,,,,,25/01/2018,True,False,False,False,,,Northamptonshire Independents working for Kingsley,,25/01/2018 14:52:57,31/12
+PP6656,Northamptonshire Independents,Political Party,Registered,Great Britain,,,,,25/01/2018,True,False,False,False,,,Northamptonshire Independents working for Nene Valley,,25/01/2018 14:52:57,31/12
+PP6656,Northamptonshire Independents,Political Party,Registered,Great Britain,,,,,25/01/2018,True,False,False,False,,,Northamptonshire Independents working for Phippsville,,25/01/2018 14:52:57,31/12
+PP6656,Northamptonshire Independents,Political Party,Registered,Great Britain,,,,,25/01/2018,True,False,False,False,,,Northamptonshire Independents working for Rectory farm,,25/01/2018 14:52:57,31/12
+PP6656,Northamptonshire Independents,Political Party,Registered,Great Britain,,,,,25/01/2018,True,False,False,False,,,Northamptonshire Independents working for Riverside,,25/01/2018 14:52:57,31/12
+PP6656,Northamptonshire Independents,Political Party,Registered,Great Britain,,,,,25/01/2018,True,False,False,False,,,Northamptonshire Independents working for Semilong,,25/01/2018 14:52:57,31/12
+PP6656,Northamptonshire Independents,Political Party,Registered,Great Britain,,,,,25/01/2018,True,False,False,False,,,Northamptonshire Independents working for Kingsthorpe North,,25/01/2018 14:52:57,31/12
+PP6656,Northamptonshire Independents,Political Party,Registered,Great Britain,,,,,25/01/2018,True,False,False,False,,,Northamptonshire Independents working for Spring Park,,25/01/2018 14:52:57,31/12
+PP12589,Northern Heart,Political Party,Registered,Great Britain,,,,,14/12/2020,True,True,True,False,,,Northern Heart (UK),,14/12/2020 15:47:25,31/12
+PP12589,Northern Heart,Political Party,Registered,Great Britain,,,,,14/12/2020,True,True,True,False,,,Northern Heart (UK) Oldham,,14/12/2020 15:47:25,31/12
+PP12589,Northern Heart,Political Party,Registered,Great Britain,,,,,14/12/2020,True,True,True,False,,,Northern Heart (UK) Trafford,,14/12/2020 15:47:25,31/12
+PP12589,Northern Heart,Political Party,Registered,Great Britain,,,,,14/12/2020,True,True,True,False,,,Northern Heart (UK) Stockport,,14/12/2020 15:47:25,31/12
+PP12589,Northern Heart,Political Party,Registered,Great Britain,,,,,14/12/2020,True,True,True,False,,,Northern Heart (UK) Tameside,,14/12/2020 15:47:25,31/12
+PP12589,Northern Heart,Political Party,Registered,Great Britain,,,,,14/12/2020,True,True,True,False,,,Northern Heart (UK) Bolton,,14/12/2020 15:47:25,31/12
+PP12589,Northern Heart,Political Party,Registered,Great Britain,,,,,14/12/2020,True,True,True,False,,,Northern Heart (UK) Bury,,14/12/2020 15:47:25,31/12
+PP12589,Northern Heart,Political Party,Registered,Great Britain,,,,,14/12/2020,True,True,True,False,,,Northern Heart (UK) Manchester,,14/12/2020 15:47:25,31/12
+PP12589,Northern Heart,Political Party,Registered,Great Britain,,,,,14/12/2020,True,True,True,False,,,Northern Heart (UK) Salford,,14/12/2020 15:47:25,31/12
+PP12589,Northern Heart,Political Party,Registered,Great Britain,,,,,14/12/2020,True,True,True,False,,,Northern Heart (UK) Wigan,,14/12/2020 15:47:25,31/12
+PP12589,Northern Heart,Political Party,Registered,Great Britain,,,,,14/12/2020,True,True,True,False,,,Northern Heart (UK) Rochdale,,14/12/2020 15:47:25,31/12
+PP4087,Northern Ireland Labour Representation Committee,Political Party,Registered,Northern Ireland,,,,,11/04/2016,False,False,False,False,,,,,,31/12
+PP6649,Nottingham Independents,Political Party,Registered,Great Britain,,,,,22/01/2018,True,False,False,False,,,Nottingham Independents Putting Clifton First,,22/01/2018 10:58:23,31/12
+PP6649,Nottingham Independents,Political Party,Registered,Great Britain,,,,,22/01/2018,True,False,False,False,,,Nottingham Independents Putting Bestwood First,,22/01/2018 10:58:23,31/12
+PP6649,Nottingham Independents,Political Party,Registered,Great Britain,,,,,22/01/2018,True,False,False,False,,,Nottingham Independents Putting Bulwell First,,22/01/2018 10:58:23,31/12
+PP6649,Nottingham Independents,Political Party,Registered,Great Britain,,,,,22/01/2018,True,False,False,False,,,Nottingham Independents Putting Aspley First,,22/01/2018 10:58:23,31/12
+PP6649,Nottingham Independents,Political Party,Registered,Great Britain,,,,,22/01/2018,True,False,False,False,,,Nottingham Independents Putting Local People First,,22/01/2018 10:58:23,31/12
+PP6649,Nottingham Independents,Political Party,Registered,Great Britain,,,,,22/01/2018,True,False,False,False,,,Nottingham Independents Putting People Before Politics,,22/01/2018 10:58:23,31/12
+PP6649,Nottingham Independents,Political Party,Registered,Great Britain,,,,,22/01/2018,True,False,False,False,,,Nottingham Independents Putting St Ann's First,,22/01/2018 10:58:23,31/12
+PP6649,Nottingham Independents,Political Party,Registered,Great Britain,,,,,22/01/2018,True,False,False,False,,,Nottingham Independents Putting Sherwood First,,22/01/2018 10:58:23,31/12
+PP6649,Nottingham Independents,Political Party,Registered,Great Britain,,,,,22/01/2018,True,False,False,False,,,Nottingham Independents Against Local Tax Rises,,22/01/2018 10:58:23,31/12
+PP6649,Nottingham Independents,Political Party,Registered,Great Britain,,,,,22/01/2018,True,False,False,False,,,Nottingham Independents Wilford Silverdale and Clifton,,29/01/2019 08:43:37,31/12
+PP6649,Nottingham Independents,Political Party,Registered,Great Britain,,,,,22/01/2018,True,False,False,False,,,Nottingham Independents for the Meadows,,29/01/2019 08:43:37,31/12
+PP6649,Nottingham Independents,Political Party,Registered,Great Britain,,,,,22/01/2018,True,False,False,False,,,Nottingham Independents for Gedling,,29/01/2019 08:43:37,31/12
+PP6848,Nova Forte,Political Party,Registered,Great Britain,,,,,23/10/2018,True,True,True,False,,,The Nova Forte Candidate,,23/10/2018 10:53:35,31/12
+PP6848,Nova Forte,Political Party,Registered,Great Britain,,,,,23/10/2018,True,True,True,False,,,Nova Forte Candidate,,23/10/2018 10:53:35,31/12
+PP6848,Nova Forte,Political Party,Registered,Great Britain,,,,,23/10/2018,True,True,True,False,,,Scottish Nova Forte Candidate,,23/10/2018 10:53:35,31/12
+PP6848,Nova Forte,Political Party,Registered,Great Britain,,,,,23/10/2018,True,True,True,False,,,Scottish Nova Forte,,23/10/2018 10:53:35,31/12
+PP6848,Nova Forte,Political Party,Registered,Great Britain,,,,,23/10/2018,True,True,True,False,,,Welsh Nova Forte Candidate,,23/10/2018 10:53:35,31/12
+PP6848,Nova Forte,Political Party,Registered,Great Britain,,,,,23/10/2018,True,True,True,False,,,Welsh Nova Forte,,23/10/2018 10:53:35,31/12
+PP6848,Nova Forte,Political Party,Registered,Great Britain,,,,,23/10/2018,True,True,True,False,,,English Nova Forte Candidate,,23/10/2018 10:53:35,31/12
+PP6848,Nova Forte,Political Party,Registered,Great Britain,,,,,23/10/2018,True,True,True,False,,,English Nova Forte,,23/10/2018 10:53:35,31/12
+PP66,Official Monster Raving Loony Party,Political Party,Registered,Great Britain,,,,,18/03/1999,True,True,True,False,,,Monster Raving Loony William Hill Party,,09/03/2012 10:36:54,31/12
+PP66,Official Monster Raving Loony Party,Political Party,Registered,Great Britain,,,,,18/03/1999,True,True,True,False,,,The Official Monster Raving Loony Party,,09/03/2012 10:36:54,31/12
+PP66,Official Monster Raving Loony Party,Political Party,Registered,Great Britain,,,,,18/03/1999,True,True,True,False,,,New Monster Raving Loony Party,,09/03/2012 10:36:54,31/12
+PP2242,Old Swan Against the Cuts,Political Party,Registered,Great Britain,,,,,18/02/2014,True,False,False,False,,,End Austerity - Old Swan Against Cuts,,26/02/2016 16:15:49,31/12
+PP12497,Old Windsor Residents Association,Political Party,Registered,Great Britain,,,,,10/09/2020,True,False,False,False,,,,,,31/12
+PP12548,One Kearsley,Political Party,Registered,Great Britain,,,,,23/06/2020,True,False,False,False,,,,,,31/12
+PP2037,Orkney Manifesto Group,Political Party,Registered,Great Britain,,,,,12/03/2013,False,True,False,False,,,,,,31/12
+PP12513,Our Island,Political Party,Registered,Great Britain,,,,,07/07/2020,True,False,False,False,,,,,,31/12
+PPm12674,Our Ryde,Minor Party,Registered,,,,,,13/01/2021,True,False,False,True,,,"Our Ryde, Our Town, Our Place",,13/01/2021 17:17:06,
+PPm12674,Our Ryde,Minor Party,Registered,,,,,,13/01/2021,True,False,False,True,,,"Our Ryde, Our Town",,13/01/2021 17:17:06,
+PP2642,Our West Lancashire,Political Party,Registered,Great Britain,,,,,20/02/2015,True,False,False,False,,,,,,31/12
+PP3978,Oxted & Limpsfield Residents Group,Political Party,Registered,Great Britain,,,,,23/03/2016,True,False,False,False,,,OLRG - Oxted & Limpsfield Residents Group,,23/03/2016 16:28:03,31/12
+PP1969,Patria,Political Party,Registered,Great Britain,,,,,09/11/2012,True,True,True,False,,,,,,31/12
+PP2,People Against Bureaucracy Group,Political Party,Registered,Great Britain,,,,,25/03/1999,True,False,False,False,,,,,,28/2
+PP773,People Before Profit Alliance,Political Party,Registered,Northern Ireland,,,,,01/09/2009,False,False,False,False,,,People Before Profit Alliance,,01/09/2009 00:00:00,31/12
+PP77,Plaid Cymru - The Party of Wales,Political Party,Registered,Great Britain,,,,,14/01/1999,False,False,True,False,,,Plaid Cymru - Your Local Party,Plaid Cymru - Eich Plaid Leol Chi,21/06/2012 15:36:48,31/12
+PP77,Plaid Cymru - The Party of Wales,Political Party,Registered,Great Britain,,,,,14/01/1999,False,False,True,False,,,Plaid Cymru - For All of Wales,Plaid Cymru - Dros Gymru Gyfan,15/03/2016 09:18:03,31/12
+PP77,Plaid Cymru - The Party of Wales,Political Party,Registered,Great Britain,,,,,14/01/1999,False,False,True,False,,,Plaid Cymru: Llais Sir Gâr,Plaid Cymru: Carmarthenshire's Voice,15/09/2020 17:28:27,31/12
+PP77,Plaid Cymru - The Party of Wales,Political Party,Registered,Great Britain,,,,,14/01/1999,False,False,True,False,,,Plaid Cymru: Achub ein Hysbyty,Plaid Cymru: Save our Hospital,15/09/2020 17:28:27,31/12
+PP77,Plaid Cymru - The Party of Wales,Political Party,Registered,Great Britain,,,,,14/01/1999,False,False,True,False,,,Plaid Cymru - Voice of the North,Plaid Cymru - Llais y Gogledd,15/09/2020 17:28:27,31/12
+PP77,Plaid Cymru - The Party of Wales,Political Party,Registered,Great Britain,,,,,14/01/1999,False,False,True,False,,,Plaid Cymru - Plaid Cymru Newydd,Plaid Cymru - New Wales Party,26/11/2020 16:52:36,31/12
+PP77,Plaid Cymru - The Party of Wales,Political Party,Registered,Great Britain,,,,,14/01/1999,False,False,True,False,,,Plaid Cymru:  O Blaid Cymru,Plaid Cymru - Vote for Wales,23/03/2021 16:04:21,31/12
+PPm2107,Polegate Residents' Association,Minor Party,Registered,,,,,,10/07/2013,True,False,False,True,,,,,,
+PP11468,Political Unity for Progress,Political Party,Registered,Great Britain,,,,,07/05/2020,True,True,True,False,,,Political Unity for Progress Candidate,,07/05/2020 13:34:14,31/12
+PP11468,Political Unity for Progress,Political Party,Registered,Great Britain,,,,,07/05/2020,True,True,True,False,,,The Political Unity for Progress Candidate,,07/05/2020 13:34:14,31/12
+PP11468,Political Unity for Progress,Political Party,Registered,Great Britain,,,,,07/05/2020,True,True,True,False,,,Your Political Unity for Progress Candidate,,07/05/2020 13:34:14,31/12
+PP3914,Populist Party,Political Party,Registered,Great Britain,,,,,14/12/2015,True,True,True,False,,,National Populist Party,,14/12/2015 17:25:26,31/12
+PP3914,Populist Party,Political Party,Registered,Great Britain,,,,,14/12/2015,True,True,True,False,,,English Populist Party,,14/12/2015 17:25:26,31/12
+PP3914,Populist Party,Political Party,Registered,Great Britain,,,,,14/12/2015,True,True,True,False,,,Scottish Populist Party,,14/12/2015 17:25:26,31/12
+PP3914,Populist Party,Political Party,Registered,Great Britain,,,,,14/12/2015,True,True,True,False,,,Localist (Populist Party),,14/12/2015 17:25:26,31/12
+PP3914,Populist Party,Political Party,Registered,Great Britain,,,,,14/12/2015,True,True,True,False,,,Protectionist (Populist Party),,14/12/2015 17:25:26,31/12
+PP6793,Portishead Independents,Political Party,Registered,Great Britain,,,,,04/05/2018,True,False,False,False,,,Portishead Independents Putting You First,,04/05/2018 15:26:43,31/12
+PP6793,Portishead Independents,Political Party,Registered,Great Britain,,,,,04/05/2018,True,False,False,False,,,Portishead Independents Putting People Before Politics,,04/05/2018 15:26:43,31/12
+PP6793,Portishead Independents,Political Party,Registered,Great Britain,,,,,04/05/2018,True,False,False,False,,,Think Local Vote Local Portishead Independents,,04/05/2018 15:26:43,31/12
+PP6793,Portishead Independents,Political Party,Registered,Great Britain,,,,,04/05/2018,True,False,False,False,,,Portishead Independents your team your town,,31/01/2019 08:08:39,31/12
+PP6793,Portishead Independents,Political Party,Registered,Great Britain,,,,,04/05/2018,True,False,False,False,,,Portishead Independents your voice your choice,,31/01/2019 08:08:39,31/12
+PP6793,Portishead Independents,Political Party,Registered,Great Britain,,,,,04/05/2018,True,False,False,False,,,Portishead Independents your family your future,,31/01/2019 08:08:39,31/12
+PP8002,Progress and Reform Party,Political Party,Registered,Great Britain,,,,,12/03/2019,True,True,True,False,,,,,,31/12
+PP8036,Progressive Party,Political Party,Registered,Great Britain,,,,,10/04/2019,True,True,True,False,,,The Progressive People's Party Candidate,Ymgeisydd Plaid Flaengar y Bobl,01/07/2019 18:06:00,31/12
+PP8036,Progressive Party,Political Party,Registered,Great Britain,,,,,10/04/2019,True,True,True,False,,,The Progressive Party Candidate,Ymgeisydd y Blaid Flaengar,05/02/2020 16:53:54,31/12
+PP101,Progressive Unionist Party of Northern Ireland,Political Party,Registered,Northern Ireland,,,,,24/03/1999,False,False,False,False,,,,,,31/12
+PP12731,Propel,Political Party,Registered,Great Britain,,,,,02/03/2021,False,False,True,False,,,Propel: Better for Wales,Propel: Gwell i Gymru,02/03/2021 14:52:38,31/12
+PP12731,Propel,Political Party,Registered,Great Britain,,,,,02/03/2021,False,False,True,False,,,Propel: Wales Needs Champions,Propel: Mae Cymru Angen Pencampwyr,02/03/2021 14:52:38,31/12
+PP12731,Propel,Political Party,Registered,Great Britain,,,,,02/03/2021,False,False,True,False,,,Propel: Not Politics as Usual,Propel: Nid Gwleidyddiaeth fel Arfer,02/03/2021 14:52:38,31/12
+PP10256,Proud of Oldham & Saddleworth,Political Party,Registered,Great Britain,,,,,11/10/2019,True,False,False,False,,,,,,31/12
+PP6655,Psychedelic Movement,Political Party,Registered,Great Britain,,,,,18/01/2018,True,True,True,False,,,Psychedelic Movement UK,,24/03/2021 18:06:46,31/12
+PP6655,Psychedelic Movement,Political Party,Registered,Great Britain,,,,,18/01/2018,True,True,True,False,,,Psychedelic Movement: Change Your Mind,,24/03/2021 18:06:46,31/12
+PP6655,Psychedelic Movement,Political Party,Registered,Great Britain,,,,,18/01/2018,True,True,True,False,,,Psychedelic Movement: Future Movement,,24/03/2021 18:06:46,31/12
+PP6655,Psychedelic Movement,Political Party,Registered,Great Britain,,,,,18/01/2018,True,True,True,False,,,Psychedelic Movement: Psyche Movement,,24/03/2021 18:06:46,31/12
+PP6655,Psychedelic Movement,Political Party,Registered,Great Britain,,,,,18/01/2018,True,True,True,False,,,Psychedelic Movement: Kamaclipse!,,24/03/2021 18:06:46,31/12
+PP6655,Psychedelic Movement,Political Party,Registered,Great Britain,,,,,18/01/2018,True,True,True,False,,,Psychedelic Movement: Psychedelic Economy,,24/03/2021 18:06:46,31/12
+PP6655,Psychedelic Movement,Political Party,Registered,Great Britain,,,,,18/01/2018,True,True,True,False,,,Psychedelic Movement: Tomorrow's Tomorrow Today,,24/03/2021 18:06:46,31/12
+PP6655,Psychedelic Movement,Political Party,Registered,Great Britain,,,,,18/01/2018,True,True,True,False,,,Psychedelic Movement: Future Party,,24/03/2021 18:06:46,31/12
+PP12493,"Putting Crewe First, Independent Residents Group.",Political Party,Registered,Great Britain,,,,,23/06/2020,True,False,False,False,,,,,,31/12
+PP9085,Radcliffe First,Political Party,Registered,Great Britain,,,,,18/04/2019,True,False,False,False,,,,,,31/12
+PP238,Rainham Resident's Association,Political Party,Registered,Great Britain,,,,,25/03/2002,True,False,False,False,,,Rainham Residents Group,,25/03/2002 00:00:00,31/12
+PP238,Rainham Resident's Association,Political Party,Registered,Great Britain,,,,,25/03/2002,True,False,False,False,,,Rainham & Wennington Residents Association,,25/03/2002 00:00:00,31/12
+PP238,Rainham Resident's Association,Political Party,Registered,Great Britain,,,,,25/03/2002,True,False,False,False,,,Rainham & Wennington Residents Group,,25/03/2002 00:00:00,31/12
+PP238,Rainham Resident's Association,Political Party,Registered,Great Britain,,,,,25/03/2002,True,False,False,False,,,Rainham Independent Residents Group,,25/03/2002 00:00:00,31/12
+PP238,Rainham Resident's Association,Political Party,Registered,Great Britain,,,,,25/03/2002,True,False,False,False,,,Rainham & Wennington Independent Residents Group,,25/03/2002 00:00:00,31/12
+PP238,Rainham Resident's Association,Political Party,Registered,Great Britain,,,,,25/03/2002,True,False,False,False,,,Rainham & South Hornchurch Residents Group,,25/03/2002 00:00:00,31/12
+PP238,Rainham Resident's Association,Political Party,Registered,Great Britain,,,,,25/03/2002,True,False,False,False,,,Rainham's Independent Local Residents Group,,25/03/2002 00:00:00,31/12
+PP238,Rainham Resident's Association,Political Party,Registered,Great Britain,,,,,25/03/2002,True,False,False,False,,,South Hornchurch Independent Local Residents Group,,25/03/2002 00:00:00,31/12
+PP238,Rainham Resident's Association,Political Party,Registered,Great Britain,,,,,25/03/2002,True,False,False,False,,,South Hornchurch Independent Residents Group,,18/05/2011 13:29:33,31/12
+PP238,Rainham Resident's Association,Political Party,Registered,Great Britain,,,,,25/03/2002,True,False,False,False,,,Dagenham and Rainham Independent Residents Group,,29/10/2014 16:40:00,31/12
+PP238,Rainham Resident's Association,Political Party,Registered,Great Britain,,,,,25/03/2002,True,False,False,False,,,Rainham and Dagenham Independent Residents Group,,29/10/2014 16:40:00,31/12
+PP268,Real Democracy Party,Political Party,Registered,Northern Ireland,,,,,26/11/2002,False,False,False,False,,,,,,31/12
+PP267,Real Democracy Party,Political Party,Registered,Great Britain,,,,,26/11/2002,True,True,True,False,,,,,,31/12
+PP2674,Rebooting Democracy,Political Party,Registered,Great Britain,,,,,01/04/2015,True,True,True,False,,,,,,31/12
+PP6878,Red Party of Scotland,Political Party,Registered,Great Britain,,,,,24/10/2018,False,True,False,False,,,,,,31/12
+PP2806,Redbridge Trade Union Party,Political Party,Registered,Great Britain,,,,,29/07/2015,True,False,False,False,,,,,,30/6
+PP86,Reform 2000 Party,Political Party,Registered,Great Britain,,,,,19/03/2000,True,True,True,False,,,,,,31/12
+PP11471,Reform Derby,Political Party,Registered,Great Britain,,,,,18/03/2020,True,False,False,False,,,Reform Derby and Reform UK,,16/03/2021 12:36:28,31/12
+PP7931,Reform UK,Political Party,Registered,Great Britain,,,,,05/02/2019,True,True,True,False,,,Brexit Party,,04/04/2019 15:34:28,31/12
+PP7931,Reform UK,Political Party,Registered,Great Britain,,,,,05/02/2019,True,True,True,False,,,Brexit Party For A Better Future,,04/04/2019 15:34:28,31/12
+PP7931,Reform UK,Political Party,Registered,Great Britain,,,,,05/02/2019,True,True,True,False,,,"Brexit Party, The One to Trust",,04/04/2019 15:34:28,31/12
+PP7931,Reform UK,Political Party,Registered,Great Britain,,,,,05/02/2019,True,True,True,False,,,ReformUK – London Deserves Better,,23/03/2021 16:19:57,31/12
+PP7931,Reform UK,Political Party,Registered,Great Britain,,,,,05/02/2019,True,True,True,False,,,ReformUK – Changing Politics for Good,,23/03/2021 16:19:57,31/12
+PP7931,Reform UK,Political Party,Registered,Great Britain,,,,,05/02/2019,True,True,True,False,,,Reform Derby and Reform UK,,23/03/2021 16:19:57,31/12
+PP11423,Rejoin EU,Political Party,Registered,Great Britain,,,,,17/02/2020,True,True,True,False,,,,,,31/12
+PP6595,Renew,Political Party,Registered,Great Britain,,,,,30/10/2017,True,True,True,False,,,,,,31/12
+PP74,Residents Associations of Epsom and Ewell,Political Party,Registered,Great Britain,,,,,13/12/2000,True,False,False,False,,,Residents Association of Epsom and Ewell,,23/03/2021 09:28:37,31/12
+PPm12486,Residents for Chesham,Minor Party,Registered,,,,,,02/10/2020,True,False,False,True,,,,,,
+PP9049,Residents for Guildford and Villages,Political Party,Registered,Great Britain,,,,,12/03/2019,True,False,False,False,,,Residents for Guildford and Villages Candidate,,17/06/2021 16:57:48,31/12
+PP2468,Residents for Uttlesford,Political Party,Registered,Great Britain,,,,,29/10/2014,True,False,False,False,,,Residents for Uttlesford - Saffron Walden,,29/10/2014 15:40:49,31/12
+PP2468,Residents for Uttlesford,Political Party,Registered,Great Britain,,,,,29/10/2014,True,False,False,False,,,Residents for Uttlesford - Newport,,29/10/2014 15:40:49,31/12
+PP2468,Residents for Uttlesford,Political Party,Registered,Great Britain,,,,,29/10/2014,True,False,False,False,,,Residents for Uttlesford - Dunmow,,29/05/2015 14:09:20,31/12
+PP8038,Residents of Wilmslow,Political Party,Registered,Great Britain,,,,,26/02/2019,True,False,False,False,,,,,,31/12
+PP6808,Residents' Association of Cuddington,Political Party,Registered,Great Britain,,,,,29/05/2018,True,False,False,False,,,,,,31/12
+PP836,Restoration Party,Political Party,Registered,Great Britain,,,,,12/03/2010,True,True,True,False,,,,,,31/12
+PP837,Restoration Party,Political Party,Registered,Northern Ireland,,,,,12/03/2010,False,False,False,False,,,,,,31/12
+PP12666,Restore Scotland,Political Party,Registered,Great Britain,,,,,12/01/2021,False,True,False,False,,,,,,31/12
+PP89,Revolutionary Communist Party Britain (Marxist-Leninist),Political Party,Registered,Great Britain,,,,,09/05/2000,True,True,True,False,,,,,,31/12
+PP341,Rochford District Residents,Political Party,Registered,Great Britain,,,,,09/07/2003,True,False,False,False,,,Rochford District Residents Candidate,,26/02/2018 11:02:24,31/12
+PP11473,Rotherham Democratic Party,Political Party,Registered,Great Britain,,,,,26/02/2020,True,False,False,False,,,,,,31/12
+PP205,Runnymede Independent Residents' Group,Political Party,Registered,Great Britain,,,,,29/10/2001,True,False,False,False,,,,,,31/12
+PP2042,Sandown Independents,Political Party,Registered,Great Britain,,,,,12/03/2013,True,False,False,False,,,Sandown Independents: Working for Sandown North,,12/03/2013 17:35:51,31/12
+PP2042,Sandown Independents,Political Party,Registered,Great Britain,,,,,12/03/2013,True,False,False,False,,,Sandown Independents: Working for Sandown South,,12/03/2013 17:35:51,31/12
+PP2042,Sandown Independents,Political Party,Registered,Great Britain,,,,,12/03/2013,True,False,False,False,,,Sandown Independents: Working for Sandown,,12/03/2013 17:35:51,31/12
+PP2042,Sandown Independents,Political Party,Registered,Great Britain,,,,,12/03/2013,True,False,False,False,,,Sandown Independents: People Before Politics,,12/03/2013 17:35:51,31/12
+PP2042,Sandown Independents,Political Party,Registered,Great Britain,,,,,12/03/2013,True,False,False,False,,,Sandown Independents: Putting Sandown First,,12/03/2013 17:35:51,31/12
+PP2042,Sandown Independents,Political Party,Registered,Great Britain,,,,,12/03/2013,True,False,False,False,,,Sandown Independents: Working With Local People,,12/03/2013 17:35:51,31/12
+PP6718,Save Our Beeston and Holbeck Independents,Political Party,Registered,Great Britain,,,,,31/01/2018,True,False,False,False,,,,,,31/12
+PP6712,Save Us Now,Political Party,Registered,Great Britain,,,,,23/03/2018,True,False,False,False,,,,,,31/12
+PP12489,Scotia Future,Political Party,Registered,Great Britain,,,,,09/09/2020,False,True,False,False,,,,,,31/12
+PP6852,Scotland - Unhyphenated,Political Party,Registered,Great Britain,,,,,28/08/2018,False,True,False,False,,,Scotland  Unhyphenated People Before Party,,28/08/2018 14:01:46,31/12
+PP6852,Scotland - Unhyphenated,Political Party,Registered,Great Britain,,,,,28/08/2018,False,True,False,False,,,Scotland Unhyphenated Sensible Sustainable,,28/08/2018 14:01:46,31/12
+PP6852,Scotland - Unhyphenated,Political Party,Registered,Great Britain,,,,,28/08/2018,False,True,False,False,,,Scotland Unhyphenated Scotland First,,28/08/2018 14:01:46,31/12
+PP6852,Scotland - Unhyphenated,Political Party,Registered,Great Britain,,,,,28/08/2018,False,True,False,False,,,Scotland Unhyphenated Country Before Party,,28/08/2018 14:01:46,31/12
+PP12712,Scotland's Independence Referendum Party,Political Party,Registered,Great Britain,,,,,08/02/2021,False,True,False,False,,,,,,31/12
+PP768,Scottish Democratic Alliance,Political Party,Registered,Great Britain,,,,,03/07/2009,False,True,False,False,,,,,,31/12
+PP2832,Scottish Democrats,Political Party,Registered,Great Britain,,,,,21/08/2015,False,True,False,False,,,Scottish Democrats Purpose Service Achievements,,21/08/2015 09:35:16,31/12
+PP2832,Scottish Democrats,Political Party,Registered,Great Britain,,,,,21/08/2015,False,True,False,False,,,Scottish Democrats Freedom & Equality,,21/08/2015 09:35:16,31/12
+PP2832,Scottish Democrats,Political Party,Registered,Great Britain,,,,,21/08/2015,False,True,False,False,,,Scottish Democrats a new world awaits,,21/08/2015 09:35:16,31/12
+PP12671,Scottish Eco-Devolutionist Party (SEDP),Political Party,Registered,Great Britain,,,,,19/03/2021,False,True,False,False,,,,,,31/12
+PP6380,Scottish Family Party,Political Party,Registered,Great Britain,,,,,11/09/2017,True,True,True,False,,,Scottish Family Party - a New Voice,,11/09/2017 12:18:25,31/12
+PP6380,Scottish Family Party,Political Party,Registered,Great Britain,,,,,11/09/2017,True,True,True,False,,,Scottish Family Party - challenging the consensus,,11/09/2017 12:18:25,31/12
+PP6380,Scottish Family Party,Political Party,Registered,Great Britain,,,,,11/09/2017,True,True,True,False,,,Scottish Family Party - breaking the mould,,11/09/2017 12:18:25,31/12
+PP6380,Scottish Family Party,Political Party,Registered,Great Britain,,,,,11/09/2017,True,True,True,False,,,Scottish Family Party - a different perspective,,11/09/2017 12:18:25,31/12
+PP6380,Scottish Family Party,Political Party,Registered,Great Britain,,,,,11/09/2017,True,True,True,False,,,Scottish Family Party - speaking the truth,,11/09/2017 12:18:25,31/12
+PP6380,Scottish Family Party,Political Party,Registered,Great Britain,,,,,11/09/2017,True,True,True,False,,,Scottish Family Party - Putting Families First,,11/09/2017 12:18:25,31/12
+PP6380,Scottish Family Party,Political Party,Registered,Great Britain,,,,,11/09/2017,True,True,True,False,,,Scottish Family Party - Standing for Life,,11/09/2017 12:18:25,31/12
+PP6380,Scottish Family Party,Political Party,Registered,Great Britain,,,,,11/09/2017,True,True,True,False,,,Scottish Family Party - Challenging Political Correctness,,11/09/2017 12:18:25,31/12
+PP6380,Scottish Family Party,Political Party,Registered,Great Britain,,,,,11/09/2017,True,True,True,False,,,Scottish Family Party - Fearlessly Speaking Truth,,11/09/2017 12:18:25,31/12
+PP6380,Scottish Family Party,Political Party,Registered,Great Britain,,,,,11/09/2017,True,True,True,False,,,Scottish Family Party - Defending Traditional Values,,08/02/2021 12:18:59,31/12
+PP6380,Scottish Family Party,Political Party,Registered,Great Britain,,,,,11/09/2017,True,True,True,False,,,Scottish Family Party - Promoting Traditional Values,,08/02/2021 12:18:59,31/12
+PP6380,Scottish Family Party,Political Party,Registered,Great Britain,,,,,11/09/2017,True,True,True,False,,,"Scottish Family Party: Pro-Family, Pro-Marriage, Pro-Life",,19/03/2021 17:18:58,31/12
+PP130,Scottish Green Party,Political Party,Registered,Great Britain,,,,,04/04/2001,False,True,False,False,,,Scottish Greens,,15/03/2016 12:54:49,31/12
+PP130,Scottish Green Party,Political Party,Registered,Great Britain,,,,,04/04/2001,False,True,False,False,,,Scottish Greens - Power In Your Hands,,10/03/2017 10:39:50,31/12
+PP3906,Scottish Libertarian Party,Political Party,Registered,Great Britain,,,,,02/03/2016,False,True,False,False,,,,,,31/12
+PP102,Scottish National Party (SNP),Political Party,Registered,Great Britain,,,,,14/01/1999,False,True,False,False,,,Scottish National Party (Leader – Nicola Sturgeon),,09/03/2016 13:34:12,31/12
+PP102,Scottish National Party (SNP),Political Party,Registered,Great Britain,,,,,14/01/1999,False,True,False,False,,,Scottish National Party – Stronger for Scotland,,09/03/2016 13:34:12,31/12
+PP102,Scottish National Party (SNP),Political Party,Registered,Great Britain,,,,,14/01/1999,False,True,False,False,,,Both Votes SNP for IndyRef2,,29/03/2021 13:01:14,31/12
+PP102,Scottish National Party (SNP),Political Party,Registered,Great Britain,,,,,14/01/1999,False,True,False,False,,,Nicola Sturgeon for SNP First Minister,,29/03/2021 13:01:14,31/12
+PP102,Scottish National Party (SNP),Political Party,Registered,Great Britain,,,,,14/01/1999,False,True,False,False,,,Vote SNP for IndyRef2,,29/03/2021 13:01:14,31/12
+PP46,Scottish Socialist Party,Political Party,Registered,Great Britain,,,,,25/02/1999,False,True,False,False,,,Scottish Socialist Party - Save Our Schools,,02/02/2001 00:00:00,31/12
+PP46,Scottish Socialist Party,Political Party,Registered,Great Britain,,,,,25/02/1999,False,True,False,False,,,Scottish Socialist Party – Save our services,,24/03/2011 16:05:05,31/12
+PP46,Scottish Socialist Party,Political Party,Registered,Great Britain,,,,,25/02/1999,False,True,False,False,,,Scottish Socialist Party – Save public services,,24/03/2011 16:05:05,31/12
+PP46,Scottish Socialist Party,Political Party,Registered,Great Britain,,,,,25/02/1999,False,True,False,False,,,Scottish Socialist Party – People not profit,,24/03/2011 16:05:05,31/12
+PP46,Scottish Socialist Party,Political Party,Registered,Great Britain,,,,,25/02/1999,False,True,False,False,,,Scottish Socialist Party – Free public transport,,24/03/2011 16:05:05,31/12
+PP46,Scottish Socialist Party,Political Party,Registered,Great Britain,,,,,25/02/1999,False,True,False,False,,,Scottish Socialist Party-Scotland's Socialist Party,,14/09/2015 17:31:04,31/12
+PP809,Scottish Unionist Party,Political Party,Registered,Great Britain,,,,,10/02/2010,False,True,False,False,,,"Scottish Unionists, Proudly Scottish, Proudly British",,10/02/2010 00:00:00,31/12
+PP809,Scottish Unionist Party,Political Party,Registered,Great Britain,,,,,10/02/2010,False,True,False,False,,,"Scottish Unionist Party, British and Proud",,10/02/2010 00:00:00,31/12
+PP809,Scottish Unionist Party,Political Party,Registered,Great Britain,,,,,10/02/2010,False,True,False,False,,,"Scottish Unionist Party, United We Stand",,10/02/2010 00:00:00,31/12
+PP809,Scottish Unionist Party,Political Party,Registered,Great Britain,,,,,10/02/2010,False,True,False,False,,,"Scottish Unionist Party, Stronger United",,10/02/2010 00:00:00,31/12
+PP809,Scottish Unionist Party,Political Party,Registered,Great Britain,,,,,10/02/2010,False,True,False,False,,,Scottish Unionists,,10/02/2010 00:00:00,31/12
+PP55,SDLP (Social Democratic & Labour Party),Political Party,Registered,Northern Ireland,,,,,14/01/1999,False,False,False,False,,,,,,31/12
+PP4182,Seaham Community Party,Political Party,Registered,Great Britain,,,,,11/08/2016,True,False,False,False,,,Our Future Together Seaham Community Party,,11/08/2016 11:08:49,1/1
+PP2803,Self-Ownership Party,Political Party,Registered,Great Britain,,,,,03/07/2015,True,False,False,False,,,,,,31/12
+PP12747,Shevington Independents,Political Party,Registered,Great Britain,,,,,17/03/2021,True,False,False,False,,,Shevington Independents working for you,,17/03/2021 11:30:30,31/12
+PP12747,Shevington Independents,Political Party,Registered,Great Britain,,,,,17/03/2021,True,False,False,False,,,Shevington Independents Representing you,,17/03/2021 11:30:30,31/12
+PP12747,Shevington Independents,Political Party,Registered,Great Britain,,,,,17/03/2021,True,False,False,False,,,Voice of Shevington is Shevington independents,,17/03/2021 11:30:30,31/12
+PPm12621,Shildon and Dene Valley Independent Party,Minor Party,Registered,,,,,,11/11/2020,True,False,False,True,,,,,,
+PPm3977,Shiromani Akali Dal Amritsar UK,Minor Party,Registered,,,,,,06/05/2016,True,False,False,True,,,,,,
+PP10290,Shropshire Party,Political Party,Registered,Great Britain,,,,,07/11/2019,True,False,False,False,,,Shropshire Party candidate,,07/11/2019 16:59:48,31/12
+PP39,Sinn Féin,Political Party,Registered,Northern Ireland,,,,,14/01/1999,False,False,False,False,,,,,,31/12
+PP6816,Skegness urban district society,Political Party,Registered,Great Britain,,,,,08/08/2018,True,False,False,False,,,"Skegness urban district society, (SUDS)",,08/08/2018 16:35:30,31/12
+PP7956,Skelmersdale Independent Party,Political Party,Registered,Great Britain,,,,,04/02/2019,True,False,False,False,,,Skelmersdale Independents Working For Skelmersdale,,04/02/2019 11:25:29,31/12
+PP7956,Skelmersdale Independent Party,Political Party,Registered,Great Britain,,,,,04/02/2019,True,False,False,False,,,Skelmersdale Independents Representing Ashurst First,,04/02/2019 11:25:29,31/12
+PP7956,Skelmersdale Independent Party,Political Party,Registered,Great Britain,,,,,04/02/2019,True,False,False,False,,,Skelmersdale Independents Representing Digmoor First,,04/02/2019 11:25:29,31/12
+PP7956,Skelmersdale Independent Party,Political Party,Registered,Great Britain,,,,,04/02/2019,True,False,False,False,,,Skelmersdale Independents Representing Moorside First,,04/02/2019 11:25:29,31/12
+PP7956,Skelmersdale Independent Party,Political Party,Registered,Great Britain,,,,,04/02/2019,True,False,False,False,,,Skelmersdale Independents Representing Tanhouse First,,04/02/2019 11:25:29,31/12
+PP7956,Skelmersdale Independent Party,Political Party,Registered,Great Britain,,,,,04/02/2019,True,False,False,False,,,Skelmersdale Independents Representing Up Holland First,,04/02/2019 11:25:29,31/12
+PP7956,Skelmersdale Independent Party,Political Party,Registered,Great Britain,,,,,04/02/2019,True,False,False,False,,,Skelmersdale Independents putting Skem First,,03/09/2020 14:23:54,31/12
+PP243,Social Democratic Party,Political Party,Registered,Great Britain,,,,,24/07/2002,True,True,True,False,,,Social Democratic Party Scotland,,16/02/2017 11:41:24,31/12
+PP243,Social Democratic Party,Political Party,Registered,Great Britain,,,,,24/07/2002,True,True,True,False,,,Social Democratic Party: Fighting For Brexit,,06/03/2019 15:21:43,31/12
+PP559,Socialist Alliance,Political Party,Registered,Great Britain,,,,,30/01/2007,True,False,True,False,,,,,,31/12
+PP108,Socialist Alternative,Political Party,Registered,Great Britain,,,,,25/03/1999,True,False,True,False,,,Socialist Alternative - Save Our Services,,06/02/2001 00:00:00,31/12
+PP108,Socialist Alternative,Political Party,Registered,Great Britain,,,,,25/03/1999,True,False,True,False,,,Socialist Alternative - Save Local Health Services,,06/02/2001 00:00:00,31/12
+PP108,Socialist Alternative,Political Party,Registered,Great Britain,,,,,25/03/1999,True,False,True,False,,,Socialist Alternative (Nellist),,06/02/2001 00:00:00,31/12
+PP108,Socialist Alternative,Political Party,Registered,Great Britain,,,,,25/03/1999,True,False,True,False,,,Socialist Alternative,,06/02/2001 00:00:00,31/12
+PP108,Socialist Alternative,Political Party,Registered,Great Britain,,,,,25/03/1999,True,False,True,False,,,Socialist Alternative - Save Our Health Service,,06/02/2001 00:00:00,31/12
+PP108,Socialist Alternative,Political Party,Registered,Great Britain,,,,,25/03/1999,True,False,True,False,,,Socialist Alternative - Save Our Schools,,06/02/2001 00:00:00,31/12
+PP108,Socialist Alternative,Political Party,Registered,Great Britain,,,,,25/03/1999,True,False,True,False,,,The Socialist Alternative Candidate,,06/02/2001 00:00:00,31/12
+PP108,Socialist Alternative,Political Party,Registered,Great Britain,,,,,25/03/1999,True,False,True,False,,,Socialist Alternative - Putting People First,,11/03/2014 12:46:35,31/12
+PP633,Socialist Equality Party,Political Party,Registered,Great Britain,,,,,27/02/2007,True,True,True,False,,,,,,31/12
+PP73,Socialist Labour Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,,,,31/12
+PP28,Socialist Party (Northern Ireland),Political Party,Registered,Northern Ireland,,,,,25/02/1999,False,False,False,False,,,,,,31/12
+PP2897,Solidarity - Scotland's Socialist Movement,Political Party,Registered,Great Britain,,,,,06/01/2016,False,True,False,False,,,,,,31/12
+PP840,Solihull and Meriden Residents Association,Political Party,Registered,Great Britain,,,,,15/03/2010,True,False,False,False,,,Independent Solihull Residents Association Candidate,,07/04/2015 15:24:24,31/12
+PP840,Solihull and Meriden Residents Association,Political Party,Registered,Great Britain,,,,,15/03/2010,True,False,False,False,,,Independent Solihull Ratepayers and Residents Association,,07/04/2015 15:24:24,31/12
+PP840,Solihull and Meriden Residents Association,Political Party,Registered,Great Britain,,,,,15/03/2010,True,False,False,False,,,Independent Solihull and Meriden Residents Association,,07/04/2015 15:24:24,31/12
+PP12535,Somerset Independents,Political Party,Registered,Great Britain,,,,,10/09/2020,True,False,False,False,,,Somerset Independents Putting You First,,10/09/2020 18:40:11,31/12
+PP12535,Somerset Independents,Political Party,Registered,Great Britain,,,,,10/09/2020,True,False,False,False,,,Somerset Independents Putting Your Area First,,10/09/2020 18:40:11,31/12
+PP12535,Somerset Independents,Political Party,Registered,Great Britain,,,,,10/09/2020,True,False,False,False,,,Somerset Independents Putting Somerset Residents First,,10/09/2020 18:40:11,31/12
+PP12535,Somerset Independents,Political Party,Registered,Great Britain,,,,,10/09/2020,True,False,False,False,,,Somerset Independents Putting Mendip Residents First,,10/09/2020 18:40:11,31/12
+PP12535,Somerset Independents,Political Party,Registered,Great Britain,,,,,10/09/2020,True,False,False,False,,,Somerset Independents Putting Sedgemoor Residents First,,10/09/2020 18:40:11,31/12
+PP12535,Somerset Independents,Political Party,Registered,Great Britain,,,,,10/09/2020,True,False,False,False,,,Somerset Independents Promoting Democracy and Rights,,10/09/2020 18:40:11,31/12
+PP12535,Somerset Independents,Political Party,Registered,Great Britain,,,,,10/09/2020,True,False,False,False,,,Somerset Independents Protecting Your Environment,,10/09/2020 18:40:11,31/12
+PP12535,Somerset Independents,Political Party,Registered,Great Britain,,,,,10/09/2020,True,False,False,False,,,Somerset Independents Protecting Wildlife,,10/09/2020 18:40:11,31/12
+PP12535,Somerset Independents,Political Party,Registered,Great Britain,,,,,10/09/2020,True,False,False,False,,,Somerset Independents Putting Taunton Residents First,,10/09/2020 18:40:11,31/12
+PP12535,Somerset Independents,Political Party,Registered,Great Britain,,,,,10/09/2020,True,False,False,False,,,Somerset Independents Standing Up For You,,10/09/2020 18:40:11,31/12
+PP12535,Somerset Independents,Political Party,Registered,Great Britain,,,,,10/09/2020,True,False,False,False,,,Somerset Independents Its Your County,,10/09/2020 18:40:11,31/12
+PP12670,South Devon Alliance,Political Party,Registered,Great Britain,,,,,23/03/2021,True,False,False,False,,,,,,31/12
+PP12771,South Holland Independents,Political Party,Registered,Great Britain,,,,,17/03/2021,True,False,False,False,,,"South Holland Independents, putting you first",,17/03/2021 20:23:34,31/12
+PP12771,South Holland Independents,Political Party,Registered,Great Britain,,,,,17/03/2021,True,False,False,False,,,"South Holland Independents, working for you",,17/03/2021 20:23:34,31/12
+PP12771,South Holland Independents,Political Party,Registered,Great Britain,,,,,17/03/2021,True,False,False,False,,,"South Holland Independents, District before party",,17/03/2021 20:23:34,31/12
+PP896,South Woodham Ferrers Council Taxpayers Association,Political Party,Registered,Great Britain,,,,,01/12/2010,True,False,False,False,,,,,,31/12
+PP549,Space Navies Party,Political Party,Registered,Great Britain,,,,,21/03/2006,True,True,True,False,,,Vote For The Space Navies,,31/03/2015 18:45:26,31/12
+PP549,Space Navies Party,Political Party,Registered,Great Britain,,,,,21/03/2006,True,True,True,False,,,The Space Navies Is For All,,31/03/2015 18:45:26,31/12
+PP6403,St. Neots Independent Group,Political Party,Registered,Great Britain,,,,,20/03/2017,True,False,False,False,,,St Neots Independent Group candidate,,20/03/2017 18:57:18,31/12
+PP6757,Stalybridge Town Party,Political Party,Registered,Great Britain,,,,,29/03/2018,True,False,False,False,,,Stalybridge Town,,29/03/2018 15:24:35,31/12
+PP6757,Stalybridge Town Party,Political Party,Registered,Great Britain,,,,,29/03/2018,True,False,False,False,,,"Your Town, Our Town, Stalybridge Town.",,29/03/2018 15:24:35,31/12
+PP6757,Stalybridge Town Party,Political Party,Registered,Great Britain,,,,,29/03/2018,True,False,False,False,,,Stalybridge Town for Stalybridge People,,29/03/2018 15:24:35,31/12
+PP7948,Standish Independents,Political Party,Registered,Great Britain,,,,,08/02/2019,True,False,False,False,,,Standish Independents working for you,,02/03/2021 16:01:52,31/12
+PP7948,Standish Independents,Political Party,Registered,Great Britain,,,,,08/02/2019,True,False,False,False,,,Voice of Standish is Standish independents,,02/03/2021 16:01:52,31/12
+PP7948,Standish Independents,Political Party,Registered,Great Britain,,,,,08/02/2019,True,False,False,False,,,Standish Independents Representing you,,02/03/2021 16:01:52,31/12
+PPm2647,Stone Independents,Minor Party,Registered,,,,,,01/04/2015,True,False,False,True,,,Stone Independents working for Stone,,26/05/2021 10:52:52,
+PP591,Stoneleigh and Auriol Residents' Association,Political Party,Registered,Great Britain,,,,,17/10/2006,True,False,False,False,,,,,,31/12
+PPm3917,Sutton Residents' Party,Minor Party,Registered,,,,,,22/02/2016,True,False,False,True,,,Sutton Coldfield Residents' Party,,04/03/2019 17:08:44,
+PP6730,Swale Independents,Political Party,Registered,Great Britain,,,,,21/05/2018,True,False,False,False,,,Swale Independents let's stop over development,,21/05/2018 10:49:37,31/12
+PP6730,Swale Independents,Political Party,Registered,Great Britain,,,,,21/05/2018,True,False,False,False,,,Swale Independents working for Sheppey,,21/05/2018 10:49:37,31/12
+PP6730,Swale Independents,Political Party,Registered,Great Britain,,,,,21/05/2018,True,False,False,False,,,Swale Independents working for Faversham,,21/05/2018 10:49:37,31/12
+PP6730,Swale Independents,Political Party,Registered,Great Britain,,,,,21/05/2018,True,False,False,False,,,Swale Independents putting Sheppey first,,21/05/2018 10:49:37,31/12
+PP6730,Swale Independents,Political Party,Registered,Great Britain,,,,,21/05/2018,True,False,False,False,,,Swale Independents a local voice,,21/05/2018 10:49:37,31/12
+PP6730,Swale Independents,Political Party,Registered,Great Britain,,,,,21/05/2018,True,False,False,False,,,Swale Independents putting our community first,,21/05/2018 10:49:37,31/12
+PP6730,Swale Independents,Political Party,Registered,Great Britain,,,,,21/05/2018,True,False,False,False,,,Swale Independents Against Excessive Housing,,21/05/2018 10:49:37,31/12
+PP6730,Swale Independents,Political Party,Registered,Great Britain,,,,,21/05/2018,True,False,False,False,,,Swale Independents Save our villages,,21/05/2018 10:49:37,31/12
+PP6730,Swale Independents,Political Party,Registered,Great Britain,,,,,21/05/2018,True,False,False,False,,,Swale Independents working for Sittingbourne,,21/05/2018 10:49:37,31/12
+PP6730,Swale Independents,Political Party,Registered,Great Britain,,,,,21/05/2018,True,False,False,False,,,"Swale Independents - Local issues, local solutions",,04/02/2019 10:22:35,31/12
+PP6730,Swale Independents,Political Party,Registered,Great Britain,,,,,21/05/2018,True,False,False,False,,,Swale Independents - People not party politics,,04/02/2019 10:22:35,31/12
+PP6730,Swale Independents,Political Party,Registered,Great Britain,,,,,21/05/2018,True,False,False,False,,,Swale Independents - Putting local people first,,04/02/2019 10:22:35,31/12
+PP6370,Swanscombe and Greenhithe Residents' Association,Political Party,Registered,Great Britain,,,,,20/03/2017,True,False,False,False,,,,,,30/9
+PP6615,Taking The Initiative Party,Political Party,Registered,Great Britain,,,,,02/10/2017,True,False,True,False,,,Taking the Initiative Party of Britain,,02/10/2017 12:58:34,31/12
+PP141,Tattenham & Preston Residents,Political Party,Registered,Great Britain,,,,,29/03/2001,True,False,False,False,,,Nork & Tattenhams Residents' Associations (joint description with Nork Residents' Association),,17/04/2014 16:53:32,31/12
+PP141,Tattenham & Preston Residents,Political Party,Registered,Great Britain,,,,,29/03/2001,True,False,False,False,,,Tattenham & Preston Residents Association,,08/04/2019 16:29:17,31/12
+PP141,Tattenham & Preston Residents,Political Party,Registered,Great Britain,,,,,29/03/2001,True,False,False,False,,,Tattenham Corner & Preston Residents,,08/04/2019 16:29:17,31/12
+PP141,Tattenham & Preston Residents,Political Party,Registered,Great Britain,,,,,29/03/2001,True,False,False,False,,,Tattenham Residents' Association,,08/04/2019 16:29:17,31/12
+PP6322,Temple and Farringdon Together,Political Party,Registered,Great Britain,,,,,16/02/2017,True,False,False,False,,,,,,31/12
+PP661,Tendring First,Political Party,Registered,Great Britain,,,,,26/03/2007,True,False,False,False,,,,,,31/12
+PP48,Tewkesbury and Twyning Independents,Political Party,Registered,Great Britain,,,,,27/07/2000,True,False,False,False,,,,,,31/12
+PP64,Thames Ditton / Weston Green Residents' Association,Political Party,Registered,Great Britain,,,,,17/02/2000,True,False,False,False,,,Thames Ditton Residents' Association,,08/02/2001 00:00:00,31/12
+PP64,Thames Ditton / Weston Green Residents' Association,Political Party,Registered,Great Britain,,,,,17/02/2000,True,False,False,False,,,Weston Green Residents' Association,,08/02/2001 00:00:00,31/12
+PP64,Thames Ditton / Weston Green Residents' Association,Political Party,Registered,Great Britain,,,,,17/02/2000,True,False,False,False,,,Dittons and Weston Green Residents' Association,,08/02/2001 00:00:00,31/12
+PP64,Thames Ditton / Weston Green Residents' Association,Political Party,Registered,Great Britain,,,,,17/02/2000,True,False,False,False,,,Thames Ditton Residents,,08/02/2001 00:00:00,31/12
+PP64,Thames Ditton / Weston Green Residents' Association,Political Party,Registered,Great Britain,,,,,17/02/2000,True,False,False,False,,,Weston Green Residents,,08/02/2001 00:00:00,31/12
+PP64,Thames Ditton / Weston Green Residents' Association,Political Party,Registered,Great Britain,,,,,17/02/2000,True,False,False,False,,,Thames Ditton and Weston Green Residents,,08/02/2001 00:00:00,31/12
+PP64,Thames Ditton / Weston Green Residents' Association,Political Party,Registered,Great Britain,,,,,17/02/2000,True,False,False,False,,,Dittons and Weston Green Residents,,08/02/2001 00:00:00,31/12
+PP64,Thames Ditton / Weston Green Residents' Association,Political Party,Registered,Great Britain,,,,,17/02/2000,True,False,False,False,,,Hinchley Wood / Weston Green Residents' Associations (Joint description with Hinchley Wood Residents Association),,23/03/2016 17:46:01,31/12
+PP8030,Thanet Independents,Political Party,Registered,Great Britain,,,,,18/02/2019,True,False,False,False,,,,,,31/12
+PP12665,The Autonomous Party,Political Party,Registered,Great Britain,,,,,12/01/2021,True,True,True,False,,,Autonomous Party,,12/01/2021 17:03:55,31/12
+PP12665,The Autonomous Party,Political Party,Registered,Great Britain,,,,,12/01/2021,True,True,True,False,,,Autonomous UK,,12/01/2021 17:03:55,31/12
+PP12665,The Autonomous Party,Political Party,Registered,Great Britain,,,,,12/01/2021,True,True,True,False,,,Autonomous International,,12/01/2021 17:03:55,31/12
+PP2644,The Beverley Party,Political Party,Registered,Great Britain,,,,,01/04/2015,True,False,False,False,,,,,,31/12
+PP6810,the Borough first Independents,Political Party,Registered,Great Britain,,,,,05/07/2018,True,False,False,False,,,tBf - the Borough first,,05/07/2018 15:57:53,31/12
+PP6810,the Borough first Independents,Political Party,Registered,Great Britain,,,,,05/07/2018,True,False,False,False,,,tBfI - the Borough first Independents,,19/10/2020 15:35:31,31/12
+PP12527,The Burning Pink Party,Political Party,Registered,Great Britain,,,,,08/10/2020,True,True,True,False,,,,,,31/12
+PP9208,The Citizens Movement Party UK,Political Party,Registered,Great Britain,,,,,10/09/2019,True,True,True,False,,,Citizens Movement Party UK,,10/09/2019 11:47:54,31/12
+PP9208,The Citizens Movement Party UK,Political Party,Registered,Great Britain,,,,,10/09/2019,True,True,True,False,,,Local Citizen Movement Party UK,,10/09/2019 11:47:54,31/12
+PP9208,The Citizens Movement Party UK,Political Party,Registered,Great Britain,,,,,10/09/2019,True,True,True,False,,,Citizens Movement Party UK Candidate,,10/09/2019 11:47:54,31/12
+PP9208,The Citizens Movement Party UK,Political Party,Registered,Great Britain,,,,,10/09/2019,True,True,True,False,,,The Citizens Movement Party UK Candidate,,10/09/2019 11:47:54,31/12
+PP2117,The Common People,Political Party,Registered,Great Britain,,,,,12/06/2015,True,True,True,False,,,,,,31/12
+PP10254,The Constitution and Reform Party,Political Party,Registered,Great Britain,,,,,09/10/2019,True,False,False,False,,,,,,31/12
+PPm6338,The Cromwell Commonwealth Republican Party,Minor Party,Registered,,,,,,11/01/2017,True,False,False,True,,,,,,
+PP12759,The Democratic Network,Political Party,Registered,Great Britain,,,,,10/03/2021,True,False,False,False,,,A Democratic Network Candidate,,10/03/2021 16:56:58,31/12
+PP12759,The Democratic Network,Political Party,Registered,Great Britain,,,,,10/03/2021,True,False,False,False,,,East Sussex Democratic Network,,10/03/2021 16:56:58,31/12
+PP1813,The Democratic Party,Political Party,Registered,Great Britain,,,,,06/07/2012,True,True,True,False,,,,,,31/12
+PP1983,The Entertainment Party,Political Party,Registered,Great Britain,,,,,05/12/2012,True,True,True,False,,,Entertainment Party,,05/12/2012 15:05:59,31/12
+PP6661,The For Britain Movement,Political Party,Registered,Great Britain,,,,,09/03/2018,True,True,True,False,,,The For Britain Movement For Brexit,,17/05/2019 17:03:36,31/12
+PP6661,The For Britain Movement,Political Party,Registered,Great Britain,,,,,09/03/2018,True,True,True,False,,,The For Britain Movement For Wales,,17/05/2019 17:03:36,31/12
+PP6661,The For Britain Movement,Political Party,Registered,Great Britain,,,,,09/03/2018,True,True,True,False,,,"The For Britain Movement, For Scotland",,17/05/2019 17:03:36,31/12
+PP6661,The For Britain Movement,Political Party,Registered,Great Britain,,,,,09/03/2018,True,True,True,False,,,"The For Britain Movement, For Freedom",,17/05/2019 17:03:36,31/12
+PP6661,The For Britain Movement,Political Party,Registered,Great Britain,,,,,09/03/2018,True,True,True,False,,,"The For Britain Movement, For Democracy",,17/05/2019 17:03:36,31/12
+PP6661,The For Britain Movement,Political Party,Registered,Great Britain,,,,,09/03/2018,True,True,True,False,,,"The For Britain Movement, For London",,17/05/2019 17:03:36,31/12
+PP6661,The For Britain Movement,Political Party,Registered,Great Britain,,,,,09/03/2018,True,True,True,False,,,The For Britain Movement: For Sovereignty,,17/05/2019 17:03:36,31/12
+PP6661,The For Britain Movement,Political Party,Registered,Great Britain,,,,,09/03/2018,True,True,True,False,,,"The For Britain Movement, For Liberty",,17/05/2019 17:03:36,31/12
+PP6661,The For Britain Movement,Political Party,Registered,Great Britain,,,,,09/03/2018,True,True,True,False,,,"The For Britain Movement, For Yorkshire",,17/05/2019 17:03:36,31/12
+PP6661,The For Britain Movement,Political Party,Registered,Great Britain,,,,,09/03/2018,True,True,True,False,,,"The For Britain Movement, For Justice",,17/05/2019 17:03:36,31/12
+PP6661,The For Britain Movement,Political Party,Registered,Great Britain,,,,,09/03/2018,True,True,True,False,,,"The For Britain Movement, For England",,17/05/2019 17:03:36,31/12
+PP6661,The For Britain Movement,Political Party,Registered,Great Britain,,,,,09/03/2018,True,True,True,False,,,"The For Britain Movement, For Truth",,17/05/2019 17:03:36,31/12
+PPm6366,The Haswells Community Party,Minor Party,Registered,,,,,,20/03/2017,True,False,False,True,,,,,,
+PP902,The House Party - Homes For Londoners,Political Party,Registered,Great Britain,,,,,02/02/2011,True,True,True,False,,,,,,31/12
+PP865,The Justice & Anti-Corruption Party,Political Party,Registered,Great Britain,,,,,13/04/2010,True,True,True,False,,,,,,31/12
+PP54,The Liberal Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Liberal Party Councillor For Re-election,,02/02/2001 00:00:00,31/12
+PP54,The Liberal Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Liberal Party Candidate And Local Resident,,02/02/2001 00:00:00,31/12
+PP54,The Liberal Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Liberal Party - Keep It Local,,02/02/2001 00:00:00,31/12
+PP54,The Liberal Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Liberal Party - Our Local Voice,,02/02/2001 00:00:00,31/12
+PP54,The Liberal Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Liberal Party In Scotland,,02/02/2001 00:00:00,31/12
+PP54,The Liberal Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Liberal Party In Wales,Y Blaid Ryddfrydol Yng Nghymru,02/02/2001 00:00:00,31/12
+PP54,The Liberal Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Liberal Party In Cornwall,Bagas Larch Kernow,02/02/2001 00:00:00,31/12
+PP54,The Liberal Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Liberal Party - Steve Radford's Candidate,,02/02/2001 00:00:00,31/12
+PP54,The Liberal Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Liberal Party – Keep Local Liberal Team,,16/03/2011 16:45:51,31/12
+PP54,The Liberal Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Liberal Party – Against Coalition Cutbacks,,16/03/2011 16:45:51,31/12
+PP54,The Liberal Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,The Liberal Party Candidate,,16/03/2011 16:45:51,31/12
+PP54,The Liberal Party,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,Your Local Liberal Party,,21/01/2021 12:08:46,31/12
+PP2692,The Local Party,Political Party,Registered,Great Britain,,,,,17/03/2015,True,True,True,False,,,,,,31/12
+PP9210,The Migrant Party,Political Party,Registered,Great Britain,,,,,10/09/2019,True,False,False,False,,,,,,31/8
+PP1701,The Moderate Group,Political Party,Registered,Great Britain,,,,,14/03/2011,True,False,False,False,,,A Moderate Group Independent,,29/07/2015 14:09:07,31/12
+PP1701,The Moderate Group,Political Party,Registered,Great Britain,,,,,14/03/2011,True,False,False,False,,,Candidate for the Moderate Group,,29/07/2015 14:09:07,31/12
+PP1701,The Moderate Group,Political Party,Registered,Great Britain,,,,,14/03/2011,True,False,False,False,,,The Moderate Party,,13/01/2016 17:32:19,31/12
+PP1701,The Moderate Group,Political Party,Registered,Great Britain,,,,,14/03/2011,True,False,False,False,,,A Moderate Group Associate,,13/01/2016 17:32:19,31/12
+PP1701,The Moderate Group,Political Party,Registered,Great Britain,,,,,14/03/2011,True,False,False,False,,,Moderate Group,,13/01/2016 17:32:19,31/12
+PP20,The Molesey Residents Association,Political Party,Registered,Great Britain,,,,,10/11/1999,True,False,False,False,,,Esher and Molesey Residents' Associations (Joint Description with Esher Residents Association),,02/02/2001 00:00:00,31/12
+PP2303,The North East Party,Political Party,Registered,Great Britain,,,,,15/05/2014,True,False,False,False,,,,,,31/12
+PP886,The Party for Poole People Ltd.,Political Party,Registered,Great Britain,,,,,06/10/2010,True,False,False,False,,,Poole People - Working for Poole,,06/10/2010 00:00:00,31/12
+PP886,The Party for Poole People Ltd.,Political Party,Registered,Great Britain,,,,,06/10/2010,True,False,False,False,,,Poole People - Delivering for Poole,,06/10/2010 00:00:00,31/12
+PP886,The Party for Poole People Ltd.,Political Party,Registered,Great Britain,,,,,06/10/2010,True,False,False,False,,,Poole People - Standing up for Parkstone,,06/10/2010 00:00:00,31/12
+PP886,The Party for Poole People Ltd.,Political Party,Registered,Great Britain,,,,,06/10/2010,True,False,False,False,,,Poole People - Fighting for Poole,,06/10/2010 00:00:00,31/12
+PP886,The Party for Poole People Ltd.,Political Party,Registered,Great Britain,,,,,06/10/2010,True,False,False,False,,,Poole People - Working for Oakdale,,06/10/2010 00:00:00,31/12
+PP886,The Party for Poole People Ltd.,Political Party,Registered,Great Britain,,,,,06/10/2010,True,False,False,False,,,Poole People - Putting Poole first,,06/10/2010 00:00:00,31/12
+PP886,The Party for Poole People Ltd.,Political Party,Registered,Great Britain,,,,,06/10/2010,True,False,False,False,,,Poole People - Working for Hamworthy,,06/10/2010 00:00:00,31/12
+PP886,The Party for Poole People Ltd.,Political Party,Registered,Great Britain,,,,,06/10/2010,True,False,False,False,,,Poole People - It's time for change,,06/10/2010 00:00:00,31/12
+PP886,The Party for Poole People Ltd.,Political Party,Registered,Great Britain,,,,,06/10/2010,True,False,False,False,,,Poole People - independent and local,,25/03/2015 18:17:45,31/12
+PP886,The Party for Poole People Ltd.,Political Party,Registered,Great Britain,,,,,06/10/2010,True,False,False,False,,,Poole People - Working for Parkstone,,25/03/2015 18:17:45,31/12
+PP886,The Party for Poole People Ltd.,Political Party,Registered,Great Britain,,,,,06/10/2010,True,False,False,False,,,Poole People - the Borough's independent party,,25/03/2015 18:17:45,31/12
+PP2168,The Party Party,Political Party,Registered,Great Britain,,,,,19/11/2013,True,True,True,False,,,,,,31/12
+PP133,"The Peace Party - Non-violence, Justice, Environment",Political Party,Registered,Great Britain,,,,,15/03/2001,True,True,True,False,,,,,,31/12
+PP378,The Peoples Party For Better Government,Political Party,Registered,Great Britain,,,,,01/04/2004,True,True,True,False,,,,,,31/12
+PP12716,The Phoenix Political Party,Political Party,Registered,Great Britain,,,,,02/03/2021,True,True,True,False,,,,,,31/12
+PP2729,The Protest Party,Political Party,Registered,Great Britain,,,,,07/04/2015,True,True,True,False,,,,,,31/12
+PP1871,The Realists' Party,Political Party,Registered,Great Britain,,,,,16/02/2012,True,True,True,False,,,,,,31/12
+PP9050,The Reclaim Party,Political Party,Registered,Great Britain,,,,,13/03/2019,True,True,True,False,,,,,,31/12
+PP1722,The Republican Socialist Party,Political Party,Registered,Great Britain,,,,,31/03/2011,True,True,True,False,,,Republican Socialist Party,,31/03/2011 16:05:00,31/12
+PP1722,The Republican Socialist Party,Political Party,Registered,Great Britain,,,,,31/03/2011,True,True,True,False,,,Bermondsey Republican Socialists,,31/03/2011 16:05:00,31/12
+PP1722,The Republican Socialist Party,Political Party,Registered,Great Britain,,,,,31/03/2011,True,True,True,False,,,Republican Socialist,,31/03/2015 19:25:51,31/12
+PP1722,The Republican Socialist Party,Political Party,Registered,Great Britain,,,,,31/03/2011,True,True,True,False,,,Republican Socialist (Scotland),,31/03/2015 19:25:51,31/12
+PP1722,The Republican Socialist Party,Political Party,Registered,Great Britain,,,,,31/03/2011,True,True,True,False,,,Republican Socialist (England),,31/03/2015 19:25:51,31/12
+PP1722,The Republican Socialist Party,Political Party,Registered,Great Britain,,,,,31/03/2011,True,True,True,False,,,Republican Socialist (Wales),Sosialydd Gweriniaethol (Cymru),31/03/2015 19:25:51,31/12
+PP6383,The Rubbish Party,Political Party,Registered,Great Britain,,,,,27/03/2017,False,True,False,False,,,,,,31/12
+PP6680,The Sensible Party,Political Party,Registered,Great Britain,,,,,22/01/2018,True,False,False,False,,,,,,31/12
+PP110,The Socialist Party of Great Britain,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,The Socialist Party (GB),,02/02/2001 00:00:00,31/12
+PP110,The Socialist Party of Great Britain,Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,The Socialist Party (SP-GB),,09/02/2016 15:26:28,31/12
+PP2027,The Spitfire Party,Political Party,Registered,Great Britain,,,,,13/02/2013,True,True,True,False,,,,,,31/12
+PP10240,The Universal Good Party,Political Party,Registered,Great Britain,,,,,01/10/2019,True,True,True,False,,,TUGP The Universal Good Party,,01/10/2019 16:45:55,31/12
+PP10240,The Universal Good Party,Political Party,Registered,Great Britain,,,,,01/10/2019,True,True,True,False,,,Tranformation by The Universal Good Party,,01/10/2019 16:45:55,31/12
+PP10240,The Universal Good Party,Political Party,Registered,Great Britain,,,,,01/10/2019,True,True,True,False,,,The Universal Good Party - Great Neighbours,,01/10/2019 16:45:55,31/12
+PP10240,The Universal Good Party,Political Party,Registered,Great Britain,,,,,01/10/2019,True,True,True,False,,,The Universal Good Party - Great Servants,,01/10/2019 16:45:55,31/12
+PP10240,The Universal Good Party,Political Party,Registered,Great Britain,,,,,01/10/2019,True,True,True,False,,,The Universal Good Party - Great Givers,,01/10/2019 16:45:55,31/12
+PP10240,The Universal Good Party,Political Party,Registered,Great Britain,,,,,01/10/2019,True,True,True,False,,,The Universal Good Party - Great Ancestors,,25/02/2020 16:34:13,31/12
+PP75,The Walton Society,Political Party,Registered,Great Britain,,,,,29/12/1999,True,False,False,False,,,,,,31/3
+PP2380,The Whig Party,Political Party,Registered,Great Britain,,,,,15/09/2014,True,True,True,False,,,Whig Party Candidate,,13/02/2015 10:45:21,31/12
+PP127,The Workers Party,Political Party,Registered,Northern Ireland,,,,,15/03/2001,False,False,False,False,,,,,,31/12
+PP296,Thornaby Independent Association,Political Party,Registered,Great Britain,,,,,14/03/2003,True,False,False,False,,,,,,31/12
+PP6707,Thurrock Independents,Political Party,Registered,Great Britain,,,,,16/02/2018,True,False,False,False,,,,,,31/12
+PP11469,Time Party,Political Party,Registered,Great Britain,,,,,18/03/2020,True,True,True,False,,,Time - Empowering The People,,18/03/2020 14:41:22,31/12
+PP11469,Time Party,Political Party,Registered,Great Britain,,,,,18/03/2020,True,True,True,False,,,Time - People Before Politics,,17/03/2021 20:42:29,31/12
+PP11469,Time Party,Political Party,Registered,Great Britain,,,,,18/03/2020,True,True,True,False,,,Time - People Not Politics,,17/03/2021 20:42:29,31/12
+PP11469,Time Party,Political Party,Registered,Great Britain,,,,,18/03/2020,True,True,True,False,,,Time - Setting The Standard,,17/03/2021 20:42:29,31/12
+PP10355,Tomorrow's World Order,Political Party,Registered,Great Britain,,,,,26/06/2020,True,True,True,False,,,,,,31/12
+PP6431,Touch Love Worldwide (UK),Political Party,Registered,Great Britain,,,,,03/11/2017,True,True,True,False,,,,,,31/12
+PP804,Trade Unionist and Socialist Coalition,Political Party,Registered,Great Britain,,,,,27/01/2010,True,True,True,False,,,Trade Unionist and Socialist Candidate,,27/01/2010 00:00:00,31/12
+PP804,Trade Unionist and Socialist Coalition,Political Party,Registered,Great Britain,,,,,27/01/2010,True,True,True,False,,,Scottish Trade Unionist and Socialist Coalition,,27/01/2010 00:00:00,31/12
+PP804,Trade Unionist and Socialist Coalition,Political Party,Registered,Great Britain,,,,,27/01/2010,True,True,True,False,,,Welsh Trade Unionist and Socialist Coalition,,27/01/2010 00:00:00,31/12
+PP804,Trade Unionist and Socialist Coalition,Political Party,Registered,Great Britain,,,,,27/01/2010,True,True,True,False,,,Carlisle Socialist and Trade Union Candidate,,27/01/2010 00:00:00,31/12
+PP804,Trade Unionist and Socialist Coalition,Political Party,Registered,Great Britain,,,,,27/01/2010,True,True,True,False,,,Trade Unionists and Socialists Against Cuts,,09/03/2011 18:38:14,31/12
+PP804,Trade Unionist and Socialist Coalition,Political Party,Registered,Great Britain,,,,,27/01/2010,True,True,True,False,,,Left Unity - Trade Unionists and Socialists (Joint Description with Left Unity),,23/02/2015 21:36:49,31/12
+PP804,Trade Unionist and Socialist Coalition,Political Party,Registered,Great Britain,,,,,27/01/2010,True,True,True,False,,,Walsall Socialist and Trade Union Candidate,,31/03/2015 18:50:43,31/12
+PP804,Trade Unionist and Socialist Coalition,Political Party,Registered,Great Britain,,,,,27/01/2010,True,True,True,False,,,Dundee Against Cuts – TUSC,,30/01/2017 14:29:12,31/12
+PP680,Traditional Unionist Voice - TUV,Political Party,Registered,Northern Ireland,,,,,10/10/2007,False,False,False,False,,,,,,31/12
+PP2693,Transhumanist Party,Political Party,Registered,Great Britain,,,,,12/06/2015,True,True,True,False,,,,,,31/12
+PP710,True Democracy Party,Political Party,Registered,Great Britain,,,,,28/03/2008,True,True,True,False,,,,,,31/12
+PP6711,Tunbridge Wells Alliance,Political Party,Registered,Great Britain,,,,,26/02/2018,True,False,False,False,,,,,,31/12
+PP9060,UK European Union Party (UKEUP),Political Party,Registered,Great Britain,,,,,18/04/2019,True,True,True,False,,,Remain !  UK EU Party,,18/04/2019 10:31:39,31/12
+PP9060,UK European Union Party (UKEUP),Political Party,Registered,Great Britain,,,,,18/04/2019,True,True,True,False,,,UK EU Party,,18/04/2019 10:31:39,31/12
+PP85,UK Independence Party (UKIP),Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,UK Independence Party,Plaid Annibyniaeth y DU,02/02/2001 00:00:00,31/12
+PP85,UK Independence Party (UKIP),Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,UKIP,UKIP,02/02/2001 00:00:00,31/12
+PP85,UK Independence Party (UKIP),Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,UKIP Wales,UKIP Cymru,02/02/2001 00:00:00,31/12
+PP85,UK Independence Party (UKIP),Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,UKIP - Scrap HS2,,02/02/2001 00:00:00,31/12
+PP85,UK Independence Party (UKIP),Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,United Kingdom Independence Party,,02/02/2001 00:00:00,31/12
+PP85,UK Independence Party (UKIP),Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,UKIP Scotland,,26/10/2015 17:48:02,31/12
+PP85,UK Independence Party (UKIP),Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,UKIP Make Brexit Happen,,11/12/2018 16:30:46,31/12
+PP85,UK Independence Party (UKIP),Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,UKIP Scrap The Senedd,,07/01/2021 17:08:30,31/12
+PP85,UK Independence Party (UKIP),Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,UKIP Scrap The Assembly/Senedd,,07/01/2021 17:08:30,31/12
+PP85,UK Independence Party (UKIP),Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,UKIP Save Britain,,07/01/2021 17:08:30,31/12
+PP85,UK Independence Party (UKIP),Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,UKIP - NO to SNP,,09/02/2021 12:23:00,31/12
+PP85,UK Independence Party (UKIP),Political Party,Registered,Great Britain,,,,,25/02/1999,True,True,True,False,,,UKIP - Get rid of Holyrood,,09/02/2021 12:23:00,31/12
+PP84,UK Independence Party (UKIP),Political Party,Registered,Northern Ireland,,,,,16/02/2001,False,False,False,False,,,United Kingdom Independence Party,,02/02/2001 00:00:00,31/12
+PP84,UK Independence Party (UKIP),Political Party,Registered,Northern Ireland,,,,,16/02/2001,False,False,False,False,,,UKIP,,22/02/2016 11:46:17,31/12
+PP84,UK Independence Party (UKIP),Political Party,Registered,Northern Ireland,,,,,16/02/2001,False,False,False,False,,,UKIP Northern Ireland,,22/02/2016 11:46:17,31/12
+PP84,UK Independence Party (UKIP),Political Party,Registered,Northern Ireland,,,,,16/02/2001,False,False,False,False,,,UKIP - UK Unionists,,19/03/2019 16:56:51,31/12
+PP84,UK Independence Party (UKIP),Political Party,Registered,Northern Ireland,,,,,16/02/2001,False,False,False,False,,,UKIP - For The Union,,19/03/2019 16:56:51,31/12
+PP84,UK Independence Party (UKIP),Political Party,Registered,Northern Ireland,,,,,16/02/2001,False,False,False,False,,,UKIP - Unionists For Brexit,,19/03/2019 16:56:51,31/12
+PP2482,UK Meritocracy Party,Political Party,Registered,Great Britain,,,,,04/11/2014,True,False,True,False,,,,,,31/12
+PP9053,UK Voice,Political Party,Registered,Great Britain,,,,,23/06/2020,True,True,True,False,,,UK VOICE safer and stronger UK,,23/06/2020 12:22:12,31/12
+PP9058,UK Voice,Political Party,Registered,Northern Ireland,,,,,23/06/2020,False,False,False,False,,,UK VOICE safer and stronger UK,,23/06/2020 11:57:59,31/12
+PP83,Ulster Unionist Party,Political Party,Registered,Northern Ireland,,,,,14/01/1999,False,False,False,False,,,,,,31/12
+PP5273,United Kingdom Liberty Party,Political Party,Registered,Great Britain,,,,,06/10/2016,True,True,True,False,,,UK Liberty Party,,04/07/2019 16:27:04,31/12
+PP649,Unity For Peace And Socialism,Political Party,Registered,Great Britain,,,,,19/03/2007,True,True,True,False,,,,,,31/12
+PP5299,Uplands,Political Party,Registered,Great Britain,,,,,30/11/2016,False,False,True,False,,,,,,31/12
+PP30,Upminster and Cranham Residents Association,Political Party,Registered,Great Britain,,,,,16/03/2000,True,False,False,False,,,,,,31/12
+PP11399,Vanguard Party,Political Party,Registered,Great Britain,,,,,05/05/2020,True,True,True,False,,,Vanguard Party four Nations in Union,,13/01/2021 16:43:35,31/12
+PP11399,Vanguard Party,Political Party,Registered,Great Britain,,,,,05/05/2020,True,True,True,False,,,Vanguard Party championing social conservatism,,13/01/2021 16:43:35,31/12
+PP11399,Vanguard Party,Political Party,Registered,Great Britain,,,,,05/05/2020,True,True,True,False,,,Scottish Vanguard Party,,05/05/2020 15:54:17,31/12
+PP11399,Vanguard Party,Political Party,Registered,Great Britain,,,,,05/05/2020,True,True,True,False,,,Welsh Vanguard Party,,05/05/2020 15:54:17,31/12
+PP11399,Vanguard Party,Political Party,Registered,Great Britain,,,,,05/05/2020,True,True,True,False,,,Scottish Vanguard Party candidate,,05/05/2020 15:54:17,31/12
+PP11399,Vanguard Party,Political Party,Registered,Great Britain,,,,,05/05/2020,True,True,True,False,,,Welsh Vanguard Party candidate,,05/05/2020 15:54:17,31/12
+PP11399,Vanguard Party,Political Party,Registered,Great Britain,,,,,05/05/2020,True,True,True,False,,,Vanguard Party champion for the Union,,30/06/2020 21:57:05,31/12
+PP11399,Vanguard Party,Political Party,Registered,Great Britain,,,,,05/05/2020,True,True,True,False,,,Vanguard Party champion for proportional representation,,30/06/2020 21:57:05,31/12
+PP11399,Vanguard Party,Political Party,Registered,Great Britain,,,,,05/05/2020,True,True,True,False,,,Vanguard Party champion for regional regeneration,,30/06/2020 21:57:05,31/12
+PP11399,Vanguard Party,Political Party,Registered,Great Britain,,,,,05/05/2020,True,True,True,False,,,Vanguard Party champion for traditional values,,30/06/2020 21:57:05,31/12
+PP11399,Vanguard Party,Political Party,Registered,Great Britain,,,,,05/05/2020,True,True,True,False,,,Vanguard Party championing Rule of Law,,20/08/2020 18:52:08,31/12
+PP11399,Vanguard Party,Political Party,Registered,Great Britain,,,,,05/05/2020,True,True,True,False,,,Vanguard Party championing Freedom of Speech,,20/08/2020 18:52:08,31/12
+PP12581,Vectis Party,Political Party,Registered,Great Britain,,,,,27/11/2020,True,False,False,False,,,Vectis Party – For the Island,,27/11/2020 14:52:33,31/12
+PP12581,Vectis Party,Political Party,Registered,Great Britain,,,,,27/11/2020,True,False,False,False,,,Vectis Party – Proud of the Island,,27/11/2020 14:52:33,31/12
+PP12581,Vectis Party,Political Party,Registered,Great Britain,,,,,27/11/2020,True,False,False,False,,,Vectis Party – Stop over-development,,27/11/2020 14:52:33,31/12
+PP12581,Vectis Party,Political Party,Registered,Great Britain,,,,,27/11/2020,True,False,False,False,,,Vectis Party – Better healthcare now,,27/11/2020 14:52:33,31/12
+PP12581,Vectis Party,Political Party,Registered,Great Britain,,,,,27/11/2020,True,False,False,False,,,Vectis Party – Subsidise mainland hospital travel,,27/11/2020 14:52:33,31/12
+PP12581,Vectis Party,Political Party,Registered,Great Britain,,,,,27/11/2020,True,False,False,False,,,Vectis Party – Protect green fields,,27/11/2020 14:52:33,31/12
+PP12581,Vectis Party,Political Party,Registered,Great Britain,,,,,27/11/2020,True,False,False,False,,,Vectis Party – For jobs and careers,,27/11/2020 14:52:33,31/12
+PP12581,Vectis Party,Political Party,Registered,Great Britain,,,,,27/11/2020,True,False,False,False,,,Vectis Party – Care for our elderly,,27/11/2020 14:52:33,31/12
+PP12581,Vectis Party,Political Party,Registered,Great Britain,,,,,27/11/2020,True,False,False,False,,,Vectis Party – Care for our environment,,27/11/2020 14:52:33,31/12
+PP12581,Vectis Party,Political Party,Registered,Great Britain,,,,,27/11/2020,True,False,False,False,,,Vectis Party – For Vectis People,,27/11/2020 14:52:33,31/12
+PP12581,Vectis Party,Political Party,Registered,Great Britain,,,,,27/11/2020,True,False,False,False,,,Vectis Party – Supporting younger Islanders,,27/11/2020 14:52:33,31/12
+PP12581,Vectis Party,Political Party,Registered,Great Britain,,,,,27/11/2020,True,False,False,False,,,"Vectis Party – Local control, local decisions",,27/11/2020 14:52:33,31/12
+PP6719,Veterans and People’s Party,Political Party,Registered,Great Britain,,,,,31/01/2018,True,True,True,False,,,UK Veterans’ and People’s Party,,31/01/2018 15:42:01,31/12
+PP6719,Veterans and People’s Party,Political Party,Registered,Great Britain,,,,,31/01/2018,True,True,True,False,,,Hartlepool Veterans' and People's Party,,25/05/2021 11:22:30,31/12
+PP6721,Veterans and People’s Party,Political Party,Registered,Northern Ireland,,,,,31/01/2018,False,False,False,False,,,UK Veterans’ and People’s Party,,31/01/2018 16:48:52,31/12
+PP8009,Volt United Kingdom,Political Party,Registered,Great Britain,,,,,06/01/2020,True,True,True,False,,,Volt UK - The Pan-European Party,,06/01/2020 16:39:20,31/12
+PP8009,Volt United Kingdom,Political Party,Registered,Great Britain,,,,,06/01/2020,True,True,True,False,,,Volt UK - The UK in Europe,,06/01/2020 16:39:20,31/12
+PP2086,Vote Roehampton,Political Party,Registered,Great Britain,,,,,03/07/2013,True,False,False,False,,,"Vote Roehampton, Putney Heath, Putney Vale",,03/07/2013 14:00:39,31/12
+PP2086,Vote Roehampton,Political Party,Registered,Great Britain,,,,,03/07/2013,True,False,False,False,,,"Vote Roehampton: local, independent, hardworking, honest",,03/07/2013 14:00:39,31/12
+PP2086,Vote Roehampton,Political Party,Registered,Great Britain,,,,,03/07/2013,True,False,False,False,,,Vote Roehampton: Your local candidates,,03/07/2013 14:00:39,31/12
+PP2086,Vote Roehampton,Political Party,Registered,Great Britain,,,,,03/07/2013,True,False,False,False,,,vote Roehampton candidate 1 of 2,,28/01/2014 16:04:49,31/12
+PP2086,Vote Roehampton,Political Party,Registered,Great Britain,,,,,03/07/2013,True,False,False,False,,,vote Roehampton candidate 2 of 2,,28/01/2014 16:04:49,31/12
+PP2086,Vote Roehampton,Political Party,Registered,Great Britain,,,,,03/07/2013,True,False,False,False,,,"vote Roehampton: local, hardworking, independent",,28/01/2014 16:04:49,31/12
+PP2600,Vox Pop,Political Party,Registered,Great Britain,,,,,17/03/2015,True,True,True,False,,,Voxpop The Voice of The People,,17/03/2015 09:36:05,31/12
+PP12728,We Matter Party,Political Party,Registered,Great Britain,,,,,09/03/2021,True,False,False,False,,,,,,31/12
+PPm6588,Wells Independents,Minor Party,Registered,,,,,,07/08/2017,True,False,False,True,,,Think local vote local - Wells Independents,,10/11/2017 14:16:50,
+PP1995,Welwyn Garden City Party,Political Party,Registered,Great Britain,,,,,26/02/2013,True,False,False,False,,,,,,31/12
+PP4039,Werrington First,Political Party,Registered,Great Britain,,,,,14/03/2016,True,False,False,False,,,Werrington First Independent,,14/03/2016 17:27:07,31/12
+PP4039,Werrington First,Political Party,Registered,Great Britain,,,,,14/03/2016,True,False,False,False,,,Werrington First Independents,,14/03/2016 17:27:07,31/12
+PP95,Wessex Regionalists,Political Party,Registered,Great Britain,,,,,25/06/1999,True,False,False,False,,,,,,31/12
+PP12799,West Dunbartonshire Community Party,Political Party,Registered,Great Britain,,,,,26/05/2021,False,True,False,False,,,The West Dunbartonshire Community Party,,26/05/2021 15:12:21,31/12
+PP2353,West Suffolk Independents,Political Party,Registered,Great Britain,,,,,04/09/2014,True,False,False,False,,,West Suffolk Independent,,04/09/2014 16:37:43,1/1
+PP6402,West Windsor Residents Association,Political Party,Registered,Great Britain,,,,,17/08/2017,True,False,False,False,,,West Windsor Residents Association (WWRA),,30/10/2017 14:47:36,31/12
+PP9067,Westhoughton First Independents,Political Party,Registered,Great Britain,,,,,20/03/2019,True,False,False,False,,,,,,31/12
+PP49,Weybridge & St. George's Independents,Political Party,Registered,Great Britain,,,,,16/03/2000,True,False,False,False,,,,,,31/12
+PP12702,Whitehill & Bordon Community Party,Political Party,Registered,Great Britain,,,,,08/02/2021,True,False,False,False,,,"Whitehill, Bordon & Lindford Community",,08/02/2021 19:17:28,31/12
+PP12702,Whitehill & Bordon Community Party,Political Party,Registered,Great Britain,,,,,08/02/2021,True,False,False,False,,,Whitehill & Bordon Community,,08/02/2021 19:17:28,31/12
+PP12702,Whitehill & Bordon Community Party,Political Party,Registered,Great Britain,,,,,08/02/2021,True,False,False,False,,,Whitehill Community,,08/02/2021 19:17:28,31/12
+PP12702,Whitehill & Bordon Community Party,Political Party,Registered,Great Britain,,,,,08/02/2021,True,False,False,False,,,Bordon Community,,08/02/2021 19:17:28,31/12
+PP129,Whitnash Residents Association,Political Party,Registered,Great Britain,,,,,30/03/2001,True,False,False,False,,,,,,31/12
+PP6679,Wickford Independents,Political Party,Registered,Great Britain,,,,,16/02/2018,True,False,False,False,,,Wickford Independents Free of Party Politics,,16/02/2018 12:57:34,31/12
+PP4047,Winchester Independents,Political Party,Registered,Great Britain,,,,,23/03/2016,True,False,False,False,,,,,,31/12
+PP2755,Women's Equality Party,Political Party,Registered,Great Britain,,,,,20/07/2015,True,True,True,False,,,Vote Women's Equality Party on orange,,15/04/2020 11:35:18,31/12
+PP11382,Workers Party of Britain,Political Party,Registered,Great Britain,,,,,22/04/2020,True,True,True,False,,,Workers Party,,22/04/2020 10:46:31,31/12
+PP11382,Workers Party of Britain,Political Party,Registered,Great Britain,,,,,22/04/2020,True,True,True,False,,,Workers Party - Birmingham,,22/04/2020 10:46:31,31/12
+PP11382,Workers Party of Britain,Political Party,Registered,Great Britain,,,,,22/04/2020,True,True,True,False,,,Workers Party - London,,22/04/2020 10:46:31,31/12
+PP11382,Workers Party of Britain,Political Party,Registered,Great Britain,,,,,22/04/2020,True,True,True,False,,,Workers Party of Britain (WPB),,04/06/2021 11:42:11,31/12
+PP184,Workers Revolutionary Party,Political Party,Registered,Great Britain,,,,,15/05/2001,True,False,False,False,,,,,,31/12
+PP2601,Wycombe Independents,Political Party,Registered,Great Britain,,,,,18/03/2015,True,False,False,False,,,East Wycombe Independent Candidate,,18/03/2015 17:06:24,31/12
+PP2601,Wycombe Independents,Political Party,Registered,Great Britain,,,,,18/03/2015,True,False,False,False,,,Independent Candidate for Micklefield,,18/03/2015 17:06:24,31/12
+PP2601,Wycombe Independents,Political Party,Registered,Great Britain,,,,,18/03/2015,True,False,False,False,,,Independent Candidate for Totteridge,,18/03/2015 17:06:24,31/12
+PP2601,Wycombe Independents,Political Party,Registered,Great Britain,,,,,18/03/2015,True,False,False,False,,,Independent Candidate for Bowerdean,,18/03/2015 17:06:24,31/12
+PP2601,Wycombe Independents,Political Party,Registered,Great Britain,,,,,18/03/2015,True,False,False,False,,,Independent Candidate for your community,,18/03/2015 17:06:24,31/12
+PP2601,Wycombe Independents,Political Party,Registered,Great Britain,,,,,18/03/2015,True,False,False,False,,,Working for Bowerdean all year round,,18/03/2015 17:06:24,31/12
+PP2601,Wycombe Independents,Political Party,Registered,Great Britain,,,,,18/03/2015,True,False,False,False,,,Working for Micklefield all year round,,18/03/2015 17:06:24,31/12
+PP2601,Wycombe Independents,Political Party,Registered,Great Britain,,,,,18/03/2015,True,False,False,False,,,Working for Totteridge all year round,,18/03/2015 17:06:24,31/12
+PP2601,Wycombe Independents,Political Party,Registered,Great Britain,,,,,18/03/2015,True,False,False,False,,,East Wycombe Independents working for Micklefield,,18/03/2015 17:06:24,31/12
+PP2601,Wycombe Independents,Political Party,Registered,Great Britain,,,,,18/03/2015,True,False,False,False,,,East Wycombe Independents working for Totteridge,,18/03/2015 17:06:24,31/12
+PP2601,Wycombe Independents,Political Party,Registered,Great Britain,,,,,18/03/2015,True,False,False,False,,,East Wycombe Independents working for Bowerdean,,18/03/2015 17:06:24,31/12
+PP279,Wythall Residents' Association,Political Party,Registered,Great Britain,,,,,19/02/2003,True,False,False,False,,,,,,31/12
+PP730,Yes 2 Europe,Political Party,Registered,Great Britain,,,,,19/09/2008,True,True,True,False,,,,,,31/12
+PP6533,Yeshua,Political Party,Registered,Great Britain,,,,,18/01/2018,True,True,True,False,,,,,,31/12
+PP2055,Yorkshire Party,Political Party,Registered,Great Britain,,,,,12/06/2013,True,False,False,False,,,Yorkshire Party,,22/08/2016 17:08:28,31/12
+PP2055,Yorkshire Party,Political Party,Registered,Great Britain,,,,,12/06/2013,True,False,False,False,,,Your local Yorkshire Party candidate,,22/08/2016 17:08:28,31/12
+PP2055,Yorkshire Party,Political Party,Registered,Great Britain,,,,,12/06/2013,True,False,False,False,,,Yorkshire Party - save our Greenbelt,,12/09/2017 12:44:01,31/12
+PP2055,Yorkshire Party,Political Party,Registered,Great Britain,,,,,12/06/2013,True,False,False,False,,,Your Yorkshire Party Mayoral candidate,,12/09/2017 12:44:01,31/12
+PP2055,Yorkshire Party,Political Party,Registered,Great Britain,,,,,12/06/2013,True,False,False,False,,,Yorkshire Party - Speaking up for Yorkshire,,12/09/2017 12:44:01,31/12
+PP2055,Yorkshire Party,Political Party,Registered,Great Britain,,,,,12/06/2013,True,False,False,False,,,Yorkshire Party - invest in our schools,,12/09/2017 12:44:01,31/12
+PP1912,Young People's Party YPP,Political Party,Registered,Great Britain,,,,,06/06/2012,True,True,True,False,,,Young People's Party YPP,,06/06/2012 16:13:17,31/12
+PP1912,Young People's Party YPP,Political Party,Registered,Great Britain,,,,,06/06/2012,True,True,True,False,,,Young People's Party,,06/06/2012 16:13:17,31/12
+PP1912,Young People's Party YPP,Political Party,Registered,Great Britain,,,,,06/06/2012,True,True,True,False,,,YPP Young People's Party,,06/06/2012 16:13:17,31/12
+PP1912,Young People's Party YPP,Political Party,Registered,Great Britain,,,,,06/06/2012,True,True,True,False,,,The Young People's Party,,06/06/2012 16:13:17,31/12
+PP1912,Young People's Party YPP,Political Party,Registered,Great Britain,,,,,06/06/2012,True,True,True,False,,,Young People's Party UK,,06/06/2012 16:13:17,31/12
+PP2300,Yourvoice,Political Party,Registered,Great Britain,,,,,17/03/2014,True,True,True,False,,,,,,31/12
+PP1949,Zero Tolerance Policing ex  Chief,Political Party,Registered,Great Britain,,,,,10/10/2012,True,False,False,False,,,,,,31/12

--- a/db/fixtures/electoral_commission_parties.rb
+++ b/db/fixtures/electoral_commission_parties.rb
@@ -20,7 +20,7 @@ require "csv"
 
 module Db
   module Fixtures
-    class Db::Fixtures::ElectoralCommissionParties
+    class ElectoralCommissionParties
       include Enumerable
 
       # wikipedia page at https://en.wikipedia.org/wiki/List_of_political_parties_in_the_United_Kingdom#cite_note-1
@@ -42,9 +42,8 @@ module Db
       # The EC has a concept of unique entities, so one parliamentary entity has a unique name,
       # even though it may have more than one registration (GB and NI) for that single name.
       # This returns a hash of those entities, with all their registered descriptions, and all registrations.
-      # Also, joint descriptions are collected, so that parties in permanent alliance
-      # (e.g. Labour and Co-op) can be tracked.
-      # However, this goes a bit beyond the EC modelling, and so Labour and Co-op for instance are returned as distinct
+      # Also, joint descriptions are collected, so that parties in permanent alliance can be tracked.
+      # Labour and Co-op for instance are returned as distinct
       # entities, which can be found to work together by matching their joint description.
       def unique_entities
         return @unique_entities if defined?(@unique_entities)
@@ -65,6 +64,10 @@ module Db
         end
       end
 
+      # This is unique entities, but with parties with a permanent electoral alliance
+      # (joint descriptions, e.g. Labour and Co-op) merged into one.
+      # The name given to the merged/joint party is the joint description from the EC data.
+      # Parties which do not represent merges keep the regulated entity name
       def unique_entities_joint_merged
         return @unique_entities_joint_merged if defined?(@unique_entities_joint_merged)
         @unique_entities_joint_merged = unique_entities.values.each_with_object({}) do  |p, result|
@@ -74,6 +77,10 @@ module Db
           result[name][:name] = name
           result[name][:regulated_entity_names] ||= []
           result[name][:regulated_entity_names] << p[:regulated_entity_name]
+          result[name][:descriptions] ||= []
+          result[name][:descriptions] += p[:descriptions].to_a
+          result[name][:registrations] ||= []
+          result[name][:registrations] += p[:registrations].to_a
         end
       end
 

--- a/db/fixtures/electoral_commission_parties.rb
+++ b/db/fixtures/electoral_commission_parties.rb
@@ -47,10 +47,10 @@ module Db
       # entities, which can be found to work together by matching their joint description.
       def unique_entities
         return @unique_entities if defined?(@unique_entities)
-        @unique_entities = each_with_object({}) do  |p, result|
-          name = p["RegulatedEntityName"]
-          register = p["RegisterName"] || "(none)"
-          description = p["Description"]
+        @unique_entities = each_with_object({}) do  |party, result|
+          name = party["RegulatedEntityName"]
+          register = party["RegisterName"] || "(none)"
+          description = party["Description"]
           result[name] ||= {}
 
           result[name][:regulated_entity_name] = name
@@ -58,7 +58,7 @@ module Db
           result[name][:joint_description] = description[0..(joint_match - 1)].strip if joint_match
 
           result[name][:registrations] ||= Set.new
-          result[name][:registrations] << { "RegisterName" => register,  "ECRef" => p[:ec_ref] }
+          result[name][:registrations] << { "RegisterName" => register,  "ECRef" => party[:ec_ref] }
           result[name][:descriptions] ||= Set.new
           result[name][:descriptions] << description unless description.nil?
         end
@@ -70,17 +70,17 @@ module Db
       # Parties which do not represent merges keep the regulated entity name
       def unique_entities_joint_merged
         return @unique_entities_joint_merged if defined?(@unique_entities_joint_merged)
-        @unique_entities_joint_merged = unique_entities.values.each_with_object({}) do  |p, result|
-          name = p[:joint_description] || p[:regulated_entity_name]
+        @unique_entities_joint_merged = unique_entities.values.each_with_object({}) do  |party, result|
+          name = party[:joint_description] || party[:regulated_entity_name]
           result[name] ||= {}
 
           result[name][:name] = name
           result[name][:regulated_entity_names] ||= []
-          result[name][:regulated_entity_names] << p[:regulated_entity_name]
+          result[name][:regulated_entity_names] << party[:regulated_entity_name]
           result[name][:descriptions] ||= []
-          result[name][:descriptions] += p[:descriptions].to_a
+          result[name][:descriptions] += party[:descriptions].to_a
           result[name][:registrations] ||= []
-          result[name][:registrations] += p[:registrations].to_a
+          result[name][:registrations] += party[:registrations].to_a
         end
       end
 

--- a/db/fixtures/electoral_commission_parties.rb
+++ b/db/fixtures/electoral_commission_parties.rb
@@ -27,6 +27,20 @@ class ElectoralCommissionParties
     end
   end
 
+  def unique_entities
+    each_with_object({}) do  |p, result|
+      name = p["RegulatedEntityName"]
+      register = p["RegisterName"]
+      result[name] = {} if result[name].nil?
+      result[name][:registrations] = {} if result[name][:registrations].nil?
+      result[name][:registrations][register] = p
+      result[name][:names] = [] if result[name][:names].nil?
+      result[name][:names] << name
+      result[name][:names] << p["Description"] unless p["Description"].nil?
+      result[name][:unique_entity_name] = name
+    end
+  end
+
   def find_by_name(name)
     ec_ref = index_ec_ref_by_name_or_description[name]
     return unless ec_ref

--- a/db/fixtures/electoral_commission_parties.rb
+++ b/db/fixtures/electoral_commission_parties.rb
@@ -26,12 +26,33 @@ class ElectoralCommissionParties
       #   name: data[NAME_KEY],
       # }
 
-      block.call(data.to_hash)
+      block.call(data.to_hash.merge(ec_ref: data[0])) # for some reason CSV gem doesn't get the first column  right
+    end
+  end
+
+  def unique_index_by_ec_ref
+    puts "unique_index_by_ec_ref"
+    each_with_object({}) do | party, parties_by_ec_ref |
+      ec_ref_name = party[:ec_ref]
+
+      # puts party.keys.to_s
+
+      # puts party.to_s
+
+      # ref = party["ECRef"].to_s
+
+      # puts "==ref==#{ref}===="
+
+      # puts "==:my_data==#{party[:my_data]}===="
+
+      # raise "kaboom"
+
+      parties_by_ec_ref[ec_ref_name] = party
     end
   end
 
   def index_by_entity
-    each_with_object({}) do | party, parties_by_entity |
+    unique_index_by_ec_ref.each_with_object({}) do | (_ec_ref, party), parties_by_entity |
       entity_name = party["RegulatedEntityName"]
 
       parties_by_entity[entity_name] = [] unless parties_by_entity.has_key?(entity_name)

--- a/db/fixtures/electoral_commission_parties.rb
+++ b/db/fixtures/electoral_commission_parties.rb
@@ -1,13 +1,15 @@
 require "open-uri"
+require "CSV"
 
 class ElectoralCommissionParties
+  include Enumerable
 
   # wikipedia page at https://en.wikipedia.org/wiki/List_of_political_parties_in_the_United_Kingdom#cite_note-1
   # starts with http://search.electoralcommission.org.uk/Search/Registrations?currentPage=1&rows=10&sort=RegulatedEntityName&order=asc&et=pp&et=ppm&register=gb&register=ni&register=none&regStatus=registered
   # we have tacked on getDescriptions=true and adapted the link to point to the CSV download, not the html search page
 
   URL = "http://search.electoralcommission.org.uk/api/csv/Registrations?sort=RegulatedEntityName&order=asc&et=pp&et=ppm&register=gb&register=ni&register=none&regStatus=registered&getDescriptions=true"
-  FILE = File.expand_path('./electoral_commission_parties.csv', __dir__)
+  FILE = File.expand_path("./electoral_commission_parties.csv", __dir__)
 
   class << self
     def download
@@ -17,4 +19,24 @@ class ElectoralCommissionParties
     end
   end
 
+  def each(&block)
+    CSV.foreach(FILE, headers: true, col_sep: ",") do |data|
+      # data_transformed = {
+      #   ons_id: data.to_h.values[0], # don't ask ... data[ID_KEY] should have worked
+      #   name: data[NAME_KEY],
+      # }
+
+      block.call(data.to_hash)
+    end
+  end
+
+  def index_by_entity
+    each_with_object({}) do | party, parties_by_entity |
+      entity_name = party["RegulatedEntityName"]
+
+      parties_by_entity[entity_name] = [] unless parties_by_entity.has_key?(entity_name)
+
+      parties_by_entity[entity_name] << party
+    end
+  end
 end

--- a/db/fixtures/electoral_commission_parties.rb
+++ b/db/fixtures/electoral_commission_parties.rb
@@ -1,0 +1,20 @@
+require "open-uri"
+
+class ElectoralCommissionParties
+
+  # wikipedia page at https://en.wikipedia.org/wiki/List_of_political_parties_in_the_United_Kingdom#cite_note-1
+  # starts with http://search.electoralcommission.org.uk/Search/Registrations?currentPage=1&rows=10&sort=RegulatedEntityName&order=asc&et=pp&et=ppm&register=gb&register=ni&register=none&regStatus=registered
+  # we have tacked on getDescriptions=true and adapted the link to point to the CSV download, not the html search page
+
+  URL = "http://search.electoralcommission.org.uk/api/csv/Registrations?sort=RegulatedEntityName&order=asc&et=pp&et=ppm&register=gb&register=ni&register=none&regStatus=registered&getDescriptions=true"
+  FILE = File.expand_path('./electoral_commission_parties.csv', __dir__)
+
+  class << self
+    def download
+      # ec_parties_data_as_csv = URI.open(URL).read ruby 3.0 syntax
+      ec_parties_data_as_csv = open(URL).read
+      File.write(FILE, ec_parties_data_as_csv)
+    end
+  end
+
+end

--- a/db/fixtures/electoral_commission_parties.rb
+++ b/db/fixtures/electoral_commission_parties.rb
@@ -5,8 +5,9 @@ require "CSV"
 # $ bundle exec rails c
 # > require "./db/fixtures/electoral_commission_parties"
 # > ElectoralCommissionParties.download
-# > fa_ref =  ElectoralCommissionParties.new.index_ec_ref_by_name_or_description["Freedom Alliance. Dignity and Democracy"]
-# > ElectoralCommissionParties.new.index_by_ec_ref[fa_ref]
+# > ecdata =  ElectoralCommissionParties.new
+# > ecdata.find_by_name("Liberal Democrat")
+# => {"ECRef"=>"PP90", "RegulatedEntityName"=>"Liberal Democrats", ...
 
 class ElectoralCommissionParties
   include Enumerable
@@ -24,6 +25,12 @@ class ElectoralCommissionParties
       ec_parties_data_as_csv = open(URL).read
       File.write(FILE, ec_parties_data_as_csv)
     end
+  end
+
+  def find_by_name(name)
+    ec_ref = index_ec_ref_by_name_or_description[name]
+    return unless ec_ref
+    index_by_ec_ref[ec_ref]
   end
 
   def each(&block)
@@ -48,7 +55,7 @@ class ElectoralCommissionParties
   def index_by_ec_ref
     each_with_object({}) do | party, parties_by_ec_ref |
       ec_ref = party[:ec_ref]
-      parties_by_ec_ref[ec_ref] = party unless parties_by_ec_ref.has_key?(ec_ref)
+      parties_by_ec_ref[ec_ref] = party unless parties_by_ec_ref.key?(ec_ref)
     end
   end
 

--- a/db/fixtures/electoral_commission_parties.rb
+++ b/db/fixtures/electoral_commission_parties.rb
@@ -36,6 +36,12 @@ class ElectoralCommissionParties
     end
   end
 
+  # The EC has a concept of unique entities, so one parliamentary entity has a unique name,
+  # even though it may have more # than one registration (GB and NI) for that single name.
+  # This returns a hash of those entities, with all their registered descriptions, and all registrations.
+  # Also, joint descriptions are collected, so that parties in permanent alliance (e.g. Labour and Co-op) can be tracked.
+  # However, this goes a bit beyond the EC modelling, and so Labour and Co-op for instance are returned as distinct
+  # entities, which can be found to work together by matching their joint description.
   def unique_entities
     return @unique_entities if defined?(@unique_entities)
     @unique_entities = each_with_object({}) do  |p, result|

--- a/spec/db/fixtures/electoral_commission_parties_spec.rb
+++ b/spec/db/fixtures/electoral_commission_parties_spec.rb
@@ -1,0 +1,52 @@
+require_relative "../../../db/fixtures/electoral_commission_parties"
+
+module Db
+  module Fixtures
+    RSpec.describe ElectoralCommissionParties do
+      # rubocop:disable RSpec/IteratedExpectation
+      # rubocop's recommendation doesn't improve the code in this instance and it worsens the spec output
+
+      describe "#each" do
+        describe "each register entry" do
+          specify { subject.each { |entry| expect(entry).to have_key(:ec_ref) } }
+          specify { subject.each { |entry| expect(entry).to have_key("RegulatedEntityName") } }
+          specify { subject.each { |entry| expect(entry).to have_key("RegisterName") } }
+          specify { subject.each { |entry| expect(entry).to have_key("Description") } }
+        end
+      end
+
+      describe "#unique_entities" do
+        let(:unique_entities) { described_class.new.unique_entities }
+
+        describe "Labour Party"  do
+          subject { unique_entities["Labour Party"] }
+
+          specify { expect(subject[:joint_description]).to eq("Labour and Co-operative Party") }
+          specify { expect(subject[:regulated_entity_name]).to eq("Labour Party") }
+        end
+
+        describe "Co-operative Party"  do
+          subject { unique_entities["Co-operative Party"] }
+
+          specify { expect(subject[:joint_description]).to eq("Labour and Co-operative Party") }
+          specify { expect(subject[:regulated_entity_name]).to eq("Co-operative Party") }
+        end
+
+        describe "Conservative and Unionist Party"  do
+          subject { unique_entities["Conservative and Unionist Party"] }
+
+          specify { expect(subject[:regulated_entity_name]).to eq("Conservative and Unionist Party") }
+
+          it "has two registrations, for NI and GB" do
+            registrations = subject[:registrations].to_a
+            register_names = registrations.map{ |r| r["RegisterName"] }
+
+            expect(registrations).to have_attributes(size: 2)
+            expect(register_names).to include("Great Britain")
+            expect(register_names).to include("Northern Ireland")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/db/fixtures/electoral_commission_parties_spec.rb
+++ b/spec/db/fixtures/electoral_commission_parties_spec.rb
@@ -106,7 +106,6 @@ module Db
           end
         end
 
-
         describe "Other parties in UK parliament" do
           describe "Liberal Democrats" do
             subject { joint_merged["Liberal Democrats"] }

--- a/spec/db/fixtures/electoral_commission_parties_spec.rb
+++ b/spec/db/fixtures/electoral_commission_parties_spec.rb
@@ -47,6 +47,34 @@ module Db
           end
         end
       end
+
+      describe "#unique_entities_joint_merged" do
+        let(:unique_entities_joint_merged) { described_class.new.unique_entities_joint_merged }
+
+        describe "Labour and Co-operative Party"  do
+          subject { unique_entities_joint_merged["Labour and Co-operative Party"] }
+
+          describe "name" do
+            specify { expect(subject[:name]).to eq("Labour and Co-operative Party") }
+          end
+
+          describe "regulated_entity_names" do
+            specify { expect(subject[:regulated_entity_names]).to eq(["Co-operative Party", "Labour Party"]) }
+          end
+        end
+
+        describe "Conservative and Unionist Party"  do
+          subject { unique_entities_joint_merged["Conservative and Unionist Party"] }
+
+          describe "name" do
+            specify { expect(subject[:name]).to eq("Conservative and Unionist Party") }
+          end
+
+          describe "regulated_entity_names" do
+            specify { expect(subject[:regulated_entity_names]).to eq(["Conservative and Unionist Party"]) }
+          end
+        end
+      end
     end
   end
 end

--- a/spec/db/fixtures/electoral_commission_parties_spec.rb
+++ b/spec/db/fixtures/electoral_commission_parties_spec.rb
@@ -105,6 +105,69 @@ module Db
             expect(register_names).to include("Northern Ireland")
           end
         end
+
+
+        describe "Other parties in UK parliament" do
+          describe "Liberal Democrats" do
+            subject { joint_merged["Liberal Democrats"] }
+
+            specify { expect(subject[:name]).to eq("Liberal Democrats") }
+          end
+
+          describe "Green Party" do
+            subject { joint_merged["Green Party"] }
+
+            specify { expect(subject[:name]).to eq("Green Party") }
+          end
+
+          describe "Scottish National Party (SNP)" do
+            subject { joint_merged["Scottish National Party (SNP)"] }
+
+            specify { expect(subject[:name]).to eq("Scottish National Party (SNP)") }
+          end
+
+          describe "Plaid Cymru - The Party of Wales" do
+            subject { joint_merged["Plaid Cymru - The Party of Wales"] }
+
+            specify { expect(subject[:name]).to eq("Plaid Cymru - The Party of Wales") }
+          end
+
+          describe "Reform UK" do
+            subject { joint_merged["Reform UK"] }
+
+            specify { expect(subject[:name]).to eq("Reform UK") }
+          end
+
+          describe "Democratic Unionist Party - D.U.P." do
+            subject { joint_merged["Democratic Unionist Party - D.U.P."] }
+
+            specify { expect(subject[:name]).to eq("Democratic Unionist Party - D.U.P.") }
+          end
+
+          describe "Sinn Féin" do
+            subject { joint_merged["Sinn Féin"] }
+
+            specify { expect(subject[:name]).to eq("Sinn Féin") }
+          end
+
+          describe "SDLP (Social Democratic & Labour Party)" do
+            subject { joint_merged["SDLP (Social Democratic & Labour Party)"] }
+
+            specify { expect(subject[:name]).to eq("SDLP (Social Democratic & Labour Party)") }
+          end
+
+          describe "Alliance - Alliance Party of Northern Ireland" do
+            subject { joint_merged["Alliance - Alliance Party of Northern Ireland"] }
+
+            specify { expect(subject[:name]).to eq("Alliance - Alliance Party of Northern Ireland") }
+          end
+
+          describe "Alba Party" do
+            subject { joint_merged["Alba Party"] }
+
+            specify { expect(subject[:name]).to eq("Alba Party") }
+          end
+        end
       end
     end
   end

--- a/spec/db/fixtures/electoral_commission_parties_spec.rb
+++ b/spec/db/fixtures/electoral_commission_parties_spec.rb
@@ -18,6 +18,12 @@ module Db
       describe "#unique_entities" do
         let(:unique_entities) { described_class.new.unique_entities }
 
+        describe "each entry" do
+          specify { unique_entities.each { |_, entry| expect(entry).to have_key(:regulated_entity_name) } }
+          specify { unique_entities.each { |_, entry| expect(entry).to have_key(:descriptions) } }
+          specify { unique_entities.each { |_, entry| expect(entry).to have_key(:registrations) } }
+        end
+
         describe "Labour Party"  do
           subject { unique_entities["Labour Party"] }
 
@@ -49,10 +55,17 @@ module Db
       end
 
       describe "#unique_entities_joint_merged" do
-        let(:unique_entities_joint_merged) { described_class.new.unique_entities_joint_merged }
+        let(:joint_merged) { described_class.new.unique_entities_joint_merged }
+
+        describe "each entry" do
+          specify { joint_merged.each { |_, entry| expect(entry).to have_key(:name) } }
+          specify { joint_merged.each { |_, entry| expect(entry).to have_key(:regulated_entity_names) } }
+          specify { joint_merged.each { |_, entry| expect(entry).to have_key(:descriptions) } }
+          specify { joint_merged.each { |_, entry| expect(entry).to have_key(:registrations) } }
+        end
 
         describe "Labour and Co-operative Party"  do
-          subject { unique_entities_joint_merged["Labour and Co-operative Party"] }
+          subject { joint_merged["Labour and Co-operative Party"] }
 
           describe "name" do
             specify { expect(subject[:name]).to eq("Labour and Co-operative Party") }
@@ -61,10 +74,19 @@ module Db
           describe "regulated_entity_names" do
             specify { expect(subject[:regulated_entity_names]).to eq(["Co-operative Party", "Labour Party"]) }
           end
+
+          it "has two registrations, for GB only" do
+            registrations = subject[:registrations].to_a
+            register_names = registrations.map{ |r| r["RegisterName"] }
+
+            expect(registrations).to have_attributes(size: 2)
+            expect(register_names).to include("Great Britain")
+            expect(register_names).not_to include("Northern Ireland")
+          end
         end
 
         describe "Conservative and Unionist Party"  do
-          subject { unique_entities_joint_merged["Conservative and Unionist Party"] }
+          subject { joint_merged["Conservative and Unionist Party"] }
 
           describe "name" do
             specify { expect(subject[:name]).to eq("Conservative and Unionist Party") }
@@ -72,6 +94,15 @@ module Db
 
           describe "regulated_entity_names" do
             specify { expect(subject[:regulated_entity_names]).to eq(["Conservative and Unionist Party"]) }
+          end
+
+          it "has two registrations, for NI and GB" do
+            registrations = subject[:registrations].to_a
+            register_names = registrations.map{ |r| r["RegisterName"] }
+
+            expect(registrations).to have_attributes(size: 2)
+            expect(register_names).to include("Great Britain")
+            expect(register_names).to include("Northern Ireland")
           end
         end
       end


### PR DESCRIPTION
Fixes #491 .

This is a wrapper and utility for the Electoral Commission data, no data is held in tables, a hash of unique parties is constructed from a CSV downloaded from the EC.

Parties with two registrations (GB and NI) are merged into one, and so are parties with a joint description (notably Labour and Co-op). No other assumptions are made about the EC Data. 

It is anticipated that entries in the hash will be used to create entries in our party table.
