### PR TITLE
record user's consent to be sent newsletters (#195)

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -44,7 +44,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :preferred_party_id, :willing_party_id])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [
+      :name, :preferred_party_id, :willing_party_id, :consent_news_email
+    ])
   end
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -38,6 +38,6 @@ class Users::SessionsController < Devise::SessionsController
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_sign_in_params
-    devise_parameter_sanitizer.permit(:sign_in, keys: [:preferred_party_id, :willing_party_id])
+    devise_parameter_sanitizer.permit(:sign_in, keys: [:preferred_party_id, :willing_party_id, :consent_news_email])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -63,7 +63,7 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:preferred_party_id, :willing_party_id, :constituency_ons_id, :email)
+    params.require(:user).permit(:preferred_party_id, :willing_party_id, :constituency_ons_id, :email, :consent_news_email)
   end
 
   def phone_param

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -63,7 +63,8 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:preferred_party_id, :willing_party_id, :constituency_ons_id, :email, :consent_news_email)
+    params.require(:user).permit(:preferred_party_id, :willing_party_id, :constituency_ons_id, :email,
+                                 :consent_news_email)
   end
 
   def phone_param

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -29,6 +29,11 @@
             <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
           </div>
 
+          <div class="form-group">
+            <%= f.label  :consent_news_email, "Would you like to opt-in to email updates from Forward Democracy ?", class: "mb-0" %>
+            <%= f.check_box :consent_news_email, class: "form-control" %>
+          </div>
+
           <div class="actions">
             <%= f.submit "Sign up", class: "btn btn-primary btn-block" %>
           </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -30,7 +30,7 @@
           </div>
 
           <div class="form-group">
-            <%= f.label  :consent_news_email, "Would you like to opt-in to email updates from Forward Democracy ?", class: "mb-0" %>
+            <%= f.label  :consent_news_email, "Opt in to email updates from Forward Democracy", class: "mb-0" %>
             <%= f.check_box :consent_news_email, class: "form-control" %>
           </div>
 

--- a/db/migrate/20220607065010_add_news_email_consent_to_user.rb
+++ b/db/migrate/20220607065010_add_news_email_consent_to_user.rb
@@ -1,0 +1,5 @@
+class AddNewsEmailConsentToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :consent_news_email, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_09_132125) do
+ActiveRecord::Schema.define(version: 2022_06_07_065010) do
 
   create_table "constituencies", force: :cascade do |t|
     t.string "name"
@@ -122,6 +122,7 @@ ActiveRecord::Schema.define(version: 2019_12_09_132125) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
+    t.boolean "consent_news_email", default: false, null: false
     t.index ["mobile_phone_id"], name: "index_users_on_mobile_phone_id", unique: true
     t.index ["preferred_party_id", "willing_party_id", "constituency_ons_id"], name: "index_users_on_complementary_users"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
fixes #195

records user consent to be sent Forward Democracy emails


- update db to record user consent for newsletters from forward democracy #195
- add checkbox to form (unstyled as yet)
- get the form value into the user db entry
