### PR TITLE
force single column action network form

### DIFF
--- a/app/views/home/_actionnetwork.html
+++ b/app/views/home/_actionnetwork.html
@@ -16,6 +16,15 @@
 	    margin: 0 auto !important;
 	}
 
+
+	/* FORCE SINGLE COLUMN FORM */
+
+	#can_embed_form.can_float #form_col1,
+	#can_embed_form.can_float #form_col2 {
+	    float: none !important;
+	    width: 100% !important;
+	}
+
 	/* HIDE HEADERS */
 	#can_embed_form h2,
 	#can_embed_form h4{


### PR DESCRIPTION
for some reason the form sometimes displays as two columns, this css fixes that.