### PR TITLE
issue 612 craft ogp info static pages

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -18,8 +18,11 @@
     %meta{name: "twitter:description", content: "Make your vote count in the June 23rd 2022 by-elections!"}
     %meta{name: "twitter:image", content: image_url("facebook_sharing_banner_BE2022.png")}
 
-    %meta{property: "description", content: "Make votes matter! Swap yours with someone in a constituency where both could count for more. You get to vote for who you really want, and help someone else do the same. Turn tactical voting into a win-win!"}
-    %meta{property: "og:description", content: "Make votes matter! Swap yours with someone in a constituency where both could count for more. You get to vote for who you really want, and help someone else do the same. Turn tactical voting into a win-win!"}
+    - meta_description = "Make votes matter! Swap yours with someone in a constituency where both could count for more. You get to vote for who you really want, and help someone else do the same. Turn tactical voting into a win-win!"
+    - meta_og_description = yield(:meta_og_description).strip || meta_description
+    %meta{property: "description", content: meta_description }
+    %meta{property: "og:description", content: meta_og_description }
+
     %meta{property: "og:url", content: "https://www.swapmyvote.uk"}
 
     = favicon_link_tag(source="favicon_16.png", {sizes: "16x16"})

--- a/app/views/static_pages/about.html.haml
+++ b/app/views/static_pages/about.html.haml
@@ -1,5 +1,5 @@
 - content_for(:meta_og_description) do
-  Special OG description for this page
+  Make votes matter! Swap yours with someone in a constituency where both could count for more. You get to vote for who you really want, and help someone else do the same. Turn tactical voting into a win-win!
 .plain-pattern.border-bottom
   .container
     %h1 About Swap My Vote

--- a/app/views/static_pages/about.html.haml
+++ b/app/views/static_pages/about.html.haml
@@ -1,3 +1,5 @@
+- content_for(:meta_og_description) do
+  Special OG description for this page
 .plain-pattern.border-bottom
   .container
     %h1 About Swap My Vote

--- a/app/views/static_pages/api.html.haml
+++ b/app/views/static_pages/api.html.haml
@@ -1,4 +1,6 @@
 -# haml-lint: disable ViewLength
+- content_for(:meta_og_description) do
+  Special OG description for this page
 .plain-pattern.border-bottom
   .container.api
     %h1 Swap My Vote API

--- a/app/views/static_pages/api.html.haml
+++ b/app/views/static_pages/api.html.haml
@@ -1,6 +1,6 @@
 -# haml-lint: disable ViewLength
 - content_for(:meta_og_description) do
-  Special OG description for this page
+  Make votes matter! Swap yours with someone in a constituency where both could count for more. You get to vote for who you really want, and help someone else do the same. Turn tactical voting into a win-win!
 .plain-pattern.border-bottom
   .container.api
     %h1 Swap My Vote API

--- a/app/views/static_pages/contact.html.haml
+++ b/app/views/static_pages/contact.html.haml
@@ -1,5 +1,5 @@
 - content_for(:meta_og_description) do
-  Special OG description for this page
+  Make votes matter! Swap yours with someone in a constituency where both could count for more. You get to vote for who you really want, and help someone else do the same. Turn tactical voting into a win-win!
 .plain-pattern.border-bottom
   .container
     %h2 Contact details

--- a/app/views/static_pages/contact.html.haml
+++ b/app/views/static_pages/contact.html.haml
@@ -1,3 +1,5 @@
+- content_for(:meta_og_description) do
+  Special OG description for this page
 .plain-pattern.border-bottom
   .container
     %h2 Contact details

--- a/app/views/static_pages/cookies.html.haml
+++ b/app/views/static_pages/cookies.html.haml
@@ -1,5 +1,5 @@
 - content_for(:meta_og_description) do
-  Special OG description for this page
+  Make votes matter! Swap yours with someone in a constituency where both could count for more. You get to vote for who you really want, and help someone else do the same. Turn tactical voting into a win-win!
 .plain-pattern.border-bottom
   .container
     %h1 Cookie Policy

--- a/app/views/static_pages/cookies.html.haml
+++ b/app/views/static_pages/cookies.html.haml
@@ -1,3 +1,5 @@
+- content_for(:meta_og_description) do
+  Special OG description for this page
 .plain-pattern.border-bottom
   .container
     %h1 Cookie Policy

--- a/app/views/static_pages/faq.html.haml
+++ b/app/views/static_pages/faq.html.haml
@@ -1,4 +1,6 @@
 -# haml-lint: disable ViewLength
+- content_for(:meta_og_description) do
+  Special OG description for this page
 .plain-pattern.border-bottom
   .container
     %h1 FAQ

--- a/app/views/static_pages/faq.html.haml
+++ b/app/views/static_pages/faq.html.haml
@@ -1,6 +1,6 @@
 -# haml-lint: disable ViewLength
 - content_for(:meta_og_description) do
-  Special OG description for this page
+  Make votes matter! Swap yours with someone in a constituency where both could count for more. You get to vote for who you really want, and help someone else do the same. Turn tactical voting into a win-win!
 .plain-pattern.border-bottom
   .container
     %h1 FAQ

--- a/app/views/static_pages/privacy.html.haml
+++ b/app/views/static_pages/privacy.html.haml
@@ -1,4 +1,6 @@
 -# haml-lint: disable ViewLength
+- content_for(:meta_og_description) do
+  Special OG description for this page
 .plain-pattern.border-bottom
   .container
     %h1 Privacy Policy

--- a/app/views/static_pages/privacy.html.haml
+++ b/app/views/static_pages/privacy.html.haml
@@ -1,6 +1,6 @@
 -# haml-lint: disable ViewLength
 - content_for(:meta_og_description) do
-  Special OG description for this page
+  Make votes matter! Swap yours with someone in a constituency where both could count for more. You get to vote for who you really want, and help someone else do the same. Turn tactical voting into a win-win!
 .plain-pattern.border-bottom
   .container
     %h1 Privacy Policy

--- a/app/views/static_pages/terms.html.haml
+++ b/app/views/static_pages/terms.html.haml
@@ -1,6 +1,6 @@
 -# haml-lint: disable ViewLength
 - content_for(:meta_og_description) do
-  Special OG description for this page
+  Make votes matter! Swap yours with someone in a constituency where both could count for more. You get to vote for who you really want, and help someone else do the same. Turn tactical voting into a win-win!
 .plain-pattern.border-bottom
   .container
     %h1 Terms and Conditions of Use

--- a/app/views/static_pages/terms.html.haml
+++ b/app/views/static_pages/terms.html.haml
@@ -1,4 +1,6 @@
 -# haml-lint: disable ViewLength
+- content_for(:meta_og_description) do
+  Special OG description for this page
 .plain-pattern.border-bottom
   .container
     %h1 Terms and Conditions of Use


### PR DESCRIPTION
Gives the means to finish #612 . Placeholder text is the same as the
default. All that's needed to complete #612 is finalising the text.

 I will create a review app for this. 

- layout change to make override of meta og:description possible (#612)
- overrides for all the static pages
- placeholder overrides for all the static pages, with the same text as default, just needs edit when text is ready (#612)
