### PR TITLE
update app.json to skip deploying add-ons for review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -87,23 +87,8 @@
   "image": "heroku/ruby",
   "addons": [
     {
-      "plan": "airbrake:free_heroku",
-      "as": "AIRBRAKE"
-    },
-    {
-      "plan": "heroku-postgresql",
-      "as": "DATABASE",
-      "options": {
-        "version": "9.5"
-      }
-    },
-    {
       "plan": "mailgun:starter",
       "as": "MAILGUN"
-    },
-    {
-      "plan": "scheduler:standard",
-      "as": "SCHEDULER"
     }
   ],
   "buildpacks": [


### PR DESCRIPTION
We don't need all these add-ons for review apps.  We can reuse the swapmyvotedev DB.