### PR TITLE
close off the route to empty constituencies via user/constituencies/edit (#622)

### DIFF
--- a/app/controllers/user/constituencies_controller.rb
+++ b/app/controllers/user/constituencies_controller.rb
@@ -11,14 +11,14 @@ class User::ConstituenciesController < ApplicationController
   def update
     ons_id = user_params[:constituency_ons_id]
 
-    if (!ons_id.nil? && !ons_id.empty?)
+    if !ons_id.nil? && !ons_id.empty?
 
       @user.update(user_params)
       redirect_to user_swap_path
 
     else
 
-      flash.now[:errors] = ['You must tell us your constituency. Without it, the swaps we offer may not make sense']
+      flash.now[:errors] = ["You must tell us your constituency. Without it, the swaps we offer may not make sense"]
       edit
       render "edit"
 

--- a/app/controllers/user/constituencies_controller.rb
+++ b/app/controllers/user/constituencies_controller.rb
@@ -9,8 +9,20 @@ class User::ConstituenciesController < ApplicationController
   end
 
   def update
-    @user.update(user_params)
-    redirect_to user_swap_path
+    ons_id = user_params[:constituency_ons_id]
+
+    if (!ons_id.nil? && !ons_id.empty?)
+
+      @user.update(user_params)
+      redirect_to user_swap_path
+
+    else
+
+      flash.now[:errors] = ['You must tell us your constituency. Without it, the swaps we offer may not make sense']
+      edit
+      render "edit"
+
+    end
   end
 
   private

--- a/spec/controllers/user/constituencies_controller_spec.rb
+++ b/spec/controllers/user/constituencies_controller_spec.rb
@@ -60,15 +60,15 @@ RSpec.describe User::ConstituenciesController, type: :controller do
         end
 
         context "and constituency_ons_id is empty string" do
-          before  { allow(logged_in_user).to receive(:constituency_ons_id).and_return('') }
+          before  { allow(logged_in_user).to receive(:constituency_ons_id).and_return("") }
 
           it "does NOT update the user" do
             expect(logged_in_user).not_to receive(:update)
-            patch :update, params: { user: { constituency_ons_id: '', email: "a@b.c" }   }
+            patch :update, params: { user: { constituency_ons_id: "", email: "a@b.c" }   }
           end
 
           it "does NOT redirect to user share" do
-            patch :update, params: { user: { constituency_ons_id: '', email: "a@b.c" }   }
+            patch :update, params: { user: { constituency_ons_id: "", email: "a@b.c" }   }
             expect(response).not_to redirect_to(:user_swap)
           end
         end

--- a/spec/controllers/user/constituencies_controller_spec.rb
+++ b/spec/controllers/user/constituencies_controller_spec.rb
@@ -47,14 +47,44 @@ RSpec.describe User::ConstituenciesController, type: :controller do
       describe "PATCH #update" do
         before { allow(logged_in_user).to receive(:update) }
 
-        it "updates the user" do
-          expect(logged_in_user).to receive(:update)
-          patch :update, params: { user: { constituency_ons_id: 2, email: "a@b.c" }   }
+        context "and constituency_ons_id is provided" do
+          it "updates the user" do
+            expect(logged_in_user).to receive(:update)
+            patch :update, params: { user: { constituency_ons_id: 2, email: "a@b.c" }   }
+          end
+
+          it "redirects to user share" do
+            patch :update, params: { user: { constituency_ons_id: 2, email: "a@b.c" }   }
+            expect(response).to redirect_to(:user_swap)
+          end
         end
 
-        it "redirects to user share" do
-          patch :update, params: { user: { constituency_ons_id: 2, email: "a@b.c" }   }
-          expect(response).to redirect_to(:user_swap)
+        context "and constituency_ons_id is empty string" do
+          before  { allow(logged_in_user).to receive(:constituency_ons_id).and_return('') }
+
+          it "does NOT update the user" do
+            expect(logged_in_user).not_to receive(:update)
+            patch :update, params: { user: { constituency_ons_id: '', email: "a@b.c" }   }
+          end
+
+          it "does NOT redirect to user share" do
+            patch :update, params: { user: { constituency_ons_id: '', email: "a@b.c" }   }
+            expect(response).not_to redirect_to(:user_swap)
+          end
+        end
+
+        context "and constituency_ons_id is nil" do
+          before  { allow(logged_in_user).to receive(:constituency_ons_id).and_return(nil) }
+
+          it "does NOT update the user" do
+            expect(logged_in_user).not_to receive(:update)
+            patch :update, params: { user: { constituency_ons_id: nil, email: "a@b.c" }   }
+          end
+
+          it "does NOT redirect to user share" do
+            patch :update, params: { user: { constituency_ons_id: nil, email: "a@b.c" }   }
+            expect(response).not_to redirect_to(:user_swap)
+          end
         end
       end
     end


### PR DESCRIPTION
Should close #622

Please can someone other than me try to prove this works ? @tdg @aspiers ?

Register as a new user, and see if you can get to a point of seeing
swaps without setting your constituency ?

I don't think it can be done any more, as of this fix
