### PR TITLE
update ruby to 2.7.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby "2.7.3"
+ruby "2.7.6"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", "~> 5.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -462,7 +462,7 @@ DEPENDENCIES
   webpacker (~> 4.x)
 
 RUBY VERSION
-   ruby 2.7.3p183
+   ruby 2.7.6p219
 
 BUNDLED WITH
    2.2.17


### PR DESCRIPTION
Reasons:

-   We should probably do it anyway
-   @tdg can install 2.7.6 but not 2.7.3, which we're currently on
