### PR TITLE
Rubocop hound update

### DIFF
--- a/.haml.yml
+++ b/.haml.yml
@@ -1,0 +1,70 @@
+# Whether to ignore frontmatter at the beginning of HAML documents for
+# frameworks such as Jekyll/Middleman
+skip_frontmatter: false
+
+linters:
+  AltText:
+    enabled: false
+
+  ClassAttributeWithStaticValue:
+    enabled: true
+
+  ClassesBeforeIds:
+    enabled: true
+
+  ConsecutiveComments:
+    enabled: true
+
+  ConsecutiveSilentScripts:
+    enabled: true
+    max_consecutive: 2
+
+  EmptyScript:
+    enabled: true
+
+  HtmlAttributes:
+    enabled: true
+
+  ImplicitDiv:
+    enabled: true
+
+  LeadingCommentSpace:
+    enabled: true
+
+  LineLength:
+    enabled: true
+    max: 80
+
+  MultilinePipe:
+    enabled: true
+
+  MultilineScript:
+    enabled: true
+
+  ObjectReferenceAttributes:
+    enabled: true
+
+  RuboCop:
+    enabled: false
+
+  RubyComments:
+    enabled: true
+
+  SpaceBeforeScript:
+    enabled: true
+
+  SpaceInsideHashAttributes:
+    enabled: true
+    style: space
+
+  TagName:
+    enabled: true
+
+  TrailingWhitespace:
+    enabled: true
+
+  UnnecessaryInterpolation:
+    enabled: true
+
+  UnnecessaryStringOutput:
+    enabled: true

--- a/.haml.yml
+++ b/.haml.yml
@@ -33,7 +33,7 @@ linters:
 
   LineLength:
     enabled: true
-    max: 80
+    max: 200
 
   MultilinePipe:
     enabled: true

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,7 +1,7 @@
-ruby:
+rubocop:
   enabled: true
   config_file: .rubocop.yml
-  version: 0.75.0
+  version: 1.22.1
 
 scss:
   config_file: .scss-lint.yml

--- a/.hound.yml
+++ b/.hound.yml
@@ -8,3 +8,6 @@ scss:
 
 jshint:
   config_file: .jshintrc
+
+haml:
+  config_file: .haml.yml

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem "webpacker", "~> 4.x"
 
 # These need to be outside the development group for Rakefile to
 # be happy in Heroku.
-gem "rubocop"
+gem "rubocop", "~> 1.22.1"
 gem "rubocop-rails"
 gem "rubocop-rspec"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,8 +238,8 @@ GEM
       omniauth-oauth (~> 1.1)
       rack
     orm_adapter (0.5.0)
-    parallel (1.20.1)
-    parser (3.0.1.1)
+    parallel (1.22.1)
+    parser (3.1.2.0)
       ast (~> 2.4.1)
     pg (1.2.3)
     pry (0.13.1)
@@ -289,14 +289,14 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
-    rainbow (3.0.0)
+    rainbow (3.1.1)
     rake (13.0.3)
     random_data (1.6.0)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rbtree3 (0.6.0)
-    regexp_parser (2.1.1)
+    regexp_parser (2.5.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -322,17 +322,17 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.4)
-    rubocop (1.15.0)
+    rubocop (1.22.3)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.5.0, < 2.0)
+      rubocop-ast (>= 1.12.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.5.0)
-      parser (>= 3.0.1.1)
+    rubocop-ast (1.18.0)
+      parser (>= 3.1.1.0)
     rubocop-rails (2.10.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
@@ -387,7 +387,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (2.0.0)
+    unicode-display_width (2.1.0)
     unicode_utils (1.4.0)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -447,7 +447,7 @@ DEPENDENCIES
   rails-controller-testing
   random_data
   rspec-rails (~> 3.8)
-  rubocop
+  rubocop (~> 1.22.1)
   rubocop-rails
   rubocop-rspec
   sassc-rails


### PR DESCRIPTION
Hound gets a bit naggy and is inconsistent with rubocop. 
Hound config also points to a rubocop version we're not using. 
Hound complains about quite reasonable haml lines that are longer than 80 chars

Lets see if we can improve things. 