### PR TITLE
issues 536 BE2022 new data

### DIFF
--- a/app/views/static_pages/api.html.haml
+++ b/app/views/static_pages/api.html.haml
@@ -107,9 +107,9 @@
       %li
         %code conservative
       %li
-        %code freedom_alliance
+        %code reform_uk
       %li
-        %code rejoin_eu
+        %code ukip
 
     %p
 

--- a/db/fixtures/be2022.yml
+++ b/db/fixtures/be2022.yml
@@ -1,0 +1,68 @@
+---
+:constituencies:
+  - :name: Wakefield
+    :ons_id: E14001009
+    :candidates:
+      - :party_name: Labour
+        :name: Simon Lightwood
+        :colour: "#DC241f"
+        :votes_count: 17_925
+        :votes_percent: 39.8
+      - :party_name: Conservative
+        :name: Nadeem Ahmed
+        :colour: "#0087DC"
+        :votes_count: 21_283
+        :votes_percent: 47.3
+      - :party_name: Liberal Democrats
+        :name: Jamie Needle
+        :colour: "#FDBB30"
+        :votes_count: 1_772
+        :votes_percent: 3.9
+      - :party_name: Green
+        :name: Ashley Routh
+        :colour: "#008066"
+        :votes_count:
+        :votes_percent:
+      - :party_name: Reform UK
+        :name: Chris Walsh
+        :colour:
+        :votes_count:
+        :votes_percent:
+      - :party_name: UKIP
+        :name: Jordan Gaskell
+        :colour:
+        :votes_count:
+        :votes_percent:
+  - :name: Tiverton and Honiton
+    :ons_id: E14000996
+    :candidates:
+      - :party_name: Labour
+        :name: Liz Pole
+        :colour: "#DC241f"
+        :votes_count: 11_654
+        :votes_percent: 19.5
+      - :party_name: Conservative
+        :name: Helen Hurford
+        :colour: "#0087DC"
+        :votes_count: 35_893
+        :votes_percent: 60.2
+      - :party_name: Liberal Democrats
+        :name: Richard Foord
+        :colour: "#FDBB30"
+        :votes_count: 8_807
+        :votes_percent: 14.8
+      - :party_name: Green
+        :name: Gill Westcott
+        :colour: "#008066"
+        :votes_count: 2_291
+        :votes_percent: 3.8
+      - :party_name: Reform UK
+        :name: Andy Foan
+        :colour: "#12B6CF"
+        :votes_count:
+        :votes_percent:
+      - :party_name: UKIP
+        :name: Ben Walker
+        :colour: "#70147A"
+        :votes_count: 968
+        :votes_percent: 1.6

--- a/db/fixtures/be2022/candidate.rb
+++ b/db/fixtures/be2022/candidate.rb
@@ -1,0 +1,19 @@
+require_relative "../be2022_yaml"
+
+module Db
+  module Fixtures
+    module Be2022
+      class Candidate
+        class << self
+          def all
+            Be2022Yaml.data[:constituencies].flat_map do |constituency|
+              constituency[:candidates].map do |candidate|
+                candidate.merge(constituency_ons_id: constituency[:ons_id])
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/fixtures/be2022/party.rb
+++ b/db/fixtures/be2022/party.rb
@@ -1,0 +1,28 @@
+require_relative "../be2022_yaml"
+require_relative "candidate"
+
+module Db
+  module Fixtures
+    module Be2022
+      class Party
+        class << self
+          def all_with_duplicates
+            Candidate.all.map do |candidate|
+              {
+                name: candidate[:party_name],
+                colour: candidate[:colour]
+              }
+            end
+          end
+
+          def all
+            all_with_duplicates.each_with_object([]) do |party, parties|
+              matching_party = parties.detect { |existing_party| existing_party[:name] == party[:name] }
+              parties << party unless matching_party
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/fixtures/be2022_yaml.rb
+++ b/db/fixtures/be2022_yaml.rb
@@ -1,0 +1,24 @@
+require "yaml"
+
+# This is an encapsulation of the Yaml file for By-election 2022
+
+module Db
+  module Fixtures
+    class Be2022Yaml
+      FILENAME = "db/fixtures/be2022.yml"
+
+      class << self
+        def data
+          ::YAML.load(file_content)
+        end
+
+        def file_content
+          @file_content ||= ::File.read(FILENAME)
+        rescue Errno::ENOENT => e
+          puts "Filename #{FILENAME} read failed with error #{e}"
+          raise e
+        end
+      end
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,9 +6,9 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-require_relative "fixtures/be2021_yaml"
-require_relative "fixtures/be2021/party"
-require_relative "fixtures/be2021/candidate"
+require_relative "fixtures/be2022_yaml"
+require_relative "fixtures/be2022/party"
+require_relative "fixtures/be2022/candidate"
 require_relative "../app/helpers/application_helper"
 
 class SeedHelper
@@ -17,7 +17,7 @@ end
 
 puts "\nParties"
 
-Db::Fixtures::Be2021::Party.all.each do |party|
+Db::Fixtures::Be2022::Party.all.each do |party|
   ::Party.find_or_create_by(name: party[:name], color: party[:colour])
   puts "Party #{party[:name]} created"
 end
@@ -26,7 +26,7 @@ end
 
 puts "\nConstituencies"
 
