### PR TITLE
only shrink width of profile-content if polls are shown

### DIFF
--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -20,9 +20,11 @@
         padding-left: 76px;
         box-sizing: border-box;
 
-        @include largescreen {
-            width: 60%;
-            float: left;
+        &.with-polls {
+            @include largescreen {
+                width: 60%;
+                float: left;
+            }
         }
     }
 

--- a/app/controllers/user/swaps_controller.rb
+++ b/app/controllers/user/swaps_controller.rb
@@ -7,7 +7,7 @@ class User::SwapsController < ApplicationController
   before_action :assert_has_email, only: [:new, :create, :update]
   before_action :assert_has_constituency, only: [:new, :create, :update]
   before_action :assert_mobile_phone_verified, only: [:new, :create, :update]
-  before_action :hide_polls, only: [:show, :new]
+  before_action :hide_polls?, only: [:show, :new]
 
   include UsersHelper
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   before_action :require_login, except: [:new]
   before_action :require_swapping_open, only: :show
   before_action :restricted_when_voting_open, only: [:edit, :update, :destroy]
-  before_action :hide_polls, only: [:show]
+  before_action :hide_polls?, only: [:show]
 
   def new
     @identity = request.env["omniauth.identity"]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -100,7 +100,7 @@ module ApplicationHelper
     ].sample
   end
 
-  def hide_polls
+  def hide_polls?
     return @hide_polls if defined?(@hide_polls)
     @hide_polls = OnsConstituency.count == 2
   end

--- a/app/views/home/_swap_form.html.haml
+++ b/app/views/home/_swap_form.html.haml
@@ -26,7 +26,7 @@
 
       %li
         We’ll find you a list of people with the complementary preferences. Pick one partner to swap your vote with.
-        - unless hide_polls
+        - unless hide_polls?
           The recent polls by their name can help you see where your vote might make most difference.
 
       %li If your partner agrees to the swap, it is confirmed. We’ll help you connect with each other, so if you like, you can introduce yourselves.

--- a/app/views/user/swaps/_double_check_constituency.html.haml
+++ b/app/views/user/swaps/_double_check_constituency.html.haml
@@ -1,5 +1,5 @@
 %p.text-center.small
-  - unless hide_polls
+  - unless hide_polls?
     Poll results are based on
     %a{ href: "https://www.electoralcalculus.co.uk/orderedseats.html", target: "blank" }
       Electoral Calculus calculations of national swing since the last election.

--- a/app/views/user/swaps/_list_potential_swaps.html.haml
+++ b/app/views/user/swaps/_list_potential_swaps.html.haml
@@ -3,7 +3,7 @@
 
 %p.text-center.small.subdued
 
-  - unless hide_polls
+  - unless hide_polls?
     Consider the polls in their constituency to give your vote the best
     chance of making a difference!
 
@@ -12,7 +12,7 @@
   .smv-card
     = render partial: "swap_profile", object: swap, as: "other_user", locals: { link_to_swap: true }
 
-- unless hide_polls
+- unless hide_polls?
   %p.text-center
     Poll results are from the 2019 General Election.
 

--- a/app/views/user/swaps/_list_potential_swaps.html.haml
+++ b/app/views/user/swaps/_list_potential_swaps.html.haml
@@ -10,7 +10,7 @@
 .spacer
 - for swap in @potential_swaps
   .smv-card
-    = render partial: "swap_profile", object: swap, as: "other_user", locals: { hide_polls: hide_polls, link_to_swap: true }
+    = render partial: "swap_profile", object: swap, as: "other_user", locals: { link_to_swap: true }
 
 - unless hide_polls
   %p.text-center

--- a/app/views/user/swaps/_swap_profile.html.haml
+++ b/app/views/user/swaps/_swap_profile.html.haml
@@ -1,9 +1,9 @@
 - if defined? link_to_swap and link_to_swap
   = link_to new_user_swap_path(user_id: other_user.id), class: "profile" do
-    = render partial: "user/swaps/swap_profile_inner", locals: { hide_polls: hide_polls, other_user: other_user }
+    = render partial: "user/swaps/swap_profile_inner", locals: { other_user: other_user }
 - else
   .profile
-    = render partial: "user/swaps/swap_profile_inner", locals: { hide_polls: hide_polls, other_user: other_user }
+    = render partial: "user/swaps/swap_profile_inner", locals: { other_user: other_user }
 
 - if !hide_polls && !other_user.constituency.nil?
   :javascript

--- a/app/views/user/swaps/_swap_profile.html.haml
+++ b/app/views/user/swaps/_swap_profile.html.haml
@@ -5,6 +5,6 @@
   .profile
     = render partial: "user/swaps/swap_profile_inner", locals: { other_user: other_user }
 
