### PR TITLE
email templates refactor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,7 @@ group :development, :test do
   gem "rspec-rails", "~> 3.8"
   gem "capybara"
   gem "database_cleaner"
+  gem "rspec-snapshot"
 
   # Guard checks everything when you save a file
   gem "guard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.2.5.1)
       execjs (> 0)
+    awesome_print (1.9.2)
     bcrypt (3.1.16)
     bindex (0.8.1)
     bootsnap (1.7.5)
@@ -334,6 +335,9 @@ GEM
       rspec-expectations (~> 3.9.0)
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
+    rspec-snapshot (2.0.1)
+      awesome_print (> 1.0.0)
+      rspec (> 3.0.0)
     rspec-support (3.9.4)
     rubocop (1.22.3)
       parallel (~> 1.10)
@@ -466,6 +470,7 @@ DEPENDENCIES
   rails-controller-testing
   random_data
   rspec-rails (~> 3.8)
+  rspec-snapshot
   rubocop (~> 1.22.1)
   rubocop-rails
   rubocop-rspec

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -88,6 +88,10 @@ module ApplicationHelper
     @donate_info = { link: link, show: show }
   end
 
+  def election_event_title
+    "Wakefield and Tiverton & Honiton 2022 by-elections"
+  end
+
   def election_hashtags
     "#Wakefield or #TivertonandHoniton #byelection"
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -96,16 +96,20 @@ module ApplicationHelper
     "#Wakefield or #TivertonandHoniton #byelection"
   end
 
-  def app_tagline
+  def app_taglines
     [
-      "I am using Swap My Vote to make my vote count in the" +
+      "I am using Swap My Vote to make my vote count in the " +
       "#Wakefield or #TivertonandHoniton #byelection\\n\\n" +
       "#SwapMyVote",
 
       "Use Swap My Vote to make your vote count in the " +
       "#Wakefield or #TivertonandHoniton #byelection\\n\\n" +
       "#SwapMyVote",
-    ].sample
+    ]
+  end
+
+  def app_tagline
+    app_taglines.sample
   end
 
   def hide_polls?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -88,6 +88,10 @@ module ApplicationHelper
     @donate_info = { link: link, show: show }
   end
 
