### PR TITLE
issue 347 proof read emails

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -6,6 +6,9 @@ class AdminController < ApplicationController
   http_basic_authenticate_with name: "swapmyvote",
                                password: ENV["ADMIN_PASSWORD"] || "secret"
 
+  def index
+  end
+
   def stats
     @user_count = User.count
     @swap_count = Swap.count

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -3,6 +3,8 @@ class AdminController < ApplicationController
     raise "You didn't set ADMIN_PASSWORD!"
   end
 
+  # before_action :require_login, only: [:send_email_proofs]
+
   http_basic_authenticate_with name: "swapmyvote",
                                password: ENV["ADMIN_PASSWORD"] || "secret"
 
@@ -43,6 +45,26 @@ class AdminController < ApplicationController
       flash.now[:errors] = ["The number #{num} wasn't verified!"]
     else
       change_mobile_verification(mode, phone)
+    end
+  end
+
+  def send_email_proofs
+    if current_user.nil?
+      flash[:errors] = ["You need to be logged on so we have an email address to send to"]
+      redirect_to root_path
+    else
+      flash[:warnings] = ["I would have sent an email if I was finished code"]
+
+      # def send_welcome_email
+      #   return if email.blank?
+      #   logger.debug "Sending Welcome email"
+      #   UserMailer.welcome_email(self).deliver_now
+      #   sent_emails.create!(template: SentEmail::WELCOME)
+      # end
+
+      logger.debug "Sending Welcome email to #{current_user}"
+      UserMailer.welcome_email(current_user).deliver_now
+      redirect_to user_path
     end
   end
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -80,7 +80,9 @@ class AdminController < ApplicationController
       UserMailer.no_swap(current_user).deliver_now
       UserMailer.swap_not_confirmed(current_user).deliver_now
 
-      redirect_to user_path
+      # flash[:info] = ["Mails have been sent"]
+
+      redirect_to admin_path
     end
   end
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -54,7 +54,7 @@ class AdminController < ApplicationController
       flash[:errors] = ["You need to be logged on so we have an email address to send to"]
       redirect_to root_path
     else
-      logger.debug "Sending proof-reading emails email to #{current_user}"
+      logger.debug "Sending proof-reading emails to #{current_user}"
 
       UserMailer.welcome_email(current_user).deliver_now
 

--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -11,4 +11,5 @@
         %li
           = link_to "Mobile verification", fake_verify_mobile_path
         %li
-          = link_to "Send 11 emails to me for proof-reading", admin_send_email_proofs_path
+          = link_to "Send 11 emails to me for proof-reading",
+              admin_send_email_proofs_path

--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -10,3 +10,5 @@
           = link_to "Statistics dashboard", admin_stats_path
         %li
           = link_to "Mobile verification", fake_verify_mobile_path
+        %li
+          = link_to "Send 11 emails to me for proof-reading", admin_send_email_proofs_path

--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -1,0 +1,12 @@
+.background-pattern
+  .container
+    %h1 Swap My Vote Admin
+    .card
+      %p
+        Welcome to the admin interface.
+
+      %ul
+        %li
+          = link_to "Statistics dashboard", admin_stats_path
+        %li
+          = link_to "Mobile verification", fake_verify_mobile_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
 
   get "admin", to: "admin#index"
   get "admin/stats", to: "admin#stats"
+  get "admin/send_email_proofs", to: "admin#send_email_proofs"
   match "admin/verify_mobile", to: "admin#verify_mobile",
       as: "fake_verify_mobile", via: [:get, :post]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
   get "mobile_phone/verify_create", as: "verify_mobile"
   match "mobile_phone/verify_token", as: "verify_token", via: [:get, :post]
 
+  get "admin", to: "admin#index"
   get "admin/stats", to: "admin#stats"
   match "admin/verify_mobile", to: "admin#verify_mobile",
       as: "fake_verify_mobile", via: [:get, :post]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
 
   get "admin", to: "admin#index"
   get "admin/stats", to: "admin#stats"
-  get "admin/send_email_proofs", to: "admin#send_email_proofs"
+  get "admin/send_email_proofs", to: "admin#send_email_proofs", via: [:get]
   match "admin/verify_mobile", to: "admin#verify_mobile",
       as: "fake_verify_mobile", via: [:get, :post]
 

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+ENV["ADMIN_PASSWORD"] = "test_password"
+
+RSpec.describe AdminController, type: :controller do
+  let(:mock_current_user) do
+    create(:ready_to_swap_user1, id: 111, constituency: build(:ons_constituency))
+  end
+
+  let(:mock_mailer_return) do
+    double(:mock_mailer_return, deliver_now: true)
+  end
+
+  it "sends email proofs" do
+    allow(controller).to receive(:current_user).and_return(mock_current_user)
+    # allow(subject).to receive(:http_basic_authenticate_with)
+
+    allow(controller).to receive(:authenticate_or_request_with_http_basic).with(anything).and_return true
+
+    expect(UserMailer).to receive(:welcome_email).and_return(mock_mailer_return)
+    expect(UserMailer).to receive(:confirm_swap).and_return(mock_mailer_return)
+    expect(UserMailer).to receive(:email_address_shared).and_return(mock_mailer_return)
+
+    expect(UserMailer).to receive(:swap_confirmed).and_return(mock_mailer_return)
+    expect(UserMailer).to receive(:swap_confirmed).and_return(mock_mailer_return)
+
+    expect(UserMailer).to receive(:swap_cancelled).and_return(mock_mailer_return)
+    expect(UserMailer).to receive(:not_swapped_follow_up).and_return(mock_mailer_return)
+    expect(UserMailer).to receive(:partner_has_voted).and_return(mock_mailer_return)
+    expect(UserMailer).to receive(:reminder_to_vote).and_return(mock_mailer_return)
+    expect(UserMailer).to receive(:no_swap).and_return(mock_mailer_return)
+    expect(UserMailer).to receive(:swap_not_confirmed).and_return(mock_mailer_return)
+
+    get :send_email_proofs
+
+    expect(flash[:errors]).not_to be_present
+  end
+end


### PR DESCRIPTION
closes #347 and #483 

(Actually it doesn't meet all the requirements of #347 but it will get us going)

Really, really basic email copy proof-reading, plus I stole the admin page commit from #483 

Instructions for use:

*   go to https://swapmyvotedev.herokuapp.com/
*   log in with the email address you want to test
*   go to https://swapmyvotedev.herokuapp.com/admin/
*   supply the secret password to the admin section (user swapmyvote)
*   select email proofreading from the menu
*   receive about 11 test emails

Note, in your local environment, these emails will not be sent with the
mailer, instead they will go to file tmp/mails/\<your logged in email address\>
