### PR TITLE
voter matching speed improvements

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -124,15 +124,13 @@ class User < ApplicationRecord
     User.where(
       preferred_party_id: willing_party_id,
       willing_party_id: preferred_party_id
-    )
+    ).where("users.email like '_%'") # We need emails to send confirmation emails
   end
 
   private def one_swap_from_possible_users(user_query)
     offset = rand(user_query.count)
     target_user = user_query.offset(offset).take
     return nil unless target_user
-    # We need emails to send confirmation emails
-    return nil if target_user.email.blank?
     # Don't include if already swapped
     return nil if target_user.swap
     # Ignore if already included

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,22 +122,21 @@ class User < ApplicationRecord
 
   private def complementary_voters
     User.
-      left_joins(:incoming_swap, :outgoing_swap).
+      left_joins(:incoming_swap, :outgoing_swap, :potential_swaps).
       where(
         preferred_party_id: willing_party_id,
         willing_party_id: preferred_party_id
       ).
       where("users.email like '_%'"). # We need emails to send confirmation emails
       where("swaps.chosen_user_id IS ?", nil). # not in an incoming swap
-      where("outgoing_swaps_users.id IS ?", nil) # not in an outgoing swap
+      where("outgoing_swaps_users.id IS ?", nil). # not in an outgoing swap
+      where("potential_swaps.id IS ?", nil) # Ignore if already included in potential swaps
   end
 
   private def one_swap_from_possible_users(user_query)
     offset = rand(user_query.count)
     target_user = user_query.offset(offset).take
     return nil unless target_user
-    # Ignore if already included
-    return nil if potential_swaps.exists?(target_user: target_user)
     # Ignore if me
     return nil if target_user.id == id
     # Ignore if my constituency

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -123,17 +123,17 @@ class User < ApplicationRecord
   private def complementary_voters
     user_ids_already_in_potential_swaps = potential_swaps.reload.map(&:target_user_id)
     user_ids_we_dont_want = user_ids_already_in_potential_swaps + [self.id]
-    User.
-      left_joins(:incoming_swap, :outgoing_swap).
-      where(
+    User
+      .left_joins(:incoming_swap, :outgoing_swap)
+      .where(
         preferred_party_id: willing_party_id,
         willing_party_id: preferred_party_id
-      ).
-      where("users.email like '_%'"). # We need emails to send confirmation emails
-      where("swaps.chosen_user_id IS ?", nil). # not in an incoming swap
-      where("outgoing_swaps_users.id IS ?", nil). # not in an outgoing swap
-      where("users.id NOT IN (?)", user_ids_we_dont_want). # Ignore if already included in potential swaps, or if me
-      where("users.constituency_ons_id != ?", constituency_ons_id)  # Ignore if my constituency
+      )
+      .where("users.email like '_%'") # We need emails to send confirmation emails
+      .where("swaps.chosen_user_id IS ?", nil) # not in an incoming swap
+      .where("outgoing_swaps_users.id IS ?", nil) # not in an outgoing swap
+      .where("users.id NOT IN (?)", user_ids_we_dont_want) # Ignore if already included in potential swaps, or if me
+      .where("users.constituency_ons_id != ?", constituency_ons_id)  # Ignore if my constituency
   end
 
   private def one_swap_from_possible_users(user_query)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -132,16 +132,14 @@ class User < ApplicationRecord
       where("users.email like '_%'"). # We need emails to send confirmation emails
       where("swaps.chosen_user_id IS ?", nil). # not in an incoming swap
       where("outgoing_swaps_users.id IS ?", nil). # not in an outgoing swap
-      where("users.id NOT IN (?)", user_ids_we_dont_want) # Ignore if already included in potential swaps, or if me
+      where("users.id NOT IN (?)", user_ids_we_dont_want). # Ignore if already included in potential swaps, or if me
+      where("users.constituency_ons_id != ?", constituency_ons_id)  # Ignore if my constituency
   end
 
   private def one_swap_from_possible_users(user_query)
     offset = rand(user_query.count)
     target_user = user_query.offset(offset).take
     return nil unless target_user
-    # Ignore if my constituency
-    return nil if target_user.constituency_ons_id == constituency_ons_id
-    # Success
     return potential_swaps.create(target_user: target_user)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,7 +122,7 @@ class User < ApplicationRecord
 
   private def complementary_voters
     user_ids_already_in_potential_swaps = potential_swaps.reload.map(&:target_user_id)
-    user_ids_we_dont_want = user_ids_already_in_potential_swaps + [self.id]
+    user_ids_we_dont_want = user_ids_already_in_potential_swaps + [id]
     User
       .left_joins(:incoming_swap, :outgoing_swap)
       .where(
@@ -132,8 +132,8 @@ class User < ApplicationRecord
       .where("users.email like '_%'") # We need emails to send confirmation emails
       .where("swaps.chosen_user_id IS ?", nil) # not in an incoming swap
       .where("outgoing_swaps_users.id IS ?", nil) # not in an outgoing swap
-      .where("users.id NOT IN (?)", user_ids_we_dont_want) # Ignore if already included in potential swaps, or if me
-      .where("users.constituency_ons_id != ?", constituency_ons_id)  # Ignore if my constituency
+      .where.not(users: { id: user_ids_we_dont_want }) # Ignore if already included in potential swaps, or if me
+      .where.not(users: { constituency_ons_id: constituency_ons_id }) # Ignore if my constituency
   end
 
   private def one_swap_from_possible_users(user_query)


### PR DESCRIPTION
What used to be SQL plus a lot of subsequent ruby logic and additional
SQL queries is now done in a single SQL query

Benefits:
* less db load
* closes #628

Coder benefits:
* logs are orders of magnitude less messy
* it becomes much easier to do experimental improvements in matching
  algorithms