+  def election_hashtags
+    "#Wakefield or #TivertonandHoniton #byelection"
+  end
+
   def app_tagline
     [
       "I am using Swap My Vote to make my vote count in the" +

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -99,11 +99,13 @@ module ApplicationHelper
   def app_taglines
     [
       "I am using Swap My Vote to make my vote count in the " +
-      "#Wakefield or #TivertonandHoniton #byelection\\n\\n" +
+      election_hashtags +
+      "\\n\\n" +
       "#SwapMyVote",
 
       "Use Swap My Vote to make your vote count in the " +
-      "#Wakefield or #TivertonandHoniton #byelection\\n\\n" +
+      election_hashtags +
+      "\\n\\n" +
       "#SwapMyVote",
     ]
   end

--- a/app/views/user_mailer/_social_media_im_using_links.html.haml
+++ b/app/views/user_mailer/_social_media_im_using_links.html.haml
@@ -1,0 +1,2 @@
+<a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
+<a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>

--- a/app/views/user_mailer/_social_media_im_using_links.html.haml
+++ b/app/views/user_mailer/_social_media_im_using_links.html.haml
@@ -1,2 +1,7 @@
-<a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
-<a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
+- twitter_link = "https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote"
+
+= link_to "Tweet", twitter_link
+
+- facebook_link = "https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin"
+
+= link_to "Share on Facebook", facebook_link

--- a/app/views/user_mailer/_social_media_im_using_links.html.haml
+++ b/app/views/user_mailer/_social_media_im_using_links.html.haml
@@ -1,4 +1,9 @@
-- twitter_link = "https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote"
+
+- twitter_raw_text = "I'm using https://SwapMyVote.uk to make my vote count in the #Wakefield or #TivertonandHoniton #byelection\n\n#SwapMyVote @SwapMyVote"
+
+- twitter_text = CGI.escape(twitter_raw_text)
+
+- twitter_link = "https://twitter.com/intent/tweet?text=#{twitter_text}"
 
 = link_to "Tweet", twitter_link
 

--- a/app/views/user_mailer/_social_media_im_using_links.html.haml
+++ b/app/views/user_mailer/_social_media_im_using_links.html.haml
@@ -1,5 +1,5 @@
 
-- twitter_raw_text = "I'm using https://SwapMyVote.uk to make my vote count in the #Wakefield or #TivertonandHoniton #byelection\n\n#SwapMyVote @SwapMyVote"
+- twitter_raw_text = "I'm using https://SwapMyVote.uk to make my vote count in the #{election_hashtags}\n\n#SwapMyVote @SwapMyVote"
 
 - twitter_text = CGI.escape(twitter_raw_text)
 

--- a/app/views/user_mailer/confirm_swap.html.haml
+++ b/app/views/user_mailer/confirm_swap.html.haml
@@ -32,9 +32,7 @@
 
   Lastly, why not share Swap My Vote with your social networks so that more people can make their vote count?
 
-  <a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
-  <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
-
+  = render partial: "social_media_im_using_links"
 %p
   To a better democracy!
   %br

--- a/app/views/user_mailer/email_address_shared.html.haml
+++ b/app/views/user_mailer/email_address_shared.html.haml
@@ -14,8 +14,7 @@
   And don't forget to share Swap My Vote with your social networks so
   that more people can make their vote count:
 
-  <a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
-  <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
+  = render partial: "social_media_im_using_links"
 %p
   To a better democracy!
   %br

--- a/app/views/user_mailer/no_swap.haml
+++ b/app/views/user_mailer/no_swap.haml
@@ -3,7 +3,7 @@
 
 %p
 
-  The Wakefield and Tiverton & Honiton 2022 by-election polls have
+  The #{election_event_title} polls have
   just opened, but we are sorry to say that we haven't been able
   to match you up with someone to swap with.
 

--- a/app/views/user_mailer/reminder_to_vote.html.haml
+++ b/app/views/user_mailer/reminder_to_vote.html.haml
@@ -3,7 +3,7 @@
 
 %p
 
-  The Wakefield and Tiverton & Honiton 2022 by-elections
+  The #{election_event_title} polls
   are now open!
 
   = user_profile_link(@user.swapped_with)

--- a/app/views/user_mailer/swap_confirmed.html.haml
+++ b/app/views/user_mailer/swap_confirmed.html.haml
@@ -28,8 +28,7 @@
   Lastly, why not share Swap My Vote with your social networks so that
   more people can make their vote count?
 
-  <a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
-  <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
+  = render partial: "social_media_im_using_links"
 %p
   To a better democracy!
   %br

--- a/app/views/user_mailer/swap_not_confirmed.html.haml
+++ b/app/views/user_mailer/swap_not_confirmed.html.haml
@@ -2,8 +2,7 @@
   Hi #{@user.name},
 
 %p
-
-  The Wakefield and Tiverton & Honiton 2022 by-election polls have
+  The #{election_event_title} polls have
   just opened, but I'm afraid we haven't been able to confirm your
   pending swap with #{@user.swapped_with.redacted_name}.
 

--- a/app/views/user_mailer/welcome_email.html.haml
+++ b/app/views/user_mailer/welcome_email.html.haml
@@ -56,9 +56,7 @@
   details of your new voting partner.
 
 %p
-  <a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
-  <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
-
+  = render partial: "social_media_im_using_links"
 %p
 
   Meanwhile if you’ve got any questions please head over to the <a
@@ -76,9 +74,7 @@
   know about Swap My Vote!
 
 %p
-  <a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
-  <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
-
+  = render partial: "social_media_im_using_links"
 %p
   Happy voting!
   %br

--- a/doc/new_election/by_election_data_coding_tasks.md
+++ b/doc/new_election/by_election_data_coding_tasks.md
@@ -27,6 +27,11 @@ We should either get an update, or find a way to hide the polls data from voters
 
 For a two party by-election, the method hide_polls? will automatically hide the polls (since they're not needed as selection criteria)
 
+The text about whether electoral calculus data is a prediction or an election result may need to be adjusted in these two templates
+
+  app/views/user/swaps/_list_potential_swaps.html.haml
+  app/views/user/swaps/_swap_profile_inner.html.haml
+
 ### Tactical Voting Recommendations
 
 Needs thorough review. We can't necessarily rely on the previous aggregator (LiveFromBrexit) giving us the same date in the same format from the same providers. We may need to find a way to hide this data. Or simply not load the data.

--- a/doc/new_election/by_election_data_coding_tasks.md
+++ b/doc/new_election/by_election_data_coding_tasks.md
@@ -1,0 +1,37 @@
+# New Election - By Election Data and Coding Tasks
+
+In general [db/fixtures/README](../../db/fixtures/README.md) can be a guide. If no other reference is given, it should be covered there.
+
+## Preparing data
+
+### Switch to by election mode if need be
+
+See [db/seeds.rb](../seeds.rb) and [db/seeds_for_general_election.rb](../seeds_for_general_election.rb) and edit.
+
+### YAML file
+
+A yaml file needs to be prepared with all the party and constituency data. Previous yaml files should be a guide, for example see the commits for the By Election in 2020 and the files 
+
+    db/seeds.rb
+    db/fixtures/be2022/candidate.rb
+    db/fixtures/be2022/party.rb
+    spec/db/fixtures/be2022/candidate_spec.rb
+    spec/db/fixtures/be2022/party_spec.rb
+    db/fixtures/be2022.yml
+    db/fixtures/be2022_yaml.rb
+    spec/db/fixtures/be2022_yaml_spec.rb
+
+### Poll predictions from electoral calculus
+
+We should either get an update, or find a way to hide the polls data from voters. Method hide_polls? in [app/helpers/application_helper.rb](../../app/helpers/application_helper.rb) should let us do it. 
+
+For a two party by-election, the method hide_polls? will automatically hide the polls (since they're not needed as selection criteria)
+
+### Tactical Voting Recommendations
+
+Needs thorough review. We can't necessarily rely on the previous aggregator (LiveFromBrexit) giving us the same date in the same format from the same providers. We may need to find a way to hide this data. Or simply not load the data.
+
+## Preparing database
+
+In [doc/admin-guide.md](../admin-guide.md) see the last step 'Resetting Heroku database for a new election cycle'
+

--- a/doc/new_election/by_election_data_coding_tasks.md
+++ b/doc/new_election/by_election_data_coding_tasks.md
@@ -6,7 +6,7 @@ In general [db/fixtures/README](../../db/fixtures/README.md) can be a guide. If 
 
 ### Switch to by election mode if need be
 
-See [db/seeds.rb](../seeds.rb) and [db/seeds_for_general_election.rb](../seeds_for_general_election.rb) and edit.
+See [db/seeds.rb](../../db/seeds.rb) and [db/seeds_for_general_election.rb](../../db/seeds_for_general_election.rb) and edit.
 
 ### YAML file
 

--- a/doc/new_election/by_election_data_coding_tasks.md
+++ b/doc/new_election/by_election_data_coding_tasks.md
@@ -36,7 +36,17 @@ The text about whether electoral calculus data is a prediction or an election re
 
 Needs thorough review. We can't necessarily rely on the previous aggregator (LiveFromBrexit) giving us the same date in the same format from the same providers. We may need to find a way to hide this data. Or simply not load the data.
 
+## Template changes
+
+These templates all refer to by elections or general election
+
+    app/views/user_mailer/confirm_swap.html.haml
+    app/views/user_mailer/email_address_shared.html.haml
+    app/views/user_mailer/swap_confirmed.html.haml
+    app/views/user_mailer/welcome_email.html.
+
+Also method app_tagline in app/helpers/application_helper.rb
+
 ## Preparing database
 
 In [doc/admin-guide.md](../admin-guide.md) see the last step 'Resetting Heroku database for a new election cycle'
-

--- a/doc/new_election/by_election_data_coding_tasks.md
+++ b/doc/new_election/by_election_data_coding_tasks.md
@@ -34,7 +34,9 @@ The text about whether electoral calculus data is a prediction or an election re
 
 ### Tactical Voting Recommendations
 
-Needs thorough review. We can't necessarily rely on the previous aggregator (LiveFromBrexit) giving us the same date in the same format from the same providers. We may need to find a way to hide this data. Or simply not load the data.
+Tactical voting suggestions were hidden in [this commit](https://github.com/swapmyvote/swapmyvote/commit/52fcb7866e1bb98dd42372464f9dc7d691c76d3d) so reverting that would be a good start, if we decide we want this feature back.
+
+But, this needs thorough review. We can't necessarily rely on the previous aggregator (LiveFromBrexit) giving us the same date in the same format from the same providers.
 
 ## Template changes
 

--- a/doc/new_election/by_election_data_coding_tasks.md
+++ b/doc/new_election/by_election_data_coding_tasks.md
@@ -40,14 +40,11 @@ But, this needs thorough review. We can't necessarily rely on the previous aggre
 
 ## Template changes
 
-These templates all refer to by elections or general election
+This template has very chatty text giving the context of the election
 
-    app/views/user_mailer/confirm_swap.html.haml
-    app/views/user_mailer/email_address_shared.html.haml
-    app/views/user_mailer/swap_confirmed.html.haml
     app/views/user_mailer/welcome_email.html.
 
-Also method app_tagline in app/helpers/application_helper.rb
+Also in app/helpers/application_helper.rb the two methods election_event_title and election_hashtags need updating but could be automated depending on the constituencies defined in the database.
 
 ## Preparing database
 

--- a/doc/new_election/general_election_data_coding_tasks.md
+++ b/doc/new_election/general_election_data_coding_tasks.md
@@ -23,7 +23,9 @@ The text about whether electoral calculus data is a prediction or an election re
 
 ### Tactical Voting Recommendations
 
-Needs thorough review. We can't necessarily rely on the previous aggregator (LiveFromBrexit) giving us the same date in the same format from the same providers. We may need to find a way to hide this data. Or simply not load the data.
+Tactical voting suggestions were hidden in [this commit](https://github.com/swapmyvote/swapmyvote/commit/52fcb7866e1bb98dd42372464f9dc7d691c76d3d) so reverting that would be a good start, if we decide we want this feature back.
+
+But, this needs thorough review. We can't necessarily rely on the previous aggregator (LiveFromBrexit) giving us the same date in the same format from the same providers.
 
 ## Template changes
 

--- a/doc/new_election/general_election_data_coding_tasks.md
+++ b/doc/new_election/general_election_data_coding_tasks.md
@@ -16,6 +16,11 @@ Consider if constituecies data needs an update. May be need for boundary changes
 
 We should either get an update, or find a way to hide the polls data from voters. Method hide_polls? in [app/helpers/application_helper.rb](../../app/helpers/application_helper.rb) should let us do it.
 
+The text about whether electoral calculus data is a prediction or an election result may need to be adjusted in these two templates
+
+  app/views/user/swaps/_list_potential_swaps.html.haml
+  app/views/user/swaps/_swap_profile_inner.html.haml
+
 ### Tactical Voting Recommendations
 
 Needs thorough review. We can't necessarily rely on the previous aggregator (LiveFromBrexit) giving us the same date in the same format from the same providers. We may need to find a way to hide this data. Or simply not load the data.

--- a/doc/new_election/general_election_data_coding_tasks.md
+++ b/doc/new_election/general_election_data_coding_tasks.md
@@ -29,14 +29,11 @@ But, this needs thorough review. We can't necessarily rely on the previous aggre
 
 ## Template changes
 
-These templates all refer to by elections or general election
+This template has very chatty text giving the context of the election
 
-    app/views/user_mailer/confirm_swap.html.haml
-    app/views/user_mailer/email_address_shared.html.haml
-    app/views/user_mailer/swap_confirmed.html.haml
-    app/views/user_mailer/welcome_email.html.haml
+    app/views/user_mailer/welcome_email.html.
 
-Also method app_tagline in app/helpers/application_helper.rb
+Also in app/helpers/application_helper.rb the two methods election_event_title and election_hashtags need updating but could be automated depending on the constituencies defined in the database.
 
 ## Preparing database
 

--- a/doc/new_election/general_election_data_coding_tasks.md
+++ b/doc/new_election/general_election_data_coding_tasks.md
@@ -25,7 +25,17 @@ The text about whether electoral calculus data is a prediction or an election re
 
 Needs thorough review. We can't necessarily rely on the previous aggregator (LiveFromBrexit) giving us the same date in the same format from the same providers. We may need to find a way to hide this data. Or simply not load the data.
 
+## Template changes
+
+These templates all refer to by elections or general election
+
+    app/views/user_mailer/confirm_swap.html.haml
+    app/views/user_mailer/email_address_shared.html.haml
+    app/views/user_mailer/swap_confirmed.html.haml
+    app/views/user_mailer/welcome_email.html.haml
+
+Also method app_tagline in app/helpers/application_helper.rb
+
 ## Preparing database
 
 In [doc/admin-guide.md](../admin-guide.md) see the last step 'Resetting Heroku database for a new election cycle'
-

--- a/doc/new_election/general_election_data_coding_tasks.md
+++ b/doc/new_election/general_election_data_coding_tasks.md
@@ -1,0 +1,26 @@
+# New Election - General Election Data and Coding Tasks
+
+In general [db/fixtures/README](../../db/fixtures/README.md) can be a guide. If no other reference is given, it should be covered there. 
+
+## Preparing data
+
+### Switch to general election mode if need be
+
+See [db/seeds.rb](../seeds.rb) and [db/seeds_for_general_election.rb](../seeds_for_general_election.rb) and edit.
+
+### Constituencies
+
+Consider if constituecies data needs an update. May be need for boundary changes. 
+
+### Poll predictions from electoral calculus
+
+We should either get an update, or find a way to hide the polls data from voters. Method hide_polls? in [app/helpers/application_helper.rb](../../app/helpers/application_helper.rb) should let us do it.
+
+### Tactical Voting Recommendations
+
+Needs thorough review. We can't necessarily rely on the previous aggregator (LiveFromBrexit) giving us the same date in the same format from the same providers. We may need to find a way to hide this data. Or simply not load the data.
+
+## Preparing database
+
+In [doc/admin-guide.md](../admin-guide.md) see the last step 'Resetting Heroku database for a new election cycle'
+

--- a/doc/new_election/general_election_data_coding_tasks.md
+++ b/doc/new_election/general_election_data_coding_tasks.md
@@ -6,7 +6,7 @@ In general [db/fixtures/README](../../db/fixtures/README.md) can be a guide. If 
 
 ### Switch to general election mode if need be
 
-See [db/seeds.rb](../seeds.rb) and [db/seeds_for_general_election.rb](../seeds_for_general_election.rb) and edit.
+See [db/seeds.rb](../../db/seeds.rb) and [db/seeds_for_general_election.rb](../../db/seeds_for_general_election.rb) and edit.
 
 ### Constituencies
 

--- a/spec/factories/swaps.rb
+++ b/spec/factories/swaps.rb
@@ -1,4 +1,8 @@
 FactoryBot.define do
   factory :swap do
+    factory :swap_with_two_users do
+      choosing_user { association :ready_to_swap_user1, outgoing_swap: instance }
+      chosen_user { association :ready_to_swap_user2, incoming_swap: instance }
+    end
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     end
 
     factory :ready_to_swap_user2 do
+      name { "Jane" }
       association :constituency, factory: :ons_constituency, name: "Constituency2"
       association :preferred_party, factory: :party, name: "PartyB", color: "orange"
       association :willing_party, factory: :party, name: "PartyA", color: "green"

--- a/spec/helpers/__snapshots__/application_helper_app_taglines.snap
+++ b/spec/helpers/__snapshots__/application_helper_app_taglines.snap
@@ -1,0 +1,4 @@
+[
+  [0] "I am using Swap My Vote to make my vote count in the #Wakefield or #TivertonandHoniton #byelection\\n\\n#SwapMyVote",
+  [1] "Use Swap My Vote to make your vote count in the #Wakefield or #TivertonandHoniton #byelection\\n\\n#SwapMyVote"
+]

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -155,4 +155,10 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#app_taglines" do
+    it "matches snapshot" do
+      expect(helper.app_taglines).to match_snapshot("application_helper_app_taglines")
+    end
+  end
 end

--- a/spec/views/user_mailer/__snapshots__/confirm_swap.snap
+++ b/spec/views/user_mailer/__snapshots__/confirm_swap.snap
@@ -28,6 +28,7 @@ another voting partner from the list.
 Lastly, why not share Swap My Vote with your social networks so that more people can make their vote count?
 <a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
 <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
+
 </p>
 <p>
 To a better democracy!

--- a/spec/views/user_mailer/__snapshots__/confirm_swap.snap
+++ b/spec/views/user_mailer/__snapshots__/confirm_swap.snap
@@ -27,7 +27,7 @@ another voting partner from the list.
 <p>
 Lastly, why not share Swap My Vote with your social networks so that more people can make their vote count?
 <a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
-<a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
+<a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&amp;sdk=joey&amp;display=popup&amp;ref=plugin">Share on Facebook</a>
 
 </p>
 <p>

--- a/spec/views/user_mailer/__snapshots__/confirm_swap.snap
+++ b/spec/views/user_mailer/__snapshots__/confirm_swap.snap
@@ -26,7 +26,7 @@ another voting partner from the list.
 </p>
 <p>
 Lastly, why not share Swap My Vote with your social networks so that more people can make their vote count?
-<a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
+<a href="https://twitter.com/intent/tweet?text=I%27m+using+https%3A%2F%2FSwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0A%0A%23SwapMyVote+%40SwapMyVote">Tweet</a>
 <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&amp;sdk=joey&amp;display=popup&amp;ref=plugin">Share on Facebook</a>
 
 </p>

--- a/spec/views/user_mailer/__snapshots__/confirm_swap.snap
+++ b/spec/views/user_mailer/__snapshots__/confirm_swap.snap
@@ -1,0 +1,44 @@
+<p>
+Hi John (test user),
+</p>
+<p>
+Good news! Jane (test user) would like to swap their vote
+and will vote for your preferred party if you vote for theirs, in
+your constituency!
+</p>
+<p>
+<a href="http://test.host/user">Click here to confirm this swap!</a>
+</p>
+<p>
+Please confirm this swap as soon as possible. Votes for your
+preferred party are in demand, so if you don't confirm this swap, we
+may not be able to find you someone else to swap with. If we don't
+get a confirmation in the next 48 hours, we'll
+have to look for someone else to swap with.
+</p>
+<p>
+If for any reason you don't wish to swap with
+Jane (test user), you can find new potential voting
+partners by simply updating your info using the link that says "Not
+right? Update your info". This will reset the swap, letting your
+partner know it has been cancelled. You are then free to select
+another voting partner from the list.
+</p>
+<p>
+Lastly, why not share Swap My Vote with your social networks so that more people can make their vote count?
+<a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
+<a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
+</p>
+<p>
+To a better democracy!
+<br>
+Swap My Vote Team
+</p>
+<p>
+<a href="https://www.swapmyvote.uk/?utm_source=email&utm_medium=confirm_swap&utm_campaign=site">Swap My Vote</a>
+<br>
+<a href="https://twitter.com/intent/follow?screen_name=swapmyvote">Follow us on Twitter</a>
+<br>
+<a href="https://facebook.com/swapmyvote">Like us on Facebook</a>
+
+</p>

--- a/spec/views/user_mailer/__snapshots__/email_address_shared.snap
+++ b/spec/views/user_mailer/__snapshots__/email_address_shared.snap
@@ -15,7 +15,7 @@ Why not reach out and say hi?
 And don't forget to share Swap My Vote with your social networks so
 that more people can make their vote count:
 <a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
-<a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
+<a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&amp;sdk=joey&amp;display=popup&amp;ref=plugin">Share on Facebook</a>
 
 </p>
 <p>

--- a/spec/views/user_mailer/__snapshots__/email_address_shared.snap
+++ b/spec/views/user_mailer/__snapshots__/email_address_shared.snap
@@ -1,0 +1,32 @@
+<p>
+Hi John (test user),
+</p>
+<p>
+Good news! Jane (test user) is going swap their vote with you.
+They've now shared their email address with with you:
+</p>
+<p>
+<a href="mailto:jane@example.com">jane@example.com</a>
+</p>
+<p>
+Why not reach out and say hi?
+</p>
+<p>
+And don't forget to share Swap My Vote with your social networks so
+that more people can make their vote count:
+<a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
+<a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
+</p>
+<p>
+To a better democracy!
+<br>
+Swap My Vote Team
+</p>
+<p>
+<a href="https://www.swapmyvote.uk/?utm_source=email&utm_medium=confirm_swap&utm_campaign=site">Swap My Vote</a>
+<br>
+<a href="https://twitter.com/intent/follow?screen_name=swapmyvote">Follow us on Twitter</a>
+<br>
+<a href="https://facebook.com/swapmyvote">Like us on Facebook</a>
+
+</p>

--- a/spec/views/user_mailer/__snapshots__/email_address_shared.snap
+++ b/spec/views/user_mailer/__snapshots__/email_address_shared.snap
@@ -14,7 +14,7 @@ Why not reach out and say hi?
 <p>
 And don't forget to share Swap My Vote with your social networks so
 that more people can make their vote count:
-<a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
+<a href="https://twitter.com/intent/tweet?text=I%27m+using+https%3A%2F%2FSwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0A%0A%23SwapMyVote+%40SwapMyVote">Tweet</a>
 <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&amp;sdk=joey&amp;display=popup&amp;ref=plugin">Share on Facebook</a>
 
 </p>

--- a/spec/views/user_mailer/__snapshots__/email_address_shared.snap
+++ b/spec/views/user_mailer/__snapshots__/email_address_shared.snap
@@ -16,6 +16,7 @@ And don't forget to share Swap My Vote with your social networks so
 that more people can make their vote count:
 <a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
 <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
+
 </p>
 <p>
 To a better democracy!

--- a/spec/views/user_mailer/__snapshots__/no_swap.snap
+++ b/spec/views/user_mailer/__snapshots__/no_swap.snap
@@ -2,7 +2,7 @@
 Hi John (test user),
 </p>
 <p>
-The Wakefield and Tiverton & Honiton 2022 by-election polls have
+The Wakefield and Tiverton &amp; Honiton 2022 by-elections polls have
 just opened, but we are sorry to say that we haven't been able
 to match you up with someone to swap with.
 </p>

--- a/spec/views/user_mailer/__snapshots__/no_swap.snap
+++ b/spec/views/user_mailer/__snapshots__/no_swap.snap
@@ -1,0 +1,29 @@
+<p>
+Hi John (test user),
+</p>
+<p>
+The Wakefield and Tiverton & Honiton 2022 by-election polls have
+just opened, but we are sorry to say that we haven't been able
+to match you up with someone to swap with.
+</p>
+<p>
+All is not lost though - you can still vote for the party you most
+wish to support, or tactically for a greater good.
+</p>
+<p>
+Thank you very much for taking part - together we are making
+democracy better and more representative.
+</p>
+<p>
+All the very best,
+<br>
+Swap My Vote Team
+</p>
+<p>
+<a href="https://www.swapmyvote.uk/?utm_source=email&utm_medium=no_swap&utm_campaign=site">Swap My Vote</a>
+<br>
+<a href="https://twitter.com/intent/follow?screen_name=swapmyvote">Follow us on Twitter</a>
+<br>
+<a href="https://facebook.com/swapmyvote">Like us on Facebook</a>
+
+</p>

--- a/spec/views/user_mailer/__snapshots__/not_swapped_follow_up.snap
+++ b/spec/views/user_mailer/__snapshots__/not_swapped_follow_up.snap
@@ -1,0 +1,31 @@
+<p>
+Hi John (test user),
+</p>
+<p>
+Thanks for taking part in Swap My Vote!
+</p>
+<p>
+Votes for your party are in high demand; wanting to cast a vote elsewhere for
+the PartyA party means that you should
+have plenty of choice for potential voting partners to ensure your vote is
+cast where it will count the most for you.
+<a href="http://test.host/user">Log in to swapmyvote.uk now to find a swap partner.</a>
+</p>
+<p>
+If you've not been able to find someone that you're willing to swap with,
+then please reply to this email and let us know why. Hopefully we can improve
+the system so that we can find as many suitable swaps as possible!
+</p>
+<p>
+All the best,
+<br>
+Swap My Vote Team
+</p>
+<p>
+<a href="https://www.swapmyvote.uk/?utm_source=email&utm_medium=not_swapped_follow_up&utm_campaign=site">Swap My Vote</a>
+<br>
+<a href="https://twitter.com/intent/follow?screen_name=swapmyvote">Follow us on Twitter</a>
+<br>
+<a href="https://facebook.com/swapmyvote">Like us on Facebook</a>
+
+</p>

--- a/spec/views/user_mailer/__snapshots__/partner_has_voted.snap
+++ b/spec/views/user_mailer/__snapshots__/partner_has_voted.snap
@@ -1,0 +1,27 @@
+<p>
+Hi John (test user),
+</p>
+<p>
+Good news! Jane (test user) has voted
+<strong>for your preferred party in Constituency2!</strong>
+</p>
+<p>
+If you haven't done so already,
+<a href="http://test.host/user/vote">please let us know</a>
+when you've voted on behalf of Jane (test user) in
+Constituency1.
+<a href="http://test.host/user/vote">You can do that by clicking here.</a>
+</p>
+<p>
+All the best,
+<br>
+Swap My Vote Team
+</p>
+<p>
+<a href="https://www.swapmyvote.uk/?utm_source=email&utm_medium=partner_has_voted&utm_campaign=site">Swap My Vote</a>
+<br>
+<a href="https://twitter.com/intent/follow?screen_name=swapmyvote">Follow us on Twitter</a>
+<br>
+<a href="https://facebook.com/swapmyvote">Like us on Facebook</a>
+
+</p>

--- a/spec/views/user_mailer/__snapshots__/reminder_to_vote.snap
+++ b/spec/views/user_mailer/__snapshots__/reminder_to_vote.snap
@@ -2,7 +2,7 @@
 Hi John (test user),
 </p>
 <p>
-The Wakefield and Tiverton & Honiton 2022 by-elections
+The Wakefield and Tiverton &amp; Honiton 2022 by-elections polls
 are now open!
 Jane (test user)
 is going to vote for your party, in the

--- a/spec/views/user_mailer/__snapshots__/reminder_to_vote.snap
+++ b/spec/views/user_mailer/__snapshots__/reminder_to_vote.snap
@@ -1,0 +1,31 @@
+<p>
+Hi John (test user),
+</p>
+<p>
+The Wakefield and Tiverton & Honiton 2022 by-elections
+are now open!
+Jane (test user)
+is going to vote for your party, in the
+Constituency2 constituency.
+</p>
+<p>
+In return, you've agreed to vote for their preferred party in your
+constituency (Constituency1).
+</p>
+<p>
+Once you've done so,
+<a href="http://test.host/user/vote">please let Jane (test user) know you&#39;ve voted!</a>
+</p>
+<p>
+All the best,
+<br>
+Swap My Vote Team
+</p>
+<p>
+<a href="https://www.swapmyvote.uk/?utm_source=email&utm_medium=reminder_to_vote&utm_campaign=site">Swap My Vote</a>
+<br>
+<a href="https://twitter.com/intent/follow?screen_name=swapmyvote">Follow us on Twitter</a>
+<br>
+<a href="https://facebook.com/swapmyvote">Like us on Facebook</a>
+
+</p>

--- a/spec/views/user_mailer/__snapshots__/swap_cancelled.snap
+++ b/spec/views/user_mailer/__snapshots__/swap_cancelled.snap
@@ -1,0 +1,27 @@
+<p>
+Hi John (test user),
+</p>
+<p>
+I'm sorry to say that your vote swap
+with Jane (test user)
+has been cancelled.
+This could have happened if either of you changed preferred parties, moved constituency,
+declined the swap, or (most likely!) if the swap expired before being confirmed.
+</p>
+<p>
+<a href="http://test.host/user">Find another vote swapping partner - log in to swapmyvote.uk now.</a>
+Don't delay!
+</p>
+<p>
+All the best,
+<br>
+Swap My Vote Team
+</p>
+<p>
+<a href="https://www.swapmyvote.uk/?utm_source=email&utm_medium=swap_cancelled&utm_campaign=site">Swap My Vote</a>
+<br>
+<a href="https://twitter.com/intent/follow?screen_name=swapmyvote">Follow us on Twitter</a>
+<br>
+<a href="https://facebook.com/swapmyvote">Like us on Facebook</a>
+
+</p>

--- a/spec/views/user_mailer/__snapshots__/swap_confirmed.snap
+++ b/spec/views/user_mailer/__snapshots__/swap_confirmed.snap
@@ -28,6 +28,7 @@ Lastly, why not share Swap My Vote with your social networks so that
 more people can make their vote count?
 <a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
 <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
+
 </p>
 <p>
 To a better democracy!

--- a/spec/views/user_mailer/__snapshots__/swap_confirmed.snap
+++ b/spec/views/user_mailer/__snapshots__/swap_confirmed.snap
@@ -1,0 +1,44 @@
+<p>
+Hi John (test user),
+</p>
+<p>
+You're all set to swap your vote with
+Jane (test user)!
+</p>
+<p>
+Jane (test user) is going to vote for your preferred party for
+you, in the Constituency2 constituency.  In
+return, you will vote for their preferred party in your constituency
+(Constituency1).
+</p>
+<p>
+We'll send some reminders to Jane (test user) to remind them to
+vote for your chosen party in their by-election, and we'll ask them
+for confirmation once they have.
+</p>
+<p>
+Unfortunately Jane (test user) has not shared their
+email address or social media profile.
+If this makes you uncomfortable you can
+<a target="_blank" href="http://test.host/faq#reset">cancel your swap</a>.
+
+</p>
+<p>
+Lastly, why not share Swap My Vote with your social networks so that
+more people can make their vote count?
+<a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
+<a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
+</p>
+<p>
+To a better democracy!
+<br>
+Swap My Vote Team
+</p>
+<p>
+<a href="https://www.swapmyvote.uk/?utm_source=email&utm_medium=swap_confirmed&utm_campaign=site">Swap My Vote</a>
+<br>
+<a href="https://twitter.com/intent/follow?screen_name=swapmyvote">Follow us on Twitter</a>
+<br>
+<a href="https://facebook.com/swapmyvote">Like us on Facebook</a>
+
+</p>

--- a/spec/views/user_mailer/__snapshots__/swap_confirmed.snap
+++ b/spec/views/user_mailer/__snapshots__/swap_confirmed.snap
@@ -26,7 +26,7 @@ If this makes you uncomfortable you can
 <p>
 Lastly, why not share Swap My Vote with your social networks so that
 more people can make their vote count?
-<a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
+<a href="https://twitter.com/intent/tweet?text=I%27m+using+https%3A%2F%2FSwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0A%0A%23SwapMyVote+%40SwapMyVote">Tweet</a>
 <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&amp;sdk=joey&amp;display=popup&amp;ref=plugin">Share on Facebook</a>
 
 </p>

--- a/spec/views/user_mailer/__snapshots__/swap_confirmed.snap
+++ b/spec/views/user_mailer/__snapshots__/swap_confirmed.snap
@@ -27,7 +27,7 @@ If this makes you uncomfortable you can
 Lastly, why not share Swap My Vote with your social networks so that
 more people can make their vote count?
 <a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
-<a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
+<a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&amp;sdk=joey&amp;display=popup&amp;ref=plugin">Share on Facebook</a>
 
 </p>
 <p>

--- a/spec/views/user_mailer/__snapshots__/swap_not_confirmed.snap
+++ b/spec/views/user_mailer/__snapshots__/swap_not_confirmed.snap
@@ -1,0 +1,29 @@
+<p>
+Hi John (test user),
+</p>
+<p>
+The Wakefield and Tiverton & Honiton 2022 by-election polls have
+just opened, but I'm afraid we haven't been able to confirm your
+pending swap with Jane (test user).
+</p>
+<p>
+All is not lost though - you can still vote for the party you most
+wish to support, or tactically for a greater good.
+</p>
+<p>
+Thank you for taking part - together we are making democracy better
+and more representative.
+</p>
+<p>
+All the best,
+<br>
+Swap My Vote Team
+</p>
+<p>
+<a href="https://www.swapmyvote.uk/?utm_source=email&utm_medium=swap_not_confirmed&utm_campaign=site">Swap My Vote</a>
+<br>
+<a href="https://twitter.com/intent/follow?screen_name=swapmyvote">Follow us on Twitter</a>
+<br>
+<a href="https://facebook.com/swapmyvote">Like us on Facebook</a>
+
+</p>

--- a/spec/views/user_mailer/__snapshots__/swap_not_confirmed.snap
+++ b/spec/views/user_mailer/__snapshots__/swap_not_confirmed.snap
@@ -2,7 +2,7 @@
 Hi John (test user),
 </p>
 <p>
-The Wakefield and Tiverton & Honiton 2022 by-election polls have
+The Wakefield and Tiverton &amp; Honiton 2022 by-elections polls have
 just opened, but I'm afraid we haven't been able to confirm your
 pending swap with Jane (test user).
 </p>

--- a/spec/views/user_mailer/__snapshots__/welcome_email.snap
+++ b/spec/views/user_mailer/__snapshots__/welcome_email.snap
@@ -49,7 +49,7 @@ details of your new voting partner.
 </p>
 <p>
 <a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
-<a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
+<a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&amp;sdk=joey&amp;display=popup&amp;ref=plugin">Share on Facebook</a>
 
 </p>
 <p>
@@ -68,7 +68,7 @@ know about Swap My Vote!
 </p>
 <p>
 <a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
-<a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
+<a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&amp;sdk=joey&amp;display=popup&amp;ref=plugin">Share on Facebook</a>
 
 </p>
 <p>

--- a/spec/views/user_mailer/__snapshots__/welcome_email.snap
+++ b/spec/views/user_mailer/__snapshots__/welcome_email.snap
@@ -50,6 +50,7 @@ details of your new voting partner.
 <p>
 <a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
 <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
+
 </p>
 <p>
 Meanwhile if you’ve got any questions please head over to the <a
@@ -68,6 +69,7 @@ know about Swap My Vote!
 <p>
 <a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
 <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
+
 </p>
 <p>
 Happy voting!

--- a/spec/views/user_mailer/__snapshots__/welcome_email.snap
+++ b/spec/views/user_mailer/__snapshots__/welcome_email.snap
@@ -1,0 +1,84 @@
+<p>
+Hello John (test user)!
+</p>
+<p>
+Thank you for taking part in this movement to make every vote count
+for more.  We’re really excited that you’re a part of this project,
+using the Internet to make democracy better.
+</p>
+<p>
+The 2022 summer by-elections for Wakefield, and Tiverton & Honiton
+are on <em>Thursday, 23rd June</em>.
+</p>
+<p>
+There is everything to play for!
+</p>
+<p>
+If there is already someone who wants to swap votes with you, you
+will have been paired up on the site. Now that the site has
+introduced you to each other, it’s over to you - the system is based
+on trust so please feel free to contact each other through social
+media; discuss policies, news, and your hopes for the new
+Parliament.
+</p>
+<p>
+If you haven't been offered a voting partner yet, <a
+href="https://www.swapmyvote.uk/?utm_source=email&utm_medium=welcome_email&utm_campaign=be2022">go
+and find your partner now!</a>
+You should see a list of potential voting partners on the site - you
+need to choose which you would like to swap with.
+<ul>
+<li>Look at the polls in their constituency to see where your vote will make most difference</li>
+<li>If need be, check that there is a candidate standing there (there is a link below)</li>
+<li><em>Click your preferred voting partner to propose a vote swap!</em></li>
+</ul>
+If the swap is not confirmed within 48 hours,
+you should receive an email from us saying that it has been
+cancelled. This is your cue to <a
+href="https://www.swapmyvote.uk/?utm_source=email&utm_medium=welcome_email&utm_campaign=be2022">choose
+a new voting partner</a>. However we want to find as many people as
+possible a good swap, so <strong>for the final few days of the
+campaign we will be shortening the time for people to confirm a
+swap</strong>.
+</p>
+<p>
+If we all tell the people we know, it won’t be long before there’s a
+critical mass working together to make votes count for more. As soon
+as we can pair you up, we will email you on this address with the
+details of your new voting partner.
+</p>
+<p>
+<a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
+<a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
+</p>
+<p>
+Meanwhile if you’ve got any questions please head over to the <a
+href="https://swapmyvote.uk/faq">FAQ</a>. If your question isn’t
+answered, please feel free to <a
+href="https://swapmyvote.uk/contact">contact us</a>. Please bear in
+mind we’re a tiny team of volunteers doing this in our spare time,
+so it may not be possible to answer or acknowledge all contacts, but
+rest assured we will do our best to incorporate your questions and
+suggestions in updates to the site.
+</p>
+<p>
+Now, please help us make every vote count by telling everyone you
+know about Swap My Vote!
+</p>
+<p>
+<a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
+<a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&sdk=joey&display=popup&ref=plugin">Share on Facebook</a>
+</p>
+<p>
+Happy voting!
+<br>
+Swap My Vote Team
+</p>
+<p>
+<a href="https://www.swapmyvote.uk/?utm_source=email&utm_medium=welcome_email&utm_campaign=site">Swap My Vote</a>
+<br>
+<a href="https://twitter.com/intent/follow?screen_name=swapmyvote">Follow us on Twitter</a>
+<br>
+<a href="https://facebook.com/swapmyvote">Like us on Facebook</a>
+
+</p>

--- a/spec/views/user_mailer/__snapshots__/welcome_email.snap
+++ b/spec/views/user_mailer/__snapshots__/welcome_email.snap
@@ -48,7 +48,7 @@ as we can pair you up, we will email you on this address with the
 details of your new voting partner.
 </p>
 <p>
-<a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
+<a href="https://twitter.com/intent/tweet?text=I%27m+using+https%3A%2F%2FSwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0A%0A%23SwapMyVote+%40SwapMyVote">Tweet</a>
 <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&amp;sdk=joey&amp;display=popup&amp;ref=plugin">Share on Facebook</a>
 
 </p>
@@ -67,7 +67,7 @@ Now, please help us make every vote count by telling everyone you
 know about Swap My Vote!
 </p>
 <p>
-<a href="https://twitter.com/intent/tweet?text=I%27m+using+https://SwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0a%0a%23SwapMyVote+@SwapMyVote">Tweet</a>
+<a href="https://twitter.com/intent/tweet?text=I%27m+using+https%3A%2F%2FSwapMyVote.uk+to+make+my+vote+count+in+the+%23Wakefield+or+%23TivertonandHoniton+%23byelection%0A%0A%23SwapMyVote+%40SwapMyVote">Tweet</a>
 <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swapmyvote.uk&amp;sdk=joey&amp;display=popup&amp;ref=plugin">Share on Facebook</a>
 
 </p>

--- a/spec/views/user_mailer/confirm_swap.html.haml_spec.rb
+++ b/spec/views/user_mailer/confirm_swap.html.haml_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe "user_mailer/confirm_swap", type: :view do
+  specify "matches snapshot" do
+    swap = build(:swap_with_two_users)
+
+    assign(:user, swap.choosing_user)
+    assign(:swap_with, swap.chosen_user)
+
+    expect { render }.not_to raise_error
+
+    expect(rendered).to match_snapshot("confirm_swap")
+  end
+end

--- a/spec/views/user_mailer/email_address_shared.html.haml_spec.rb
+++ b/spec/views/user_mailer/email_address_shared.html.haml_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe "user_mailer/email_address_shared.html.haml", type: :view do
+  specify "matches snapshot" do
+    swap = build(:swap_with_two_users)
+
+    assign(:user, swap.choosing_user)
+    assign(:swap_with, swap.chosen_user)
+
+    expect { render }.not_to raise_error
+
+    expect(rendered).to match_snapshot("email_address_shared")
+  end
+end

--- a/spec/views/user_mailer/no_swap.haml_spec.rb
+++ b/spec/views/user_mailer/no_swap.haml_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe "user_mailer/no_swap.html.haml", type: :view do
+  specify "matches snapshot" do
+    assign(:user, build(:ready_to_swap_user1))
+
+    expect { render }.not_to raise_error
+
+    expect(rendered).to match_snapshot("no_swap")
+  end
+end

--- a/spec/views/user_mailer/not_swapped_follow_up.haml_spec.rb
+++ b/spec/views/user_mailer/not_swapped_follow_up.haml_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe "user_mailer/not_swapped_follow_up.html.haml", type: :view do
+  specify "matches snapshot" do
+    assign(:user, build(:ready_to_swap_user1))
+
+    expect { render }.not_to raise_error
+
+    expect(rendered).to match_snapshot("not_swapped_follow_up")
+  end
+end

--- a/spec/views/user_mailer/partner_has_voted.html.haml_spec.rb
+++ b/spec/views/user_mailer/partner_has_voted.html.haml_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe "user_mailer/partner_has_voted.html.haml", type: :view do
+  specify "matches snapshot" do
+    swap = build(:swap_with_two_users)
+
+    assign(:user, swap.choosing_user)
+    assign(:swap_with, swap.chosen_user)
+
+    expect { render }.not_to raise_error
+
+    expect(rendered).to match_snapshot("partner_has_voted")
+  end
+end

--- a/spec/views/user_mailer/reminder_to_vote.html.haml_spec.rb
+++ b/spec/views/user_mailer/reminder_to_vote.html.haml_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe "user_mailer/reminder_to_vote", type: :view do
+  specify "matches snapshot" do
+    swap = build(:swap_with_two_users)
+
+    assign(:user, swap.choosing_user)
+    assign(:swap_with, swap.chosen_user)
+
+    expect { render }.not_to raise_error
+
+    expect(rendered).to match_snapshot("reminder_to_vote")
+  end
+end

--- a/spec/views/user_mailer/swap_cancelled.haml_spec.rb
+++ b/spec/views/user_mailer/swap_cancelled.haml_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "user_mailer/swap_cancelled", type: :view do
+  specify "matches snapshot" do
+    swap = build(:swap_with_two_users)
+
+    assign(:user, swap.choosing_user)
+    assign(:swap_with, swap.chosen_user)
+    assign(:swap_with_email_consent, true)
+
+    expect { render }.not_to raise_error
+
+    expect(rendered).to match_snapshot("swap_cancelled")
+  end
+end

--- a/spec/views/user_mailer/swap_confirmed.html.haml_spec.rb
+++ b/spec/views/user_mailer/swap_confirmed.html.haml_spec.rb
@@ -1,29 +1,17 @@
 require "rails_helper"
 
 RSpec.describe "user_mailer/swap_confirmed", type: :view do
-  context "wit all options on" do
-    specify do
-      willing_party = build(:party)
-      preferred_party = build(:party)
-      consituency1 = build(:ons_constituency)
-      consituency2 = build(:ons_constituency)
+  context "with :swap_with_email_consent, true" do
+    specify "matches snapshot" do
+      swap = build(:swap_with_two_users)
 
-      assign(:user,
-             build(:user,
-                   willing_party: willing_party,
-                   preferred_party: preferred_party,
-                   constituency: consituency1
-             )
-      )
-      assign(:swap_with,
-             build(:user,
-                   willing_party: preferred_party,
-                   preferred_party: willing_party,
-                   constituency: consituency2
-             )
-      )
+      assign(:user, swap.choosing_user)
+      assign(:swap_with, swap.chosen_user)
       assign(:swap_with_email_consent, true)
+
       expect { render }.not_to raise_error
+
+      expect(rendered).to match_snapshot("swap_confirmed")
     end
   end
 end

--- a/spec/views/user_mailer/swap_not_confirmed.html.haml_spec.rb
+++ b/spec/views/user_mailer/swap_not_confirmed.html.haml_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "user_mailer/swap_not_confirmed", type: :view do
+  specify "matches snapshot" do
+    swap = build(:swap_with_two_users)
+
+    assign(:user, swap.choosing_user)
+    assign(:swap_with, swap.chosen_user)
+    assign(:swap_with_email_consent, true)
+
+    expect { render }.not_to raise_error
+
+    expect(rendered).to match_snapshot("swap_not_confirmed")
+  end
+end

--- a/spec/views/user_mailer/welcome_email.html.haml_spec.rb
+++ b/spec/views/user_mailer/welcome_email.html.haml_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe "user_mailer/welcome_email", type: :view do
+  specify "matches snapshot" do
+    assign(:user, build(:ready_to_swap_user1))
+
+    expect { render }.not_to raise_error
+
+    expect(rendered).to match_snapshot("welcome_email")
+  end
+end


### PR DESCRIPTION
This PR DRYs the repetetive code/text in emails, closing #479.

It is built on #658, so it would be simplest to separately review and
merge that first.