-- if !hide_polls && !other_user.constituency.nil?
+- if !hide_polls? && !other_user.constituency.nil?
   :javascript
     drawPollChart("poll_#{other_user.id}", #{poll_data_for(other_user.constituency)});

--- a/app/views/user/swaps/_swap_profile_inner.html.haml
+++ b/app/views/user/swaps/_swap_profile_inner.html.haml
@@ -20,7 +20,7 @@
     if you vote
     %strong= other_user.preferred_party.name
 
-- if !hide_polls && !other_user.constituency.nil?
+- if !hide_polls? && !other_user.constituency.nil?
   .profile-poll
     .text-center.small
       GE2019 results for #{other_user.constituency.try(:name) or "Unknown"}

--- a/app/views/user/swaps/_swap_profile_inner.html.haml
+++ b/app/views/user/swaps/_swap_profile_inner.html.haml
@@ -1,5 +1,5 @@
 %img.profile-img{ src: other_user.image_url }
-.profile-content
+.profile-content{ class: [hide_polls? ? 'without-polls' : 'with-polls'] }
   .profile-name= other_user.redacted_name
 
   .profile-icons

--- a/app/views/user/swaps/new.html.haml
+++ b/app/views/user/swaps/new.html.haml
@@ -1,8 +1,8 @@
 .background-pattern.border-bottom
   .container.container-narrow
     .smv-card.profile
-      = render partial: "swap_profile", locals: { other_user: @swap_with, hide_polls: @hide_polls}
-    = render partial: "user/swaps/double_check_constituency", locals: { swap_with: @swap_with, hide_polls: @hide_polls }
+      = render partial: "swap_profile", locals: { other_user: @swap_with }
+    = render partial: "user/swaps/double_check_constituency", locals: { swap_with: @swap_with  }
     %p.text-center
       Are you sure you would like to swap your vote with #{@swap_with.redacted_name}?
 
@@ -23,4 +23,3 @@
     %p.text-center.small.subdued
       We'll send #{@swap_with.redacted_name} a confirmation email, and if they agree,
       you're all good to go! Democracy here we come.
-

--- a/app/views/user/swaps/show.html.haml
+++ b/app/views/user/swaps/show.html.haml
@@ -6,7 +6,7 @@
 
     - if @potential_swaps.length > 0
       = render partial: "user/swaps/list_potential_swaps",
-               locals: {expiry: potential_swap_expiry_mins, hide_polls: @hide_polls}
+               locals: {expiry: potential_swap_expiry_mins}
     - else
       = render partial: "user/swaps/searching_for_swap"
 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -5,12 +5,12 @@
   .container.container-narrow
     - if @user.swap_confirmed?
       = render partial: "users/show/swap_confirmed",
-        locals: {user: @user, hide_polls: @hide_polls}
+        locals: {user: @user}
     - elsif @user.outgoing_swap
       = render partial: "users/show/confirm_outgoing_swap",
-        locals: {user: @user, hide_polls: @hide_polls}
+        locals: {user: @user}
     - elsif @user.incoming_swap
       = render partial: "users/show/confirm_incoming_swap",
-        locals: {user: @user, mobile_number: @mobile_number, hide_polls: @hide_polls}
+        locals: {user: @user, mobile_number: @mobile_number}
 
 = render partial: "users/info_summary"

--- a/app/views/users/show/_confirm_incoming_swap.html.haml
+++ b/app/views/users/show/_confirm_incoming_swap.html.haml
@@ -4,10 +4,10 @@
 %p
   .smv-card.profile
     = render partial: "user/swaps/swap_profile",
-      locals: {other_user: user.swapped_with, hide_polls: hide_polls}
+      locals: {other_user: user.swapped_with}
 
 = render partial: "user/swaps/double_check_constituency",
-    locals: { swap_with: user.swapped_with, hide_polls: hide_polls }
+    locals: { swap_with: user.swapped_with}
 
 %p.text-center
   - if current_user.mobile_verification_missing?

--- a/app/views/users/show/_confirm_outgoing_swap.html.haml
+++ b/app/views/users/show/_confirm_outgoing_swap.html.haml
@@ -4,7 +4,7 @@
 %p
   .smv-card.profile
     = render partial: "user/swaps/swap_profile",
-    locals: {other_user: user.swapped_with, hide_polls: hide_polls}
+    locals: {other_user: user.swapped_with}
 
 %p.text-center
   %i.fa.fa-fw.fa-hourglass-half

--- a/app/views/users/show/_swap_confirmed.html.haml
+++ b/app/views/users/show/_swap_confirmed.html.haml
@@ -4,7 +4,7 @@
 %p
   .smv-card.profile
     = render partial: "user/swaps/swap_profile",
-    locals: {other_user: user.swapped_with, hide_polls: hide_polls}
+    locals: {other_user: user.swapped_with}
 
 %p.text-center
   #{user.swapped_with.name} will vote


### PR DESCRIPTION
When we're in two-constituency by-election mode, we hide GE2019 polls.  But this left some unused space in the profile card, so fix the layout to only shrink the `div.profile-content` to 60% width if we're showing polls.

Also move the two party / hidden polls test from a controller to a helper, so that it's available everywhere in user views by default, which means we don't have to pass it around as a local.
