### PR TITLE
visual tweaks

### DIFF
--- a/app/views/user/swaps/new.html.haml
+++ b/app/views/user/swaps/new.html.haml
@@ -10,7 +10,7 @@
       = form_tag user_swap_path, class: "form-inline" do
         = hidden_field_tag 'user_id', @swap_with.id
 
-        .form-check.row.mx-auto
+        .form-group.form-check.row.mx-auto
           %input.form-check-input{ type: "checkbox", id: "consent-check",
                                   name: "consent_share_email_chooser" }
           %label.form-check-label{ for: "consent-check" }

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -10,7 +10,7 @@
           Edit profile
       .card-body
         - if @user.swapped?
-          %p.text-center.text-warning.small
+          %p.text-center.text-error.small
             - if voting_info_locked?
 
               Warning: it's election day and you've already confirmed

--- a/app/views/users/show/_confirm_incoming_swap.html.haml
+++ b/app/views/users/show/_confirm_incoming_swap.html.haml
@@ -28,7 +28,7 @@
     %p.text-center
       = form_tag user_swap_path, class: "form-inline", method: "put" do
         = hidden_field_tag 'swap[confirmed]', true
-        .form-check.mx-auto
+        .form-group.form-check.mx-auto
           %input{ type: "hidden", id: "swap_dummy",
                   name: "swap[dummy]", value: "dummy"}
           %input.form-check-input{ type: "checkbox", id: "consent-check",

--- a/app/views/users/show/_confirm_outgoing_swap.html.haml
+++ b/app/views/users/show/_confirm_outgoing_swap.html.haml
@@ -32,7 +32,7 @@
     When they confirm the swap, they will be notified of your email address.
   %p.text-center
     = form_tag user_swap_path, class: "form-inline", method: "put" do
-      .form-check.mx-auto
+      .form-group.form-check.mx-auto
         %input{ type: "hidden", id: "swap_dummy",
           name: "swap[dummy]", value: "dummy"}
         %input.form-check-input{ type: "checkbox", id: "swap_consent_share_email_chooser",

--- a/app/views/users/show/_swap_confirmed.html.haml
+++ b/app/views/users/show/_swap_confirmed.html.haml
@@ -30,7 +30,7 @@
     with #{@user.swapped_with.name}.
   %p.text-center
     = form_tag user_swap_path, class: "form-inline", method: "put" do
-      .form-check.mx-auto
+      .form-group.form-check.mx-auto
         %input{ type: "hidden", id: "swap_dummy",
           name: "swap[dummy]", value: "dummy"}
         %input.form-check-input{ type: "checkbox", id: "consent-check",


### PR DESCRIPTION
- changed class on the warning text about not changing your party or constituency from warning to error. much easier to see.

- added .form-group to checkbox and label containers on forms confirming if user wants to share their email address with the other person. now the checkbox sits alongside the label nicely.