### PR TITLE
action network form embed partial

### DIFF
--- a/app/views/home/_actionnetwork.html
+++ b/app/views/home/_actionnetwork.html
@@ -1,0 +1,11 @@
+<!-- Begin Action Network Signup Form -->
+<link href='https://actionnetwork.org/css/style-embed-whitelabel-v3.css' rel='stylesheet' type='text/css' /><script src='https://actionnetwork.org/widgets/v4/form/swapmyvote?format=js&source=widget'></script><div id='can-form-area-swapmyvote' style='width: 400px'><!-- this div is the target for our HTML insertion --></div>
+<style>
+  <!--
+  #can_embed_form_inner h2 {display:none;}
+  #can_embed_form_inner h4 {display:none;}
+  #can_embed_form .clearfix div:nth-child(2) {display:none;}
+  #can_embed_form .clearfix div:nth-child(3) {display:none;}
+  -->
+</style>
+<!-- End Action Network Signup Form -->

--- a/app/views/home/_closed_warm_up.html.haml
+++ b/app/views/home/_closed_warm_up.html.haml
@@ -6,8 +6,9 @@
       %p
 
         We have updated the Swap My Vote platform for the two
-        by&#8209;elections to be held this summer on June 23rd: Wakefield, and Tiverton & Honiton. We will aim to
-        open for vote swapping extremely soon!
+        by&#8209;elections to be held this summer on June 23rd:
+        Wakefield, and Tiverton & Honiton. We aim to open for
+        vote swapping soon!
 
       %p
 

--- a/app/views/home/_closed_warm_up.html.haml
+++ b/app/views/home/_closed_warm_up.html.haml
@@ -14,7 +14,7 @@
         Please enter your email address for a reminder when vote
         swapping is open, and for further updates.
 
-      = render partial: "mailchimp.html"
+      = render partial: "actionnetwork.html"
 
       %hr
 

--- a/app/views/home/_closed_wind_down.html.haml
+++ b/app/views/home/_closed_wind_down.html.haml
@@ -34,7 +34,7 @@
         democratic tools. You can unsubscribe at any time from the
         link in the footer of any of these emails.
 
-      = render partial: "mailchimp.html"
+      = render partial: "actionnetwork.html"
 
       %hr
 


### PR DESCRIPTION
not being included anywhere yet, but intended to replace everywhere _mailchimp.html is included.

still needs more css work. unlike mailchimp, you don't embed the html, instead js builds the form. so if you want to make changes you can only use css.

Closes #558.