-Db::Fixtures::Be2021Yaml.data[:constituencies].each do |constituency|
+Db::Fixtures::Be2022Yaml.data[:constituencies].each do |constituency|
   cons = OnsConstituency.find_or_initialize_by ons_id: constituency[:ons_id]
   puts "#{cons.ons_id} #{cons.name}"
   cons.update!(constituency.slice(:name, :ons_id))
@@ -38,7 +38,7 @@ puts "#{OnsConstituency.count} Constituencies loaded\n\n"
 
 puts "\n\nPolls Data\n\n"
 
-Db::Fixtures::Be2021::Candidate.all.each do |candidate|
+Db::Fixtures::Be2022::Candidate.all.each do |candidate|
   vote_count = candidate[:votes_percent] ? (candidate[:votes_percent] * 100).to_i : nil
   ons_id = candidate[:constituency_ons_id]
   party_name = candidate[:party_name]

--- a/spec/db/fixtures/be2022/candidate_spec.rb
+++ b/spec/db/fixtures/be2022/candidate_spec.rb
@@ -1,0 +1,18 @@
+require_relative "../../../../db/fixtures/be2022/candidate"
+
+RSpec.describe Db::Fixtures::Be2022::Candidate do
+  # rubocop:disable RSpec/IteratedExpectation
+  # rubocop's recommendation doesn't improve the code in this instance and it worsens the spec output
+
+  subject { described_class.all }
+
+  describe ".all" do
+    specify { expect(subject).to be_an_instance_of(Array) }
+
+    describe "each candidate" do
+      specify { subject.each { |candidate| expect(candidate).to have_key(:name) } }
+      specify { subject.each { |candidate| expect(candidate).to have_key(:party_name) } }
+      specify { subject.each { |candidate| expect(candidate).to have_key(:constituency_ons_id) } }
+    end
+  end
+end

--- a/spec/db/fixtures/be2022/party_spec.rb
+++ b/spec/db/fixtures/be2022/party_spec.rb
@@ -1,0 +1,40 @@
+require_relative "../../../../db/fixtures/be2022/party"
+
+RSpec.describe Db::Fixtures::Be2022::Party do
+  # rubocop:disable RSpec/IteratedExpectation
+  # rubocop's recommendation doesn't improve the code in this instance and it worsens the spec output
+
+  describe ".all_with_duplicates" do
+    subject { described_class.all_with_duplicates }
+
+    specify { expect(subject).to be_an_instance_of(Array) }
+
+    it "has more than 1 party" do
+      expect(subject.size).to be > 1
+    end
+
+    describe "each party" do
+      specify { subject.each { |party| expect(party).to have_key(:name) } }
+      specify { subject.each { |party| expect(party).to have_key(:colour) } }
+    end
+  end
+
+  describe ".all" do
+    subject { described_class.all }
+
+    specify { expect(subject).to be_an_instance_of(Array) }
+
+    it "has less parties than .all_with_duplicates" do
+      expect(subject.size).to be < described_class.all_with_duplicates.size
+    end
+
+    it "has more than 1 party" do
+      expect(subject.size).to be > 1
+    end
+
+    describe "each party" do
+      specify { subject.each { |party| expect(party).to have_key(:name) } }
+      specify { subject.each { |party| expect(party).to have_key(:colour) } }
+    end
+  end
+end

--- a/spec/db/fixtures/be2022_yaml_spec.rb
+++ b/spec/db/fixtures/be2022_yaml_spec.rb
@@ -1,0 +1,25 @@
+require_relative "../../../db/fixtures/be2022_yaml"
+
+RSpec.describe Db::Fixtures::Be2022Yaml do
+  # rubocop:disable RSpec/IteratedExpectation
+  # rubocop's recommendation doesn't improve the code in this instance and it worsens the spec output
+
+  subject { described_class.data }
+
+  it "returns data as a hash" do
+    expect(subject).to be_an_instance_of(Hash)
+  end
+
+  it "has an array of constituencies" do
+    expect(subject.keys).to eq([:constituencies])
+    expect(subject[:constituencies]).to be_an_instance_of(Array)
+  end
+
+  describe "each constituency" do
+    subject { described_class.data[:constituencies] }
+
+    specify { subject.each { |constituency| expect(constituency).to have_key(:name) } }
+    specify { subject.each { |constituency| expect(constituency).to have_key(:ons_id) } }
+    specify { subject.each { |constituency| expect(constituency).to have_key(:candidates) } }
+  end
+end

--- a/spec/models/party_spec.rb
+++ b/spec/models/party_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Party, type: :model do
        liberal_democrats
        green
        conservative
-       freedom_alliance
-       rejoin_eu
+       reform_uk
+       ukip
     ].each do |canonical_name|
       it "includes #{canonical_name.inspect} mentioned in api docs" do
         expect(described_class.canonical_names).to include(canonical_name)


### PR DESCRIPTION
Closes #536

New yaml file added containing data for the BE2022 By Election (candidates, polls, constituencies, parties)

db/seed.rb replaced for the by election. This can be run on a development environment with

    rake db:drop && rake db:create && rake db:schema:load && rake db:seed

which will completely destroy your existing dev database of course, so take a backup first if need.

Api page updated for the new parties

I've verified correctness only by inspecting the database. I have not as yet investigated the impact on running code.
