### PR TITLE
issue 594 my email consent confusion

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -11,7 +11,7 @@ module UsersHelper
   def contact_methods(user)
     methods = social_contact_methods(user)
 
-    if user.email.present? && user.email_consent?
+    if user.email.present? && user.consented_to_share_email?
       methods << "by email at " + link_to(user.email, user.email_url)
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -221,15 +221,8 @@ class User < ApplicationRecord
     UserMailer.swap_confirmed(swapped_with, self, incoming_swap.consent_share_email_chosen).deliver_now
   end
 
-  def email_consent?
+  def consented_to_share_email?
     # Check if user has given permission for swap partner to see their email
-    return outgoing_swap.consent_share_email_chooser if outgoing_swap
-    return incoming_swap.consent_share_email_chosen if incoming_swap
-    return false
-  end
-
-  def my_email_consent?
-    # Check if I have given permission for swapper to see my email
     return outgoing_swap.consent_share_email_chooser if outgoing_swap
     return incoming_swap.consent_share_email_chosen if incoming_swap
     return false

--- a/app/views/users/show/_confirm_outgoing_swap.html.haml
+++ b/app/views/users/show/_confirm_outgoing_swap.html.haml
@@ -21,7 +21,7 @@
 
     When they do we'll send you an email.
 
-- if user.my_email_consent?
+- if user.consented_to_share_email?
   %p.text-center
     You have opted to share your email address
     with #{user.swapped_with.redacted_name}.

--- a/app/views/users/show/_swap_confirmed.html.haml
+++ b/app/views/users/show/_swap_confirmed.html.haml
@@ -21,7 +21,7 @@
   %i.fa.fa-fw.fa-check
   #{user.swapped_with.name} has confirmed the swap. You're all set!
 
-- if user.my_email_consent?
+- if user.consented_to_share_email?
   %p.text-center
     You have shared your email address
     with #{user.swapped_with.name}.

--- a/doc/analysis_for_issue_594.md
+++ b/doc/analysis_for_issue_594.md
@@ -1,0 +1,63 @@
+# Analysis for issue 594
+
+## Timeline, recent first
+
+### commit d954bd57d9ea7e88e4e0b5d25da8c863dcf6fa72 (issue-337-retrospective-email-consent)
+
+Author: baob <coder@onesandthrees.com>
+Date:   Wed Dec 11 13:06:15 2019 +0000
+
+    deal with redundant method introduced by rebase
+
+appears to delete swap_email_consent? which has different definition to my_email_consent?
+
+Final state: my_email_consent and email_consent have the same definition AND SAME PURPOSE
+
+### commit 8bb716f1e30b393b7271a95d1ded15a7d482b281
+
+Author: baob <coder@onesandthrees.com>
+Date:   Wed Dec 11 01:01:07 2019 +0000
+
+    method my_email_consent? (#337)
+
+adds def my_email_consent? - # Check if I have given permission for swapper to see my email
+*appears to serve same purpose as adams added email_consent?*
+
+Final state: my_email_consent and email_consent have the same definition, swap_my_email_consent differs
+
+### commit 18e733ec9bdeaed6a7e845da0d907f35f1921319
+
+Author: baob <coder@onesandthrees.com>
+Date:   Tue Dec 10 19:19:25 2019 +0000
+
+    detect update without confirm to make tests pass (#337)
+
+adds def swap_email_consent? - Check if our swapper has given permission for us to see their email
+*added by rebase on top of steve baxters work*
+
+Final state: my_email_consent and swap_my_email_consent exist, content differs
+
+### commit 68a54f1db35f16b60a9603bfe8d4e73d8a9cfbcb
+
+Author: Adam Spiers <git@adamspiers.org>
+Date:   Wed Dec 11 02:11:37 2019 +0400
+
+    Fix text regarding how to reach out to swap partner
+
+renames swap_email_consent? to email_consent?
+
+deletes def swap_email_consent? - Check if our swapper has given permission for us to see their email
+add +  def email_consent? - Check if user has given permission for swap partner to see their email
+
+Final state: only email_consent exist
+
+### commit 4f74f02f94f50baa750983f4f254f091550d071c (origin/issue-324-share-email-address, issue-324-share-email-address)
+
+Author: Steve Baxter <steve@kuamka.com>
+Date:   Tue Dec 10 17:21:13 2019 +0000
+
+    Change swap_confirmed page so it shows any combination of email and social link. Added separate email_url get get an email link, profile_url will no longer return the email link.
+
+adds +  def swap_email_consent? - Check if our swapper has given permission for us to see their email
+
+Final state: only swap_consent exist

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -375,11 +375,11 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe "#email_consent?" do
+  describe "#consented_to_share_email?" do
     let(:swap) { build(:swap) }
 
     it "is false by default" do
-      expect(subject.email_consent?).to be_falsey
+      expect(subject.consented_to_share_email?).to be_falsey
     end
 
     context "swapper is chooser and" do
@@ -389,12 +389,12 @@ RSpec.describe User, type: :model do
 
       it "has consented to share email" do
         swap.consent_share_email_chooser = true
-        expect(subject.email_consent?).to be_truthy
+        expect(subject.consented_to_share_email?).to be_truthy
       end
 
       it "has not consented to share email" do
         swap.consent_share_email_chooser = false
-        expect(subject.email_consent?).to be_falsey
+        expect(subject.consented_to_share_email?).to be_falsey
       end
     end
 
@@ -405,12 +405,12 @@ RSpec.describe User, type: :model do
 
       it "has consented to share email" do
         swap.consent_share_email_chosen = true
-        expect(subject.email_consent?).to be_truthy
+        expect(subject.consented_to_share_email?).to be_truthy
       end
 
       it "has not consented to share email" do
         swap.consent_share_email_chosen = false
-        expect(subject.email_consent?).to be_falsey
+        expect(subject.consented_to_share_email?).to be_falsey
       end
     end
   end
@@ -428,44 +428,6 @@ RSpec.describe User, type: :model do
 
     it "allows different emails to be being created" do
       expect{create(:user, name: "Bob")}.not_to raise_error
-    end
-  end
-
-  describe "#my_email_consent?" do
-    it "is false by default" do
-      expect(subject.my_email_consent?).to be_falsey
-    end
-
-    it "swapper is chooser and has consented to share email" do
-      confirmed_swap = build(:swap, confirmed: true)
-      confirmed_swap.consent_share_email_chooser = true
-      subject.outgoing_swap = confirmed_swap
-
-      expect(subject.my_email_consent?).to be_truthy
-    end
-
-    it "swapper is chooser and has not consented to share email" do
-      confirmed_swap = build(:swap, confirmed: true)
-      confirmed_swap.consent_share_email_chooser = false
-      subject.outgoing_swap = confirmed_swap
-
-      expect(subject.my_email_consent?).to be_falsey
-    end
-
-    it "swapper is chosen and has consented to share email" do
-      confirmed_swap = build(:swap, confirmed: true)
-      confirmed_swap.consent_share_email_chosen = true
-      subject.incoming_swap = confirmed_swap
-
-      expect(subject.my_email_consent?).to be_truthy
-    end
-
-    it "swapper is chosen and has not consented to share email" do
-      confirmed_swap = build(:swap, confirmed: true)
-      confirmed_swap.consent_share_email_chosen = false
-      subject.incoming_swap = confirmed_swap
-
-      expect(subject.my_email_consent?).to be_falsey
     end
   end
 


### PR DESCRIPTION
fixes #594

- two methods with identical purpose and implementation: merge and give intent-revealing name
