### PR TITLE
issue 720 electoral calculus update

### DIFF
--- a/app/views/user/swaps/_double_check_constituency.html.haml
+++ b/app/views/user/swaps/_double_check_constituency.html.haml
@@ -2,4 +2,4 @@
   - unless hide_polls?
     Poll results are based on
     %a{ href: "https://www.electoralcalculus.co.uk/orderedseats.html", target: "blank" }
-      Electoral Calculus calculations of national swing since the last election.
+      Electoral Calculus predictions for the next General Election.

--- a/app/views/user/swaps/_list_potential_swaps.html.haml
+++ b/app/views/user/swaps/_list_potential_swaps.html.haml
@@ -14,7 +14,7 @@
 
 - unless hide_polls?
   %p.text-center
-    Poll results are from the 2019 General Election.
+    Poll results are based on Electoral Calculus predictions for the next General Election.
 
 %p.text-center.small.subdued
 

--- a/db/fixtures/electoral_calculus_constituencies.tsv
+++ b/db/fixtures/electoral_calculus_constituencies.tsv
@@ -1,632 +1,632 @@
-1	567	Chorley	Lindsay Hoyle	76404	72.8	0	98.2	0	0	1.6	0	0	0	0.3	LAB	LAB
-2	566	Birmingham Hodge Hill	Liam Byrne	75698	61.3	15.6	69.1	5.4	5.6	3.2	0	0	0	1	LAB	LAB
-3	565	Manchester Gorton	Mohammed Khan	75362	61	12.2	64.3	9.3	6.5	7.7	0	0	0	0	LAB	LAB
-4	564	Birmingham Hall Green	Roger Godsiff	78271	69.4	15.1	67	9.4	3.7	3.8	0	0	0	1	LAB	LAB
-5	563	Birmingham Ladywood	Shabana Mahmood	70023	59	14.7	66.7	10	3.9	4.6	0	0	0	0	LAB	LAB
-6	562	East Ham	Stephen Timms	83827	67.6	15.4	67.3	6.9	5.2	3.8	0	0	0	1.3	LAB	LAB
-7	561	Bethnal Green and Bow	Rushanara Ali	86071	69.5	14	61.8	10.9	4.5	6.8	0	0	0	2	LAB	LAB
-8	560	Liverpool Riverside	Louise Ellman	76332	62.9	13.8	60.9	11.8	4.7	8.8	0	0	0	0	LAB	LAB
-9	559	Tottenham	David Lammy	72883	67.7	14.7	60.6	13	4.4	6	0	0	0	1.4	LAB	LAB
-10	558	Bradford West	Naz Shah	67568	67.4	17.1	62.8	3.6	8.8	5.4	0	0	0	2.4	LAB	LAB
-11	557	Walthamstow	Stella Creasy	68144	70.6	16	61.6	11.6	4.3	5.1	0	0	0	1.3	LAB	LAB
-12	556	Hackney South and Shoreditch	Meg Hillier	82004	67.5	13	58.3	16.6	3.2	7.2	0	0	0	1.6	LAB	LAB
-13	555	Bristol West	Thangam Debbonaire	92986	77	16.1	61.4	0	3.1	19.4	0	0	0	0	LAB	LAB
-14	554	Dulwich and West Norwood	Helen Hayes	77947	72	22.9	66.8	0	4.3	5	0	0	0	1	LAB	LAB
-15	553	Manchester Withington	Jeff Smith	74553	71.9	13.1	54.7	22	4	6.2	0	0	0	0	LAB	LAB
-16	552	Leicester South	Jon Ashworth	75534	66.9	19.7	61	7.4	6	5.8	0	0	0	0	LAB	LAB
-17	551	West Ham	Lyn Brown	92243	65.8	18.9	59.5	9.4	6	4.7	0	0	0	1.5	LAB	LAB
-18	550	Manchester Central	Lucy Powell	90261	55.1	17.4	57.1	9.9	7.2	7.1	0	0	0	1.3	LAB	LAB
-19	549	Camberwell and Peckham	Harriet Harman	85586	67.1	15.3	54.9	17.4	4	6.7	0	0	0	1.7	LAB	LAB
-20	548	Liverpool West Derby	Stephen Twigg	65164	69.3	17.5	57	9.2	9.4	4.5	0	0	0	2.4	LAB	LAB
-21	547	Liverpool Wavertree	Luciana Berger	62411	69.9	16.9	56.3	13.6	6.5	5.2	0	0	0	1.5	LAB	LAB
-22	546	Knowsley	George Howarth	81751	67.9	17.8	57	9.2	9.8	4.4	0	0	0	1.7	LAB	LAB
-23	545	Lewisham Deptford	Vicky Foxcroft	78472	70.2	14.8	53.9	18.6	3.2	7.8	0	0	0	1.8	LAB	LAB
-24	544	Ilford South	Mike Gapes	85358	67.5	21	60.1	8.4	5.2	4	0	0	0	1.3	LAB	LAB
-25	543	Islington North	Jeremy Corbyn	74831	73.4	13.8	52.5	20.9	3.4	7.7	0	0	0	1.6	LAB	LAB
-26	542	Poplar and Limehouse	Jim Fitzpatrick	87274	67.4	19.3	57.5	11.4	4.9	5.3	0	0	0	1.6	LAB	LAB
-27	541	Bootle	Peter Dowd	72872	69	19.3	56.9	10.2	9	4.6	0	0	0	0	LAB	LAB
-28	540	Sheffield Central	Paul Blomfield	77560	61.7	14.7	51.7	12.1	5.4	14.8	0	0	0	1.3	LAB	LAB
-29	539	Hackney North and Stoke Newington	Diane Abbott	83955	67.1	14.4	50.8	20.9	2.8	9.6	0	0	0	1.6	LAB	LAB
-30	538	Bradford East	Imran Hussain	70389	64.8	21.1	57.3	6.7	10.3	4.6	0	0	0	0	LAB	LAB
-31	537	Nottingham East	Chris Leslie	61762	63.7	20.8	55.2	8.7	7.3	6.6	0	0	0	1.4	LAB	LAB
-32	536	Blackburn	Kate Hollern	70657	67.2	24.6	58	4.3	8.5	3.3	0	0	0	1.3	LAB	LAB
-33	535	Leyton and Wanstead	John Cryer	65285	70.7	20.3	53.6	14.7	4.4	5.6	0	0	0	1.4	LAB	LAB
-34	534	Holborn and St Pancras	Keir Starmer	88088	67	17.5	50.8	18.6	3.6	7.9	0	0	0	1.5	LAB	LAB
-35	533	Cardiff Central	Jo Stevens	59288	68.1	19.7	51.9	20.8	6.3	0	0	0	0	1.2	LAB	LAB
-36	532	Edmonton	Kate Osamor	65705	66.5	23.4	55.2	9.2	6.4	4.3	0	0	0	1.4	LAB	LAB
-37	531	Ealing Southall	Virendra Sharma	65188	69.3	21.7	53.1	12.5	5.8	5.3	0	0	0	1.7	LAB	LAB
-38	530	Garston and Halewood	Maria Eagle	75248	71.1	21.8	53.1	11	8.1	4.5	0	0	0	1.6	LAB	LAB
-39	529	Croydon North	Steve Reed	87461	68.2	21.8	52.8	13.1	5.8	4.8	0	0	0	1.7	LAB	LAB
-40	528	Birkenhead	Frank Field	64484	67.7	22.1	52.8	9.6	8.8	5.1	0	0	0	1.6	LAB	LAB
-41	527	Leicester East	Keith Vaz	77788	67.4	23.3	53.8	6.6	8.8	5.5	0	0	0	2	LAB	LAB
-42	526	Liverpool Walton	Dan Carden	62738	67.3	28.3	58.3	9.2	0	3	0	0	0	1.2	LAB	LAB
-43	525	Streatham	Chuka Umunna	78532	71	19.4	48.6	22.1	3.7	6.2	0	0	0	0	LAB	LAB
-44	524	Hornsey and Wood Green	Catherine West	79944	77.9	14.3	43.4	33	2.8	4.9	0	0	0	1.6	LAB	LAB
-45	523	Leeds Central	Hilary Benn	89537	53.2	22.4	50.7	8.4	10	7	0	0	0	1.5	LAB	LAB
-46	522	Edinburgh South	Ian Murray	64553	74.1	19.5	47.3	7.4	0	0.2	25.5	0	0	0	LAB	LAB
-47	521	Brent Central	Dawn Butler	80845	64.7	27.2	53.9	15.2	0	3.7	0	0	0	0	LAB	LAB
-48	520	Blackley and Broughton	Graham Stringer	71648	56	25.2	51.5	8.3	10	5.1	0	0	0	0	LAB	LAB
-49	519	Birmingham Perry Barr	Khalid Mahmood	70106	63	25.5	51.6	10.4	6.6	4.1	0	0	0	1.7	LAB	LAB
-50	518	Islington South and Finsbury	Emily Thornberry	69534	69.1	19.1	44.9	23.8	4.4	6.2	0	0	0	1.5	LAB	LAB
-51	517	Newcastle upon Tyne Central	Chi Onwurah	55571	66.8	24.8	50.3	9.8	9.5	5.6	0	0	0	0	LAB	LAB
-52	516	Oxford East	Anneliese Dodds	78360	68.8	19.9	45.3	21.6	4.5	7.1	0	0	0	1.5	LAB	LAB
-53	515	Preston	Mark Hendrick	57791	61.6	25.4	50.6	8.4	10.7	5	0	0	0	0	LAB	LAB
-54	514	Sheffield Brightside and Hillsborough	Gill Furniss	70344	59.5	24.8	50	7.2	12.7	5.4	0	0	0	0	LAB	LAB
-55	513	Rhondda	Chris Bryant	50513	65.2	16.6	41.5	6.2	11.7	3.6	20.5	0	0	0	LAB	LAB
-56	512	Luton South	Gavin Shuker	67188	68.7	31.6	55.9	0	7.9	3.4	0	0	0	1.2	LAB	LAB
-57	511	Vauxhall	Kate Hoey	81907	67.2	17.8	41.7	29.7	3.4	5.7	0	0	0	1.7	LAB	LAB
-58	510	Lewisham West and Penge	Ellie Reeves	72902	73	22.2	46	19.2	5.1	5.6	0	0	0	1.9	LAB	LAB
-59	509	Mitcham and Morden	Siobhain McDonagh	68705	70	25.2	48.8	13	6.9	4.4	0	0	0	1.7	LAB	LAB
-60	508	Wallasey	Angela Eagle	67454	71.7	26.1	49.7	9.6	10.1	4.5	0	0	0	0	LAB	LAB
-61	507	Barking	Margaret Hodge	77020	61.9	26.2	49.6	9.7	9.9	4.7	0	0	0	0	LAB	LAB
-62	506	Lewisham East	Heidi Alexander	68126	69.3	23.3	46.6	17.1	5.7	5.1	0	0	0	2.1	LAB	LAB
-63	505	Hammersmith	Andy Slaughter	72803	71.8	24.8	48	17.5	4.6	5.1	0	0	0	0	LAB	LAB
-64	504	Greenwich and Woolwich	Matthew Pennycook	77190	68.8	23.2	46.3	17.7	4.9	6.3	0	0	0	1.6	LAB	LAB
-65	503	Exeter	Ben Bradshaw	77329	71.7	32.3	55.3	0	7.1	4.1	0	0	0	1.2	LAB	LAB
-65	502	Bermondsey and Old Southwark	Neil Coyle	87227	67.1	15.4	38.3	42	4.3	0	0	0	0	0	LAB	LIB
-66	502	Oldham West and Royton	Jim McMahon	72418	63.2	27.6	50	5.4	11.1	4.4	0	0	0	1.5	LAB	LAB
-66	501	Glasgow North East	Paul Sweeney	59932	53	13.1	35.4	6.4	0	0	45.1	0	0	0	LAB	NAT
-67	501	Stretford and Urmston	Kate Green	71840	69.9	27.3	49.5	9.4	9	4.8	0	0	0	0	LAB	LAB
-68	500	Halton	Derek Twigg	73457	67.4	26.3	48.6	9.2	11.6	4.2	0	0	0	0	LAB	LAB
-69	499	Nottingham South	Lilian Greenwood	71178	67.6	27.3	48.8	10.2	8	5.6	0	0	0	0	LAB	LAB
-70	498	Merthyr Tydfil and Rhymney	Gerald Jones	55463	60.5	22.5	43.8	8.5	13.2	0	10.4	0	0	1.5	LAB	LAB
-71	497	York Central	Rachael Maskell	77315	68.7	26.5	47.3	12.8	6.9	5.1	0	0	0	1.4	LAB	LAB
-72	496	Aberavon	Stephen Kinnock	49891	66.7	22.4	43.2	6.8	12.9	3.9	9.4	0	0	1.5	LAB	LAB
-73	495	Rochdale	Tony Lloyd	78064	64.1	27.8	47.7	9.6	10.6	4.2	0	0	0	0	LAB	LAB
-74	494	Warley	John Spellar	63724	63.1	27.9	47.7	10.9	9.1	4.4	0	0	0	0	LAB	LAB
-75	493	Westminster North	Karen Buck	63846	67.8	27.8	47.1	14.8	4.2	4.7	0	0	0	1.4	LAB	LAB
-76	492	Hayes and Harlington	John McDonnell	73268	65.2	28.8	48	9.1	8.2	4.2	0	0	0	1.6	LAB	LAB
-77	491	Leeds North East	Fabian Hamilton	70112	75.6	28.2	47.2	12	6.3	4.8	0	0	0	1.5	LAB	LAB
-78	490	Slough	Tan Dhesi	83272	65.2	29.8	48.8	10.1	7.7	3.6	0	0	0	0	LAB	LAB
-79	489	Tooting	Rosena Allin-Khan	77960	74.6	26.5	45.3	18	3.8	4.9	0	0	0	1.5	LAB	LAB
-80	488	St Helens South and Whiston	Marie Rimmer	79036	66.9	26.7	45.4	11.2	11.3	5.5	0	0	0	0	LAB	LAB
-80	487	Coatbridge, Chryston and Bellshill	Hugh Gaffney	71198	63.3	16.3	35	6.5	0	0.2	42.1	0	0	0	LAB	NAT
-80	487	Cambridge	Daniel Zeichner	78003	71.7	15.4	34.1	39.6	3.6	5.9	0	0	0	1.4	LAB	LIB
-81	487	Salford and Eccles	Rebecca Long-Bailey	78082	61	27.4	45.7	10.6	10.9	5.5	0	0	0	0	LAB	LAB
-82	486	Leeds West	Rachel Reeves	67955	62.1	26.6	44.9	8.8	11.3	6.7	0	0	0	1.8	LAB	LAB
-83	485	Middlesbrough	Andy McDonald	61114	58.3	27.9	46.2	6.3	12.7	4.9	0	0	0	1.9	LAB	LAB
-84	484	Birmingham Yardley	Jess Phillips	72581	61.3	24.4	42.5	19.6	9.2	4.3	0	0	0	0	LAB	LAB
-85	483	Brent North	Barry Gardiner	82556	68.4	28.7	46.7	12.9	5.7	4.4	0	0	0	1.6	LAB	LAB
-85	482	Glasgow South West	Chris Stephens	62991	56.2	15	32.9	6.9	1.2	0	43.9	0	0	0	NAT	NAT
-86	482	Cynon Valley	Ann Clwyd	51332	62	22.9	40.8	7.4	12.7	0	14.9	0	0	1.4	LAB	LAB
-87	481	Hull North	Diana Johnson	64666	57.5	26.6	44.3	11.2	11.9	6	0	0	0	0	LAB	LAB
-88	480	Blaenau Gwent	Nick Smith	51227	63.2	20.8	38.5	6.2	14.1	4.1	16.3	0	0	0	LAB	LAB
-89	479	Stockport	Ann Coffey	63425	65.5	27.9	45.5	11.7	9.7	5.1	0	0	0	0	LAB	LAB
-90	478	Luton North	Kelvin Hopkins	66811	69.8	30.9	47.7	8.7	7.4	3.8	0	0	0	1.4	LAB	LAB
-90	477	Glasgow Central	Alison Thewliss	64346	55.9	14.1	30.8	7.3	0	0.2	47.7	0	0	0	NAT	NAT
-91	477	Huddersfield	Barry Sheerman	67033	65.4	29.5	46.2	8.7	9.1	6.5	0	0	0	0	LAB	LAB
-92	476	Ealing Central and Acton	Rupa Huq	74200	74.6	28.4	44.7	18.4	4.5	4	0	0	0	0	LAB	LAB
-93	475	Pontypridd	Owen Smith	60566	65.9	27.9	44.2	0	10.5	0	16.4	0	0	1	LAB	LAB
-94	474	Easington	Grahame Morris	62385	58.3	28.1	44.3	10.5	14.6	0	0	0	0	2.6	LAB	LAB
-95	473	Leicester West	Liz Kendall	64834	57.9	28.8	44.9	8.9	11.5	5.9	0	0	0	0	LAB	LAB
-96	472	Bolton South East	Yasmin Qureshi	68886	61.4	30	45.8	6.4	12.8	4.9	0	0	0	0	LAB	LAB
-97	471	Newcastle upon Tyne East	Nicholas Brown	62333	66.8	32.7	48.3	13.9	0	5.2	0	0	0	0	LAB	LAB
-98	470	Derby South	Margaret Beckett	69918	64.8	31.4	47	9.6	12	0	0	0	0	0	LAB	LAB
-99	469	Hove	Peter Kyle	74236	77.6	27.8	43.2	16.7	5.4	5.1	0	0	0	1.7	LAB	LAB
-100	468	Swansea West	Geraint Davies	56892	65.5	28.3	43.6	11.5	8.9	0	7.6	0	0	0	LAB	LAB
-101	467	Norwich South	Clive Lewis	74182	69.2	25.7	40.7	19.3	5.6	8.6	0	0	0	0	LAB	LAB
-102	466	Feltham and Heston	Seema Malhotra	81707	64.9	30.5	45.3	11.4	8.2	4.6	0	0	0	0	LAB	LAB
-102	465	Arfon	Hywel Williams	41367	68.2	18.7	33.5	0	7.5	0	40.2	0	0	0	NAT	NAT
-102	465	Brighton Pavilion	Caroline Lucas	75486	76.4	17.2	32	0	3	47.1	0	0	0	0.6	Green	Green
-103	465	Leeds East	Richard Burgon	65950	62.8	30.3	45.1	7.5	12.4	4.7	0	0	0	0	LAB	LAB
-104	464	Hampstead and Kilburn	Tulip Siddiq	82957	70.4	26.7	41.5	23	3.9	4.8	0	0	0	0	LAB	LAB
-105	463	Birmingham Selly Oak	Steve McCabe	74370	65.9	29.1	43.7	16	6.3	4.9	0	0	0	0	LAB	LAB
-106	462	Cardiff South and Penarth	Stephen Doughty	76499	66.3	28.5	43.1	8.9	9.7	4.2	5.7	0	0	0	LAB	LAB
-107	461	Ogmore	Chris Elmore	56661	65.7	26.3	40.9	7.6	12.2	3.8	9.2	0	0	0	LAB	LAB
-108	460	Jarrow	Stephen Hepburn	64828	66.4	28.6	43.2	8.9	12.6	5	0	0	0	1.8	LAB	LAB
-109	459	Caerphilly	Wayne David	64381	64.1	27.6	41.9	0	12.5	0	18	0	0	0	LAB	LAB
-110	458	Wythenshawe and Sale East	Mike Kane	76361	60	29.1	43.4	10.1	10.6	5	0	0	0	1.7	LAB	LAB
-111	457	Tyneside North	Mary Glindon	78914	65.8	29.4	43.7	10.1	12	4.8	0	0	0	0	LAB	LAB
-112	456	Coventry North East	Colleen Fletcher	75792	61.4	30.2	44.3	11.9	9.3	4.3	0	0	0	0	LAB	LAB
-113	455	Harrow West	Gareth Thomas	69798	72.1	30.6	44.6	14.4	6	4.5	0	0	0	0	LAB	LAB
-114	454	Sheffield Heeley	Louise Haigh	68040	65	29	42.4	11.2	11.6	5.7	0	0	0	0	LAB	LAB
-115	453	Cardiff West	Kevin Brennan	67221	69.4	27.7	41.1	9	9	3.7	9.5	0	0	0	LAB	LAB
-116	452	Swansea East	Carolyn Harris	58521	60.1	27.4	40.7	7.7	12.8	4.2	7.3	0	0	0	LAB	LAB
-117	451	South Shields	Emma Lewell-Buck	63449	64.3	29	42.2	7.6	13.4	6	0	0	0	1.8	LAB	LAB
-117	450	Dunbartonshire West	Martin Docherty	67602	65.2	16.9	29.8	6.3	0	0.2	45.9	0	0	1	NAT	NAT
-118	450	Llanelli	Nia Griffith	59434	67.9	26.8	39.7	0	12.8	0	20.6	0	0	0	LAB	LAB
-119	449	Nottingham North	Alex Norris	66894	57.3	30.2	43	8	13.6	5.3	0	0	0	0	LAB	LAB
-119	448	Glasgow North	Patrick Grady	53863	62.1	14.1	26.8	7.8	1.1	9.9	40.4	0	0	0	NAT	NAT
-120	448	Rotherham	Sarah Champion	63237	60	29.8	42.5	9.2	16.2	0	0	0	0	2.3	LAB	LAB
-121	447	Ealing North	Steve Pound	74764	70.2	35.9	48.5	12.5	0	3.1	0	0	0	0	LAB	LAB
-122	446	Barnsley Central	Dan Jarvis	64204	60.9	28.8	41.3	7.3	15.3	5.2	0	0	0	2	LAB	LAB
-123	445	St Helens North	Conor McGinn	76088	66	30.1	42.5	10.1	12.1	5.3	0	0	0	0	LAB	LAB
-123	444	Glasgow East	David Linden	66242	54.6	19.1	31.3	7.2	0	0	42.3	0	0	0	NAT	NAT
-123	444	Leeds North West	Alex Sobel	68152	67.9	20.5	32.7	35.2	6.2	5.4	0	0	0	0	LAB	LIB
-124	444	Denton and Reddish	Andrew Gwynne	65751	60.2	30.1	42	8.5	12.7	4.9	0	0	0	1.8	LAB	LAB
-125	443	Bristol South	Karin Smyth	83009	65.5	28.6	40.4	16.5	8.5	6	0	0	0	0	LAB	LAB
-126	442	Sheffield South East	Clive Betts	68945	63.2	31.9	43.5	9.4	13.4	0	0	0	0	1.9	LAB	LAB
-127	441	Durham, City of	Roberta Blackman-Woods	71132	67.9	28.5	40	17.2	8.8	5.5	0	0	0	0	LAB	LAB
-128	440	Neath	Christina Rees	55859	68.5	25.4	36.8	7	12	3.7	13.7	0	0	1.4	LAB	LAB
-129	439	Sefton Central	Bill Esterson	69019	75.5	31.8	42.9	12	7.8	4	0	0	0	1.5	LAB	LAB
-130	438	Bristol East	Kerry McCarthy	72414	70.2	31	41.8	14.7	7.4	5	0	0	0	0	LAB	LAB
-131	437	Doncaster North	Ed Miliband	72372	58.5	30.9	41.5	9.2	16.1	0	0	0	0	2.3	LAB	LAB
-131	436	Glasgow South	Stewart McDonald	69126	64.4	18.2	28.9	7.7	1.1	0.2	43.9	0	0	0	NAT	NAT
-132	436	Southampton Test	Alan Whitehead	70194	66.8	30.3	40.9	14.8	7.4	4.4	0	0	0	2.2	LAB	LAB
-132	435	Rutherglen and Hamilton West	Ged Killen	80098	63.5	19.7	30.3	9.6	0	0	40.5	0	0	0	LAB	NAT
-132	435	Glasgow North West	Carol Monaghan	63773	60.9	18	28.4	8.1	0	0	45.6	0	0	0	NAT	NAT
-133	435	Islwyn	Chris Evans	56256	64.2	28	38.3	7.4	13.1	3.9	9.4	0	0	0	LAB	LAB
-134	434	Enfield North	Joan Ryan	68454	70.9	33	43.3	12.3	7.2	4.2	0	0	0	0	LAB	LAB
-135	433	Wentworth and Dearne	John Healey	74890	58.7	32.5	42.7	10	13	0	0	0	0	1.8	LAB	LAB
-135	432	Motherwell and Wishaw	Marion Fellows	68215	61.5	20.2	30.3	7.4	0	0	42.1	0	0	0	NAT	NAT
-136	432	Washington and Sunderland West	Sharon Hodgson	67280	60.3	31.1	41.2	9.2	13.4	5.1	0	0	0	0	LAB	LAB
-136	431	Dundee West	Chris Law	62644	61.7	15.2	25.2	7.1	1	0	49.5	0	0	2	NAT	NAT
-136	431	Na h-Eileanan An Iar (Western Isles)	Angus MacNeil	21301	69.6	16.5	26.3	6.1	0	0	43.6	0	7.5	0	NAT	NAT
-137	431	Wigan	Lisa Nandy	75359	63.1	31.5	41.2	9	13.3	5	0	0	0	0	LAB	LAB
-138	430	Brentford and Isleworth	Ruth Cadbury	85151	72.4	32	41.7	16	6.2	4	0	0	0	0	LAB	LAB
-139	429	Durham North	Kevan Jones	66970	64.6	31.1	40.3	10.2	12.3	4.3	0	0	0	1.8	LAB	LAB
-140	428	Ashton under Lyne	Angela Rayner	67674	58.8	32.5	41.5	7.9	13.1	4.9	0	0	0	0	LAB	LAB
-141	427	Batley and Spen	Tracy Brabin	80153	67.1	34.2	43	6.2	10.5	4.4	0	0	0	1.7	LAB	LAB
-141	426	Inverclyde	Ronnie Cowan	58853	66.4	21.3	30	7.1	0	0	41.6	0	0	0	NAT	NAT
-141	426	Edinburgh East	Tommy Sheppard	65896	66	18.5	27.1	8.7	0	0.2	45.6	0	0	0	NAT	NAT
-141	426	Glenrothes	Peter Grant	66378	60.9	18.6	27.1	7.5	1.1	0	45.7	0	0	0	NAT	NAT
-142	426	Walsall South	Valerie Vaz	67417	65.4	34.2	42.7	8.5	9.4	3.6	0	0	0	1.6	LAB	LAB
-143	425	Blaydon	Liz Twist	68459	70.2	29.9	38.2	13.4	11.7	4.8	0	0	0	1.9	LAB	LAB
-143	424	Cumbernauld, Kilsyth and Kirkintilloch East	Stuart McDonald	66554	65.9	18.3	26.4	8	0	0	47.2	0	0	0	NAT	NAT
-144	424	Houghton and Sunderland South	Bridget Phillipson	68123	60.9	32	40.1	9.2	13.4	5.2	0	0	0	0	LAB	LAB
-145	423	Normanton, Pontefract and Castleford	Yvette Cooper	81641	60.3	32.4	40.5	9	15.8	0	0	0	0	2.2	LAB	LAB
-145	422	Paisley and Renfrewshire South	Mhairi Black	61344	68	19.9	27.6	8.7	0	0	43.8	0	0	0	NAT	NAT
-146	422	Tynemouth	Alan Campbell	77434	73.4	33.5	41.1	11.2	9.6	4.5	0	0	0	0	LAB	LAB
-147	421	Wansbeck	Ian Lavery	62099	68.4	32	39.3	10.7	11.2	5	0	0	0	1.7	LAB	LAB
-148	420	Newcastle upon Tyne North	Catherine McKinnell	66312	72.8	32.3	39.6	12.6	10.9	4.7	0	0	0	0	LAB	LAB
-149	419	Barnsley East	Stephanie Peacock	69204	58.9	31.4	38.6	8.1	17.4	4.5	0	0	0	0	LAB	LAB
-150	418	Hull East	Karl Turner	65959	55.5	31.6	38.8	8.5	15.8	5.2	0	0	0	0	LAB	LAB
-151	417	Hull West and Hessle	Emma Hardy	60181	57.4	31.1	38.3	10.6	14.7	5.4	0	0	0	0	LAB	LAB
-152	416	Brighton Kemptown	Lloyd Russell-Moyle	67893	72.5	33	40	15.6	7	4.3	0	0	0	0	LAB	LAB
-153	415	Sunderland Central	Julie Elliott	72728	62	32.4	39.4	9.5	11.7	5.2	0	0	0	1.8	LAB	LAB
-154	414	Ellesmere Port and Neston	Justin Madders	68666	74.2	34.5	41.4	9.6	10.4	4	0	0	0	0	LAB	LAB
-155	413	Oldham East and Saddleworth	Debbie Abrahams	72223	65.1	33.7	40.5	8.3	11.7	4.1	0	0	0	1.6	LAB	LAB
-155	412	Kirkcaldy and Cowdenbeath	Lesley Laird	72721	63.5	22.4	29.2	7.5	1.2	0.2	39.5	0	0	0	LAB	NAT
-156	412	Torfaen	Nick Thomas-Symonds	61839	62.1	30.5	37.1	7.8	13.4	4	7.3	0	0	0	LAB	LAB
-156	411	Airdrie and Shotts	Neil Gray	64146	59.2	23	29.5	6.6	0	0.2	40.7	0	0	0	NAT	NAT
-157	411	Chester, City of	Chris Matheson	72859	77.4	35.1	41.5	11.4	8.3	3.7	0	0	0	0	LAB	LAB
-158	410	Erith and Thamesmead	Teresa Pearce	69724	63.8	33.1	39.4	11.7	9.3	4.6	0	0	0	1.9	LAB	LAB
-158	409	Sheffield Hallam	Jared O Mara	73455	77.6	22	28.2	37.9	5.8	4.6	0	0	0	1.5	LAB	LIB
-159	409	Makerfield	Yvonne Fovargue	74259	63.2	33.3	39.5	9.7	13.1	4.4	0	0	0	0	LAB	LAB
-160	408	Lancashire West	Rosie Cooper	73258	74.2	34.9	41	9.9	9.8	4.4	0	0	0	0	LAB	LAB
-161	407	Wirral South	Alison McGovern	57670	78.4	35.1	41.1	11.7	8.2	3.9	0	0	0	0	LAB	LAB
-162	406	Coventry South	James Cunningham	70754	66.4	33.1	38.9	14	7.6	4.7	0	0	0	1.7	LAB	LAB
-163	405	Birmingham Edgbaston	Preet Gill	68091	64	33.6	39.4	15.7	6.8	4.6	0	0	0	0	LAB	LAB
-164	404	Doncaster Central	Rosie Winterton	71716	60	33.2	39	7.5	13.6	4.4	0	0	0	2.3	LAB	LAB
-165	403	Newport East	Jessica Morden	57233	64.3	32.4	37.8	8.5	12.7	3.9	4.7	0	0	0	LAB	LAB
-166	402	Bradford South	Judith Cummins	67752	60.6	35	40.3	6.7	13.4	4.7	0	0	0	0	LAB	LAB
-167	401	Stalybridge and Hyde	Jonathan Reynolds	71409	59.5	34.3	39.5	8.6	10.7	5.3	0	0	0	1.6	LAB	LAB
-168	400	Stockton North	Alex Cunningham	66279	64.5	35.2	40.4	9.1	13.5	0	0	0	0	1.8	LAB	LAB
-169	399	Lancaster and Fleetwood	Cat Smith	67171	68.5	34.8	39.9	10.7	9.3	5.4	0	0	0	0	LAB	LAB
-170	398	Ilford North	Wes Streeting	72997	72.5	35.6	40.4	12.4	6.3	3.6	0	0	0	1.7	LAB	LAB
-171	397	Birmingham Erdington	Jack Dromey	65067	57.2	35	39.8	11.9	9	4.3	0	0	0	0	LAB	LAB
-172	396	Ynys Mon	Albert Owen	52448	71.2	28.6	33.4	0	11.1	0	26.9	0	0	0	LAB	LAB
-173	395	Battersea	Marsha De Cordova	77572	71	31.5	35.9	23.1	4.4	5.1	0	0	0	0	LAB	LAB
-174	394	Chesterfield	Toby Perkins	72063	66.5	32.8	37.1	11.6	11.8	4.9	0	0	0	1.8	LAB	LAB
-175	393	Halifax	Holly Lynch	71224	67.8	36.5	40.8	7.4	11.4	3.9	0	0	0	0	LAB	LAB
-176	392	Stroud	David Drew	82849	77	41.6	45.6	0	8.1	3.6	0	0	0	1.2	LAB	LAB
-177	391	Hemsworth	Jon Trickett	71870	63.9	33.9	37.6	7.3	14.6	4.4	0	0	0	2.2	LAB	LAB
-178	390	Dewsbury	Paula Sherriff	81338	69.5	37.1	40.8	6.7	9.5	4.6	0	0	0	1.4	LAB	LAB
-178	389	Midlothian	Danielle Rowley	68328	66.3	25.3	28.8	8.4	0	0	37.5	0	0	0	LAB	NAT
-179	389	Worsley and Eccles South	Barbara Keeley	73692	61.9	35.7	39.1	9.4	10.9	4.8	0	0	0	0	LAB	LAB
-180	388	Leigh	Joanne Platt	76211	61.5	35.6	38.9	10.1	13.4	0	0	0	0	1.9	LAB	LAB
-181	387	Blyth Valley	Ronnie Campbell	63371	67	34.9	38.3	10.9	10.9	4.9	0	0	0	0	LAB	LAB
-182	386	Warrington North	Helen Jones	72015	67.4	35.2	38.5	9.7	11.9	4.7	0	0	0	0	LAB	LAB
-183	385	Plymouth Sutton and Devonport	Luke Pollard	76584	66.9	34	37.2	15.4	8.2	5.1	0	0	0	0	LAB	LAB
-184	384	Eltham	Clive Efford	64474	71.6	35.5	38.4	14.6	7.6	3.9	0	0	0	0	LAB	LAB
-185	383	Redcar	Anna Turley	66836	63.7	33.1	36	11.3	13.4	4.4	0	0	0	1.9	LAB	LAB
-186	382	Enfield Southgate	Bambos Charalambous	65137	74.2	35.3	38.1	16.8	5.3	4.5	0	0	0	0	LAB	LAB
-187	381	Durham North West	Laura Pidcock	71982	66.5	33.6	36.2	11.9	11.8	4.7	0	0	0	1.8	LAB	LAB
-188	380	Reading East	Matt Rodda	75522	73.1	33.2	35.8	18.7	5.5	5.2	0	0	0	1.7	LAB	LAB
-189	379	Hartlepool	Mike Hill	70718	59.2	35	37.5	9.3	16.3	0	0	0	0	2	LAB	LAB
-190	378	Burnley	Julie Cooper	64714	62.3	31.8	34.3	13.3	13.5	5.1	0	0	0	2	LAB	LAB
-191	377	Wirral West	Margaret Greenwood	55995	78.5	36.9	39.4	11.8	8.1	3.8	0	0	0	0	LAB	LAB
-192	376	Coventry North West	Geoffrey Robinson	75214	66.3	34.6	37	14.3	9.5	4.6	0	0	0	0	LAB	LAB
-193	375	West Bromwich East	Tom Watson	63833	61.3	36.1	38.1	10.1	9.8	4.1	0	0	0	1.8	LAB	LAB
-194	374	Gateshead	Ian Mearns	65186	64.6	42	43.9	11	0	3.1	0	0	0	0	LAB	LAB
-194	373	Dunfermline and West Fife	Douglas Chapman	75672	67.4	24.5	26.3	10.4	0	0.2	38.6	0	0	0	NAT	NAT
-195	373	Bolton North East	David Crausby	67233	67.2	37.2	39	8	11.4	4.4	0	0	0	0	LAB	LAB
-196	372	Newport West	Paul Flynn	64399	67.5	34.9	36.6	8.6	10.9	4.1	4.9	0	0	0	LAB	LAB
-197	371	Hyndburn	Graham Jones	73110	61.8	37.1	38.7	7.1	13	4.2	0	0	0	0	LAB	LAB
-198	370	Wolverhampton South East	Pat McFadden	69951	51.9	35.1	36.7	11.5	12.1	4.6	0	0	0	0	LAB	LAB
-199	369	Cardiff North	Anna McMorrin	67221	77.4	35.1	36.6	10.6	7.6	3.4	5.7	0	0	1.1	LAB	LAB
-200	368	Croydon Central	Sarah Jones	80045	71.3	36.5	37.9	13.9	7.5	4.3	0	0	0	0	LAB	LAB
-201	367	Bury North	James Frith	67587	70.9	38.4	39.6	8.8	9.6	3.7	0	0	0	0	LAB	LAB
-201	366	Livingston	Hannah Bardell	81208	64.7	24.2	25.1	7.4	0	0.2	43.1	0	0	0	NAT	NAT
-202	366	Keighley	John Grogan	71429	72.4	38.8	39.5	9.8	10.3	0	0	0	0	1.7	LAB	LAB
-203	365	Heywood and Middleton	Liz McInnes	79901	62.4	36.3	36.9	8.6	13.7	4.4	0	0	0	0	LAB	LAB
-204	364	Sedgefield	Phil Wilson	63890	65.1	36	36.5	8.9	12.1	4.8	0	0	0	1.7	LAB	LAB
-204	363	Aberdeen North	Kirsty Blackman	62130	59.2	22.2	22.6	9.7	1.3	0.2	44.1	0	0	0	NAT	NAT
-205	363	Gedling	Vernon Coaker	71221	72.6	37.4	37.8	9.6	11	4.3	0	0	0	0	LAB	LAB
-206	362	Clwyd South	Susan Elan Jones	54341	69	35.2	35.5	8.3	12.6	0	8.4	0	0	0	LAB	LAB
-207	361	Bridgend	Madeleine Moon	62185	69.6	34.7	34.8	9.1	11.1	3.6	6.6	0	0	0	LAB	LAB
-208	360	Alyn and Deeside	Mark Tami	63041	71	36.3	36.3	9	12.2	0	6.1	0	0	0	LAB	LAB
-209	359	Kensington	Emma Dent Coad	60594	63.8	32.6	32.5	23.2	4.5	5.5	0	0	0	1.7	LAB	CON
-210	358	Portsmouth South	Stephen Morgan	69785	63.9	31.5	31.3	28.1	7.4	0	0	0	0	1.7	LAB	CON
-211	357	Delyn	David Hanson	54116	72.8	36.6	36.4	9.2	11	0	6.8	0	0	0	LAB	CON
-212	356	Wolverhampton South West	Eleanor Smith	60003	70.6	38.2	37.9	15.8	8.1	0	0	0	0	0	LAB	CON
-213	355	Weaver Vale	Mike Amesbury	69016	73.3	37.8	37.4	11	9.3	4.5	0	0	0	0	LAB	CON
-214	354	Derby North	Chris Williamson	69919	69.6	36.8	36.1	10.7	10.5	4.2	0	0	0	1.6	LAB	CON
-214	353	Carmarthen East and Dinefwr	Jonathan Edwards	55976	73.3	26.6	25.8	0	11	0	36.7	0	0	0	NAT	NAT
-214	353	East Lothian	Martin Whitfield	79093	70.6	29.6	28.7	8	0	0	33.7	0	0	0	LAB	NAT
-215	353	Gower	Tonia Antoniazzi	62163	73.3	36.7	35.7	10.2	10	0	7.3	0	0	0	LAB	CON
-215	352	East Kilbride, Strathaven and Lesmahagow	Lisa Cameron	80442	67.3	25.3	24.1	8	0	0.2	42.3	0	0	0	NAT	NAT
-215	352	Orkney and Shetland	Alistair Carmichael	34164	68.1	8.2	7	51.4	0.7	0	31	0	0	1.8	LIB	LIB
-216	352	Stoke-on-Trent Central	Gareth Snell	58196	57	36.9	35.6	11.8	11.2	4.6	0	0	0	0	LAB	CON
-217	351	Colne Valley	Thelma Walker	84381	71.6	37.8	36.4	10.4	9.2	4.7	0	0	0	1.6	LAB	CON
-218	350	Wakefield	Mary Creagh	70340	65.8	39	37.5	9.5	12.1	0	0	0	0	2	LAB	CON
-219	349	Darlington	Jenny Chapman	66341	67.6	37.6	35.9	9.2	11.1	4.5	0	0	0	1.7	LAB	CON
-220	348	Warrington South	Faisal Rashid	85755	72.3	38.2	36.4	14.2	9.3	0	0	0	0	1.8	LAB	CON
-221	347	High Peak	Ruth George	73254	73.5	38.2	36.3	12.1	9.5	3.9	0	0	0	0	LAB	CON
-222	346	Vale of Clwyd	Chris Ruane	56890	68	37.7	35.6	8.6	10.9	0	7.2	0	0	0	LAB	CON
-223	345	Scunthorpe	Nic Dakin	61578	65.3	38.5	36.4	7.3	13.6	4.2	0	0	0	0	LAB	CON
-224	344	Birmingham Northfield	Richard Burden	72322	61.3	37.7	35.6	13	9.1	4.5	0	0	0	0	LAB	CON
-225	343	Lincoln	Karen Lee	73111	66.6	37.6	35.4	9.2	11.4	4.7	0	0	0	1.8	LAB	CON
-226	342	Bassetlaw	John Mann	78535	66.5	39.6	37.1	10	13.4	0	0	0	0	0	LAB	CON
-227	341	Workington	Sue Hayman	60256	69.2	38	35.3	8.6	12.3	4	0	0	0	1.8	LAB	CON
-228	340	Wolverhampton North East	Emma Reynolds	60799	60	37.9	35.1	11.4	11.3	4.4	0	0	0	0	LAB	CON
-228	339	Edinburgh North and Leith	Deidre Brock	79473	71.2	26.1	23.3	8.6	1	3.2	36.8	0	0	1	NAT	NAT
-229	339	Don Valley	Caroline Flint	73988	62.2	37.8	35	7.5	13.4	4.2	0	0	0	2.1	LAB	CON
-229	338	Paisley and Renfrewshire North	Gavin Newlands	67436	69.1	27.4	24.3	7.7	0	0	40.6	0	0	0	NAT	NAT
-230	338	Great Grimsby	Melanie Onn	61743	57.5	37.1	34	7.2	14.9	4.7	0	0	0	2.1	LAB	CON
-230	337	Ceredigion	Ben Lake	52889	75.2	20.8	17.7	23.9	9.3	4.5	23.9	0	0	0	NAT	LIB
-231	337	Warwick and Leamington	Matt Western	74237	72.8	35.7	32.7	18.5	6.5	4.9	0	0	0	1.6	LAB	CON
-232	336	Bury South	Ivan Lewis	73723	69.2	38.8	35.7	10.4	9.4	4	0	0	0	1.6	LAB	CON
-233	335	Stockton South	Paul Williams	75619	71.2	40.6	37.4	11.2	10.8	0	0	0	0	0	LAB	CON
-234	334	Bedford	Mohammad Yasin	71829	67.5	37.9	34.6	15.4	7.5	4.6	0	0	0	0	LAB	CON
-235	333	Bolsover	Dennis Skinner	73429	63.4	37.7	34.2	7.3	14.7	4.3	0	0	0	1.9	LAB	CON
-236	332	West Bromwich West	Adrian Bailey	65956	54.7	38.4	34.6	10	12.6	4.4	0	0	0	0	LAB	CON
-236	331	Falkirk	Johnny McNally	82240	65.4	26.1	22.2	7.3	0	1.9	42.4	0	0	0	NAT	NAT
-237	331	Peterborough	Fiona Onasanya	71522	66.7	39.5	35.4	10.3	8.8	4.3	0	0	0	1.6	LAB	CON
-238	330	Wrexham	Ian Lucas	50422	69.6	37.5	33	8.5	11.2	3.5	6.4	0	0	0	LAB	CON
-239	329	Blackpool South	Gordon Marsden	58450	59.8	38.7	34.1	7.1	13.5	4.7	0	0	0	1.8	LAB	CON
-239	328	Linlithgow and East Falkirk	Martyn Day	86186	65.1	27.9	23.2	7.5	1	0.2	39.2	0	0	1	NAT	NAT
-240	328	Ipswich	Sandy Martin	74799	68.4	38.7	34	13.3	9.4	4.6	0	0	0	0	LAB	CON
-241	327	Dagenham and Rainham	Jon Cruddas	70620	64.9	38.8	33.7	9.1	12	4.4	0	0	0	2	LAB	CON
-241	326	Kilmarnock and Loudoun	Alan Brown	73327	63.4	26.2	21.1	6.2	0	0	45.5	0	0	1	NAT	NAT
-242	326	Rother Valley	Kevin Barron	75230	65.8	38.1	32.9	7.9	14.3	4.9	0	0	0	1.9	LAB	CON
-243	325	Bishop Auckland	Helen Goodman	67661	64	40.8	35.5	11.7	12.1	0	0	0	0	0	LAB	CON
-243	324	Dunbartonshire East	Jo Swinson	66300	78.1	14.3	8.8	43.5	0	0.1	32.5	0	0	0.7	LIB	LIB
-244	324	Penistone and Stocksbridge	Angela Smith	71293	69.8	40.1	34.1	12.2	13.6	0	0	0	0	0	LAB	CON
-245	323	Barrow and Furness	John Woodcock	69474	68.5	40.6	34.4	9.4	11.4	4.2	0	0	0	0	LAB	CON
-246	322	Bristol North West	Darren Jones	75431	71.7	41.8	35.5	19	0	3.8	0	0	0	0	LAB	CON
-247	321	Putney	Justine Greening	65026	72.1	38.9	32.5	24	0	4.6	0	0	0	0	CON	CON
-247	320	Dwyfor Meirionnydd	Liz Roberts	44699	67.9	27.3	20.9	0	10.3	0	41.5	0	0	0	NAT	NAT
-248	320	Crewe and Nantwich	Laura Smith	78895	69.7	40.3	33.7	8.6	11.8	4	0	0	0	1.7	LAB	CON
-249	319	Stoke-on-Trent North	Ruth Smeeth	72368	57.7	40.1	33.2	10	10.7	4.2	0	0	0	1.7	LAB	CON
-249	318	Lanark and Hamilton East	Angela Crawley	77313	65.3	32	24.4	7.5	0	0	36.1	0	0	0	NAT	NAT
-250	318	Ashfield	Gloria De Piero	78099	64	37.7	30	8.2	16.3	4.9	0	0	0	2.8	LAB	CON
-250	317	Dundee East	Stewart Hosie	65854	65.2	26.9	18.3	7.8	0	0	46	0	0	1	NAT	NAT
-251	317	Newcastle-under-Lyme	Paul Farrelly	65540	66.9	41.1	31.9	14.1	9.2	3.7	0	0	0	0	LAB	CON
-252	316	Broxtowe	Anna Soubry	74017	75	42.5	32.9	0	0	1.5	0	0	22.9	0.2	CON	CON
-253	315	Vale of Glamorgan	Alun Cairns	73958	72.6	54.1	44.5	0	0	1.3	0	0	0	0.1	CON	CON
-254	314	Cities of London and Westminster	Mark Field	61533	62.8	40.6	30.4	23	0	4.8	0	0	0	1.2	CON	CON
-254	313	Bath	Wera Hobhouse	66769	74.3	25.5	15.3	53.6	4.2	0	0	0	0	1.3	LIB	LIB
-254	313	Ayrshire North and Arran	Patricia Gibson	73174	64.8	31.1	19.9	6.9	0	0.2	42	0	0	0	NAT	NAT
-255	313	Canterbury	Rosie Duffield	78137	72.7	43.7	32.2	23.1	0	0	0	0	0	1	LAB	CON
-256	312	Wimbledon	Stephen Hammond	66771	77.2	40.4	28.6	29.9	0	0	0	0	0	1.1	CON	CON
-257	311	Chipping Barnet	Theresa Villiers	77020	72	43.5	31.5	19.7	0	4.2	0	0	0	1.1	CON	CON
-257	310	Edinburgh West	Christine Jardine	71500	73.8	21.6	9.3	37.9	0	0.1	31	0	0	0	LIB	LIB
-258	310	Finchley and Golders Green	Mike Freer	73138	71.6	42.7	29.9	27.5	0	0	0	0	0	0	CON	CON
-258	309	Edinburgh South West	Joanna Cherry	71178	69.4	32.2	18.9	8.3	1	0.2	38.4	0	0	1	NAT	NAT
-258	309	Caithness Sutherland and Easter Ross	Jamie Stone	46868	65.9	21.6	7.7	38.8	0.7	0	31.1	0	0	0	LIB	LIB
-259	309	Harrow East	Bob Blackman	71757	70.9	48.9	34.5	16.6	0	0	0	0	0	0	CON	CON
-260	308	Hendon	Matthew Offord	76329	68.4	46.3	31.9	18.2	0	3.5	0	0	0	0	CON	CON
-260	307	Ayrshire Central	Philippa Whitford	68997	65.3	34.2	18.6	6.9	0	0	40.3	0	0	0	NAT	NAT
-261	307	Pudsey	Stuart Andrew	72622	74.3	50.5	34.8	11.5	0	2.3	0	0	0	1	CON	CON
-262	306	Chingford and Woodford Green	Iain Duncan Smith	66078	71.1	49.2	33.5	17.3	0	0	0	0	0	0	CON	CON
-262	305	Kingston and Surbiton	Ed Davey	81584	76.2	29.7	13.6	45.8	5.5	3.8	0	0	0	1.6	LIB	LIB
-262	305	Twickenham	Vince Cable	83362	79.5	27.6	11.5	56.5	4.3	0	0	0	0	0	LIB	LIB
-263	305	Milton Keynes North	Mark Lancaster	89272	71.5	48.6	32.4	15.7	0	3.3	0	0	0	0	CON	CON
-263	304	Ross Skye and Lochaber	Ian Blackford	53638	71.7	23.7	7.4	23.6	0.7	0	42.2	0	0	2.4	NAT	NAT
-264	304	Aberconwy	Guto Bebb	45251	71	46.9	30.3	8.9	0	0	14	0	0	0	CON	CON
-265	303	Watford	Richard Harrington	86507	67.8	47.6	30.6	20.8	0	0	0	0	0	1	CON	CON
-266	302	Chelsea and Fulham	Greg Hands	63728	66.1	45.2	28.1	25.6	0	0	0	0	0	1	CON	CON
-267	301	Calder Valley	Craig Whittaker	79045	73.4	51.8	34.7	12.5	0	0	0	0	0	0.9	CON	CON
-268	300	Pendle	Andrew Stephenson	64963	69	54.1	36.6	6.5	0	2.2	0	0	0	0.6	CON	CON
-268	299	Fife North East	Stephen Gethins	58685	71.3	23.7	6.2	35.6	0	0	34.6	0	0	0	NAT	LIB
-269	299	Hastings and Rye	Amber Rudd	78298	69.9	50.7	33.1	15	0	0	0	0	0	1.1	CON	CON
-270	298	Reading West	Alok Sharma	74518	69.5	48.9	31.4	16.6	0	3.1	0	0	0	0	CON	CON
-270	297	Oxford West and Abingdon	Layla Moran	79289	75.7	31.8	14.2	48.3	5.7	0	0	0	0	0	LIB	LIB
-271	297	Milton Keynes South	Iain Stewart	92494	69.7	49.8	32.1	14	0	3.2	0	0	0	0.9	CON	CON
-272	296	Swindon South	Robert Buckland	72391	70.8	50.4	32.6	16.9	0	0	0	0	0	0	CON	CON
-273	295	Norwich North	Chloe Smith	66924	68.6	50.2	32.2	14.6	0	3	0	0	0	0	CON	CON
-274	294	Preseli Pembrokeshire	Stephen Crabb	58540	72.1	49	31	8.1	0	0	11.8	0	0	0	CON	CON
-275	293	Southampton Itchen	Royston Smith	71716	65.2	50.5	32.5	13.9	0	3	0	0	0	0	CON	CON
-275	292	Carshalton and Wallington	Tom Brake	70849	71.6	33.3	15.2	38.1	7.5	4	0	0	0	1.9	LIB	LIB
-276	292	Loughborough	Nicky Morgan	79607	68	51.6	33.3	11.1	0	3.3	0	0	0	0.6	CON	CON
-277	291	Wycombe	Steve Baker	77089	69.4	48.8	29.6	17	0	3.6	0	0	0	1	CON	CON
-278	290	Truro and Falmouth	Sarah Newton	74691	75.8	44.9	25.5	25.4	0	3.1	0	0	0	1.1	CON	CON
-278	289	Inverness Nairn Badenoch and Strathspey	Drew Hendry	76844	68.7	29.9	10.2	16.5	1.1	0.2	42.2	0	0	0	NAT	NAT
-279	289	Rushcliffe	Kenneth Clarke	74740	78	51.6	31.9	15.7	0	0	0	0	0	0.8	CON	CON
-280	288	Crawley	Henry Smith	73424	68.5	52.4	32.6	12.8	0	2.1	0	0	0	0	CON	CON
-281	287	Altrincham and Sale West	Graham Brady	73220	72.1	49.7	29.9	16	0	3.6	0	0	0	0.9	CON	CON
-282	286	Filton and Bradley Stoke	Jack Lopresti	72569	69.9	48.8	28.8	18	0	3.5	0	0	0	1	CON	CON
-283	285	Shipley	Philip Davies	73133	73	52.7	32.5	11.4	0	2.5	0	0	0	0.9	CON	CON
-284	284	Worcester	Robin Walker	72815	70.6	50.7	30.3	14.8	0	3.2	0	0	0	0.9	CON	CON
-285	283	Camborne and Redruth	George Eustice	67462	71.8	49.6	29.2	17	0	3.1	0	0	0	1	CON	CON
-286	282	Colchester	Will Quince	79996	66.9	45.1	24.5	27.2	0	3.3	0	0	0	0	CON	CON
-287	281	Renfrewshire East	Paul Masterton	70067	76.7	39.8	19.2	6.6	0	0	34.4	0	0	0	CON	CON
-288	280	Northampton North	Michael Ellis	58183	69.4	54.4	33.5	9.4	0	2.8	0	0	0	0	CON	CON
-289	279	Northampton South	Andrew Lewer	60993	67.3	54.5	33.5	9.1	0	2.9	0	0	0	0	CON	CON
-290	278	York Outer	Julian Sturdy	75856	75.7	50.8	29.7	18.6	0	0	0	0	0	0.9	CON	CON
-291	277	Telford	Lucy Allan	68164	65.6	53.9	32.7	13.4	0	0	0	0	0	0	CON	CON
-292	276	Clwyd West	David Jones	58263	69.8	49.9	28.3	8.2	0	0	13.6	0	0	0	CON	CON
-293	275	Bolton West	Chris Green	72797	70.1	54.8	33.2	10.1	0	1.9	0	0	0	0	CON	CON
-294	274	St Albans	Anne Main	72811	78.3	39.8	18.2	38	0	3	0	0	0	1	CON	CON
-295	273	Southport	Damien Moore	69400	69.1	47.1	25.3	27.6	0	0	0	0	0	0	CON	CON
-296	272	Stoke-on-Trent South	Jack Brereton	66046	63.1	54.7	32.8	12.5	0	0	0	0	0	0	CON	CON
-297	271	Stevenage	Stephen McPartland	70765	69.7	52.2	30.3	14.6	0	3	0	0	0	0	CON	CON
-298	270	Carmarthen West and Pembrokeshire South	Simon Hart	58548	72.1	50.6	28.6	7.5	0	0	13.2	0	0	0	CON	CON
-299	269	Hitchin and Harpenden	Bim Afolami	75916	77.4	47.5	25.4	25.8	0	0	0	0	0	1.2	CON	CON
-299	268	Westmorland and Lonsdale	Tim Farron	66391	77.9	35.3	13.1	43.1	8.4	0	0	0	0	0	LIB	LIB
-299	268	Stirling	Stephen Kerr	66415	74.3	37.1	14.7	8.3	0	0.2	39.8	0	0	0	CON	NAT
-300	268	Corby	Tom Pursglove	82439	72.8	56.2	33.7	10.1	0	0	0	0	0	0	CON	CON
-301	267	Forest of Dean	Mark Harper	70898	73	60	37.5	0	0	1.9	0	0	0	0.6	CON	CON
-302	266	Guildford	Anne Milton	75454	73.6	36.7	14	26.4	0	0	0	0	22	0.9	CON	CON
-303	265	Morecambe and Lunesdale	David Morris	66838	68.3	54.9	32.2	9.9	0	2.4	0	0	0	0.6	CON	CON
-304	264	Morley and Outwood	Andrea Jenkyns	76495	68.4	55.7	32.6	9.2	0	1.9	0	0	0	0.6	CON	CON
-305	263	Rossendale and Darwen	Jake Berry	72495	69.2	55.6	32.3	9.5	0	2.5	0	0	0	0	CON	CON
-306	262	Cambridgeshire South	Heidi Allen	85257	76.2	45.5	22.2	32.4	0	0	0	0	0	0	CON	CON
-307	261	Middlesbrough South and Cleveland East	Simon Clarke	72336	65.8	56.3	32.9	9.1	0	1.7	0	0	0	0	CON	CON
-308	260	Bury St Edmunds	Jo Churchill	87758	70.8	59.9	36.3	0	0	3.2	0	0	0	0.5	CON	CON
-309	259	Ayr Carrick and Cumnock	Bill Grant	71241	64.9	40	16.3	6.4	0	0	37.3	0	0	0	CON	CON
-310	258	Beaconsfield	Dominic Grieve	77534	72.3	49.8	26.1	0	0	1.6	0	0	22.3	0.3	CON	CON
-311	257	Uxbridge and South Ruislip	Boris Johnson	69938	66.8	52.9	29.1	13.8	0	3.3	0	0	0	0.9	CON	CON
-312	256	Worthing East and Shoreham	Tim Loughton	75543	70.3	51.5	27.3	16.6	0	3.3	0	0	0	1.3	CON	CON
-312	255	Norfolk North	Norman Lamb	69263	75.3	36.1	11.8	44.2	7.9	0	0	0	0	0	LIB	LIB
-313	255	Carlisle	John Stevenson	62294	69.1	57.2	32.7	10.1	0	0	0	0	0	0	CON	CON
-314	254	Monmouth	David Davies	64909	76.6	51.7	27.1	10.2	0	2.3	8.3	0	0	0.4	CON	CON
-315	253	Copeland	Trudy Harrison	61751	69.5	56.8	31.9	9.5	0	1.8	0	0	0	0	CON	CON
-315	252	Argyll and Bute	Brendan O'Hara	67230	71.5	32.7	7.9	21.3	0	0	38.1	0	0	0	NAT	NAT
-315	252	Richmond Park	Zac Goldsmith	80025	79.1	36.8	11.9	50.3	0	0	0	0	0	1	CON	LIB
-316	252	Welwyn Hatfield	Grant Shapps	72888	70.9	51.9	27	17.8	0	3.3	0	0	0	0	CON	CON
-317	251	Croydon South	Chris Philp	83518	73.3	51.6	26.7	18.3	0	3.5	0	0	0	0	CON	CON
-317	250	Eastbourne	Stephen Lloyd	78754	72.9	36.5	11.5	42.7	7.6	0	0	0	0	1.7	LIB	LIB
-318	250	Gloucester	Richard Graham	82963	65.2	53.7	28.6	14.9	0	2.7	0	0	0	0	CON	CON
-319	249	Shrewsbury and Atcham	Daniel Kawczynski	79043	73.6	51.6	26.4	18.2	0	2.8	0	0	0	1	CON	CON
-320	248	Macclesfield	David Rutley	75228	72.2	53.9	28.3	14.2	0	3.6	0	0	0	0	CON	CON
-321	247	Scarborough and Whitby	Robert Goodwill	73593	68.6	57	31.3	10.8	0	0	0	0	0	0.9	CON	CON
-322	246	Dudley North	Ian Austin	62043	62.7	57.1	31.1	10.1	0	1.8	0	0	0	0	LAB	CON
-323	245	Hertfordshire South West	David Gauke	80293	75.5	41.4	15.3	17.7	0	2.9	0	0	21.8	0.9	CON	CON
-324	244	Erewash	Maggie Throup	72991	68.2	57.3	31	8.7	0	2.4	0	0	0	0.6	CON	CON
-325	243	Bournemouth East	Tobias Ellwood	74591	65.2	51.8	25.4	18	0	3.7	0	0	0	1.1	CON	CON
-326	242	Isle of Wight	Bob Seely	110697	67.3	57.5	30.8	0	0	11.1	0	0	0	0.7	CON	CON
-327	241	Cheadle	Mary Robinson	72780	75	45.6	18.9	35.5	0	0	0	0	0	0	CON	CON
-328	240	Derbyshire North East	Lee Rowley	72097	69.9	57.4	30.6	9.8	0	2.2	0	0	0	0	CON	CON
-329	239	Stafford	Jeremy Lefroy	68445	75.9	54.6	27.7	14.8	0	2.9	0	0	0	0	CON	CON
-330	238	Cambridgeshire South East	Lucy Frazer	86121	73.2	48	21.1	29.9	0	0	0	0	0	1	CON	CON
-331	237	Bournemouth West	Conor Burns	73195	60.8	52.6	25.6	17.9	0	3.9	0	0	0	0	CON	CON
-332	236	Somerset North East	Jacob Rees-Mogg	71350	75.7	52	24.7	18.9	0	3.2	0	0	0	1.2	CON	CON
-333	235	Rochford and Southend East	James Duddridge	73501	64.3	55.3	27.9	14.9	0	0	0	0	0	1.9	CON	CON
-334	234	Hemel Hempstead	Mike Penning	75011	69.7	54	26.5	16.5	0	3	0	0	0	0	CON	CON
-335	233	Kingswood	Chris Skidmore	69426	70.2	54.8	27.2	14.4	0	2.7	0	0	0	0.9	CON	CON
-336	232	Hexham	Guy Opperman	61012	75.8	54.6	26.8	15.1	0	3.4	0	0	0	0	CON	CON
-337	231	Basingstoke	Maria Miller	81873	68.3	53.5	25.5	17	0	2.9	0	0	0	1	CON	CON
-338	230	Blackpool North and Cleveleys	Paul Maynard	63967	64.1	58.7	30.6	8.1	0	2	0	0	0	0.6	CON	CON
-339	229	Elmet and Rothwell	Alec Shelbrooke	80291	74.2	56.5	28.4	11.6	0	2.7	0	0	0	0.9	CON	CON
-340	228	Banbury	Victoria Prentis	83818	73.4	53.9	25.7	17.1	0	3.3	0	0	0	0	CON	CON
-341	227	Swindon North	Justin Tomlinson	80194	68.5	55.6	27.3	14.4	0	2.7	0	0	0	0	CON	CON
-342	226	Bromley and Chislehurst	Bob Neill	65113	71.7	53	24.4	17.9	0	3.6	0	0	0	1	CON	CON
-343	225	Mansfield	Ben Bradley	77811	64.5	59.9	31.3	8.1	0	0	0	0	0	0.7	CON	CON
-344	224	Cannock Chase	Amanda Milling	74540	64.2	63.6	35	0	0	1.4	0	0	0	0	CON	CON
-345	223	Ochil and South Perthshire	Luke Graham	76767	70.6	41.3	12.5	7.8	0	0	38.4	0	0	0	CON	CON
-346	222	Sherwood	Mark Spencer	76196	70	58.8	30	8.5	0	2.1	0	0	0	0.5	CON	CON
-347	221	Rugby	Mark Pawsey	72175	71.1	55.3	26.4	15.7	0	2.7	0	0	0	0	CON	CON
-348	220	Nuneaton	Marcus Jones	69201	66.6	57.3	28.4	11.9	0	2.4	0	0	0	0	CON	CON
-349	219	Aberdeen South	Ross Thomson	64964	68.5	42	13	10.4	0	0	34.6	0	0	0	CON	CON
-349	218	Cheltenham	Alex Chalk	78875	72.3	41.2	11.7	46.1	0	0	0	0	0	0.9	CON	LIB
-350	218	Wantage	Ed Vaizey	87735	72.5	51.1	21.6	26.3	0	0	0	0	0	1	CON	CON
-351	217	Chelmsford	Vicky Ford	81045	70.2	52.4	22.9	23.7	0	0	0	0	0	1	CON	CON
-352	216	Dover	Charlie Elphicke	74564	69.7	56.9	27.1	12.7	0	2.4	0	0	0	0.9	CON	CON
-353	215	Hazel Grove	William Wragg	62684	70.4	49.2	19.4	31.4	0	0	0	0	0	0	CON	CON
-354	214	Dumfries and Galloway	Alister Jack	74206	69.5	43.4	13.6	7.5	0	0	35.5	0	0	0	CON	CON
-355	213	Plymouth Moor View	Johnny Mercer	69342	65.5	58	28	11.8	0	2.2	0	0	0	0	CON	CON
-356	212	Harborough	Neil O'Brien	78647	73.2	55	25	16.1	0	3.2	0	0	0	0.8	CON	CON
-357	211	Woking	Jonathan Lord	76170	72.5	50	20	26.8	0	3.2	0	0	0	0	CON	CON
-358	210	Wokingham	John Redwood	79879	74.7	49.5	19.4	26.7	0	3.3	0	0	0	1	CON	CON
-359	209	Tunbridge Wells	Greg Clark	75138	72.1	52.7	22.4	23.8	0	0	0	0	0	1.2	CON	CON
-360	208	Halesowen and Rowley Regis	James Morris	68856	64.5	58.1	27.6	11.4	0	2	0	0	0	0.8	CON	CON
-361	207	Ribble South	Seema Kennedy	75752	72.4	59	28.5	10.5	0	2.1	0	0	0	0	CON	CON
-362	206	Somerset North	Liam Fox	80538	77	51.2	20.6	24.5	0	3.7	0	0	0	0	CON	CON
-363	205	Walsall North	Eddie Hughes	67309	56.6	59.4	28.8	10.1	0	1.6	0	0	0	0	CON	CON
-364	204	Thanet South	Craig Mackinlay	72342	68.8	57.6	26.8	13.2	0	2.4	0	0	0	0	CON	CON
-365	203	Southend West	David Amess	67677	69.7	56	25.1	17.7	0	0	0	0	0	1.2	CON	CON
-366	202	Redditch	Rachel Maclean	64334	70.3	57.6	26.6	13.5	0	2.3	0	0	0	0	CON	CON
-367	201	Aylesbury	David Lidington	82546	71.2	54.3	23.2	19.3	0	3.2	0	0	0	0	CON	CON
-368	200	Ruislip, Northwood and Pinner	Nick Hurd	73425	72.7	54	22.8	18.6	0	3.5	0	0	0	1.1	CON	CON
-369	199	St Ives	Derek Thomas	67462	75.9	44	12.6	40.2	0	2.1	0	0	0	1	CON	CON
-370	198	Totnes	Sarah Wollaston	68913	72.9	53.1	21.6	24.2	0	0	0	0	0	1	CON	CON
-371	197	Burton	Andrew Griffiths	73954	67.5	58.8	27.2	11.7	0	2.3	0	0	0	0	CON	CON
-372	196	Weston-Super-Mare	John Penrose	82160	68.7	54.8	23.2	19.2	0	2.8	0	0	0	0	CON	CON
-373	195	Huntingdon	Jonathan Djanogly	84320	70.8	54.3	22.7	18.9	0	3.1	0	0	0	1	CON	CON
-374	194	Devon East	Hugo Swire	82382	73.3	41.7	10.2	14.1	0	2.3	0	0	26.6	5.1	CON	CON
-375	193	Derbyshire Mid	Pauline Latham	67466	74.7	58.6	27	11.5	0	2.9	0	0	0	0	CON	CON
-376	192	Brecon and Radnorshire	Chris Davies	56010	73.8	52.2	20.5	26.7	0	0	0	0	0	0.6	CON	CON
-377	191	Wrekin, The	Mark Pritchard	68642	72.1	57.6	26	13.9	0	2.5	0	0	0	0	CON	CON
-378	190	Beckenham	Bob Stewart	67928	76	54.2	22.4	19.8	0	3.6	0	0	0	0	CON	CON
-379	189	St Austell and Newquay	Steve Double	78618	69	51.9	20.1	24.8	0	2.1	0	0	0	1	CON	CON
-380	188	Gillingham and Rainham	Rehman Chishti	72093	67.8	57.8	25.9	12.9	0	2.5	0	0	0	1	CON	CON
-381	187	Norfolk South	Richard Bacon	83056	73.6	54.4	22.5	19.9	0	3.2	0	0	0	0	CON	CON
-382	186	Sutton and Cheam	Paul Scully	70404	73.8	48.3	16.3	32.6	0	2.8	0	0	0	0	CON	CON
-383	185	Harlow	Robert Halfon	67697	66.2	59.7	27.7	12.6	0	0	0	0	0	0	CON	CON
-384	184	Stourbridge	Margot James	70215	67.1	58.7	26.6	11.9	0	2.1	0	0	0	0.8	CON	CON
-385	183	Devon Central	Mel Stride	74370	77.8	52.8	20.6	23.2	0	3.5	0	0	0	0	CON	CON
-386	182	Waveney	Peter Aldous	80784	65.2	58.2	25.9	12.2	0	2.8	0	0	0	1	CON	CON
-387	181	Dorset South	Richard Drax	72323	71.8	56.2	23.8	15.4	0	3.7	0	0	0	0.9	CON	CON
-388	180	Winchester	Steve Brine	72497	78.8	44.4	12	42.6	0	0	0	0	0	1	CON	CON
-389	179	Congleton	Fiona Bruce	76694	73.3	58.1	25.6	12.9	0	2.8	0	0	0	0.7	CON	CON
-390	178	Hertfordshire North East	Oliver Heald	75967	73.2	54.1	21.6	19.6	0	4.7	0	0	0	0	CON	CON
-391	177	Worthing West	Peter Bottomley	77777	70.1	55.7	23.1	16.8	0	3.3	0	0	0	1	CON	CON
-392	176	Eddisbury	Antoinette Sandbach	70272	73	58.6	25.9	12.7	0	2.7	0	0	0	0	CON	CON
-393	175	Amber Valley	Nigel Mills	68065	67.3	60.9	28.2	8.7	0	2.2	0	0	0	0	CON	CON
-394	174	Kettering	Philip Hollobone	71523	69.1	60	27.3	9.3	0	2.8	0	0	0	0.5	CON	CON
-395	173	Romsey and Southampton North	Caroline Nokes	67186	74.7	50.3	17.6	32.1	0	0	0	0	0	0	CON	CON
-396	172	Gordon	Colin Clark	78531	68.4	40.2	7.4	14.5	0	0	37.9	0	0	0	CON	CON
-397	171	Aldershot	Leo Docherty	76205	64.2	55.9	22.7	18.1	0	3.2	0	0	0	0	CON	CON
-398	170	Tatton	Esther McVey	67874	72.4	57	23.7	16	0	3.4	0	0	0	0	CON	CON
-399	169	Chippenham	Michelle Donelan	76432	74.8	49.9	16.4	33.7	0	0	0	0	0	0	CON	CON
-400	168	Wyre and Preston North	Ben Wallace	72319	72.8	59.4	25.9	11.5	0	2.6	0	0	0	0.6	CON	CON
-401	167	Bedfordshire South West	Andrew Selous	79670	69.8	57.7	24.2	15.3	0	2.7	0	0	0	0	CON	CON
-402	166	Hertford and Stortford	Mark Prisk	82429	72.8	54.7	21.1	19.6	0	3.6	0	0	0	1	CON	CON
-403	165	Sussex Mid	Nicholas Soames	83747	73.6	52.5	18.9	24.2	0	3.3	0	0	0	1.1	CON	CON
-404	164	Lewes	Maria Caulfield	70947	76.4	44.2	10.6	42.2	0	2.1	0	0	0	1	CON	CON
-405	163	Witney	Robert Courts	82727	73.6	52.4	18.8	28.8	0	0	0	0	0	0	CON	CON
-406	162	Esher and Walton	Dominic Raab	80938	73.9	51.7	18	29.2	0	0	0	0	0	1.1	CON	CON
-407	161	Berwick-upon-Tweed	Anne-Marie Trevelyan	58774	71.8	54.2	20.4	22.6	0	2.8	0	0	0	0	CON	CON
-408	160	Derbyshire South	Heather Wheeler	76341	68.9	60.6	26.8	10.1	0	2.5	0	0	0	0	CON	CON
-409	159	Suffolk Coastal	Therese Coffey	79366	73.2	55.6	21.8	18	0	3.4	0	0	0	1.2	CON	CON
-410	158	Thurrock	Jackie Doyle-Price	78153	64.4	60.8	26.9	9.8	0	1.7	0	0	0	0.7	CON	CON
-411	157	Sutton Coldfield	Andrew Mitchell	75652	69.9	56.9	22.9	17.3	0	2.8	0	0	0	0	CON	CON
-412	156	Portsmouth North	Penny Mordaunt	71374	66.1	58.3	24.2	14	0	2.7	0	0	0	0.9	CON	CON
-413	155	Warwickshire North	Craig Tracey	72277	65.3	59.9	25.8	12	0	2.3	0	0	0	0	CON	CON
-414	154	Rochester and Strood	Kelly Tolhurst	82702	65	59.3	25.1	12	0	2.6	0	0	0	0.9	CON	CON
-415	153	Gravesham	Adam Holloway	72948	67.2	59.8	25.6	12.1	0	2.4	0	0	0	0	CON	CON
-416	152	Reigate	Crispin Blunt	74628	72.1	53.8	19.5	22.2	0	4.4	0	0	0	0	CON	CON
-417	151	Derbyshire Dales	Patrick McLoughlin	64418	77	59	24.6	13.6	0	2.9	0	0	0	0	CON	CON
-418	150	Eastleigh	Mims Davies	81213	70.5	50.3	15.8	31.3	0	2.5	0	0	0	0	CON	CON
-419	149	Epsom and Ewell	Chris Grayling	80029	74.1	53.8	19.2	22.6	0	3.4	0	0	0	1	CON	CON
-420	148	Montgomeryshire	Glyn Davies	50755	68.7	55.4	20.8	23.2	0	0	0	0	0	0.6	CON	CON
-421	147	Harrogate and Knaresborough	Andrew Jones	77265	73.4	53.8	19	26.3	0	0	0	0	0	1	CON	CON
-421	146	Perth and North Perthshire	Pete Wishart	71743	71.8	41.3	6.5	7.6	0.6	0	44	0	0	0	NAT	NAT
-422	146	Bracknell	Phillip Lee	79199	70.6	56.8	22	17.6	0	2.5	0	0	0	1.1	CON	CON
-423	145	Poole	Robert Syms	73811	67.5	56	21.1	18.6	0	3.1	0	0	0	1.1	CON	CON
-424	144	Ribble Valley	Nigel Evans	77968	70.8	60	24.9	11.6	0	2.9	0	0	0	0.6	CON	CON
-425	143	Bexleyheath and Crayford	David Evennett	65315	69.2	60.1	24.8	11.8	0	2.4	0	0	0	0.9	CON	CON
-426	142	Fylde	Mark Menzies	65937	70.5	60	24.7	11.5	0	3.1	0	0	0	0.7	CON	CON
-427	141	Leicestershire North West	Andrew Bridgen	75362	71	60.7	25.3	10.9	0	2.6	0	0	0	0.6	CON	CON
-428	140	Broadland	Keith Simpson	77334	72.4	56.6	21.1	18.5	0	2.7	0	0	0	1	CON	CON
-429	139	Salisbury	John Glen	72892	73.1	54.6	19.1	22.1	0	3.1	0	0	0	1.1	CON	CON
-430	138	Beverley and Holderness	Graham Stuart	80657	69	60.5	24.9	11.2	0	2.5	0	0	0	0.9	CON	CON
-431	137	Harwich and North Essex	Bernard Jenkin	71294	71.7	57.7	22.1	16.3	0	2.9	0	0	0	1	CON	CON
-432	136	Kenilworth and Southam	Jeremy Wright	66323	77.4	54.8	19.1	22.3	0	3	0	0	0	0.9	CON	CON
-433	135	Thanet North	Roger Gale	72657	66.5	59.9	24	13.6	0	2.4	0	0	0	0	CON	CON
-434	134	Chatham and Aylesford	Tracey Crouch	70419	63.7	60.3	24.4	12	0	2.4	0	0	0	0.9	CON	CON
-435	133	Wells	James Heappey	82449	73.8	48.1	12.2	38.6	0	0	0	0	0	1	CON	CON
-436	132	Buckingham	John Bercow	79616	66.2	50.4	14.3	21.8	10.2	0	0	0	0	3.3	CON	CON
-437	131	Bedfordshire Mid	Nadine Dorries	83800	75.4	57	20.9	17.5	0	3.4	0	0	0	1.1	CON	CON
-438	130	Wellingborough	Peter Bone	79258	67.2	62.2	26	9.2	0	2.7	0	0	0	0	CON	CON
-439	129	Henley	John Howell	74987	76.1	53.1	16.8	26.3	0	3.8	0	0	0	0	CON	CON
-440	128	Devon North	Peter Heaton-Jones	75784	73.5	48.3	11.9	36.3	0	2.4	0	0	0	1	CON	CON
-441	127	Bromsgrove	Sajid Javid	73571	73.5	58.6	22.2	16.5	0	2.7	0	0	0	0	CON	CON
-442	126	Selby and Ainsty	Nigel Adams	75765	74	61.9	25.5	10.2	0	1.8	0	0	0	0.6	CON	CON
-443	125	Taunton Deane	Rebecca Pow	85466	73.8	51	14.6	33.4	0	0	0	0	0	1	CON	CON
-444	124	Angus	Kirstene Hair	63840	63	44.7	8.2	6.4	0	0	40.7	0	0	0	CON	CON
-445	123	Cornwall South East	Sheryll Murray	71896	74	53.7	17.2	25.1	0	3	0	0	0	1	CON	CON
-446	122	Suffolk Central and Ipswich North	Dan Poulter	78116	72.4	58.5	21.9	16.3	0	3.3	0	0	0	0	CON	CON
-447	121	Haltemprice and Howden	David Davis	71520	71.9	60.4	23.9	12.2	0	2.7	0	0	0	0.9	CON	CON
-448	120	Great Yarmouth	Brandon Lewis	71408	61.8	61.4	24.8	10.9	0	2.1	0	0	0	0.8	CON	CON
-449	119	Dorset West	Oliver Letwin	79043	75.4	51.6	15	30.5	0	2.9	0	0	0	0	CON	CON
-450	118	Newton Abbot	Anne Marie Morris	71722	72	53.3	16.6	26.5	0	2.7	0	0	0	1	CON	CON
-451	117	Staffordshire Moorlands	Karen Bradley	66009	67.6	60.1	23.5	14.3	0	2.2	0	0	0	0	CON	CON
-452	116	Devon South West	Gary Streeter	71262	74.2	58.3	21.6	17.1	0	2.9	0	0	0	0	CON	CON
-453	115	Cambridgeshire North West	Shailesh Vara	93223	68.6	59.2	22.5	15.5	0	2.9	0	0	0	0	CON	CON
-454	114	Dudley South	Mike Wood	61323	62.4	61.8	25	11.2	0	1.9	0	0	0	0	CON	CON
-455	113	Runnymede and Weybridge	Philip Hammond	74887	68.9	56.7	19.9	18.7	0	3.6	0	0	0	1	CON	CON
-456	112	Surrey South West	Jeremy Hunt	78042	77.4	53.5	16.6	29.9	0	0	0	0	0	0	CON	CON
-457	111	Shropshire North	Owen Paterson	80535	69	58.8	22	15.3	0	3.1	0	0	0	0.8	CON	CON
-458	110	Thornbury and Yate	Luke Hall	67927	74.6	49.2	12.3	38.5	0	0	0	0	0	0	CON	CON
-459	109	Folkestone and Hythe	Damian Collins	84090	70	57.8	20.9	16.4	0	3.8	0	0	0	1.1	CON	CON
-460	108	Tamworth	Christopher Pincher	71319	66.1	60.8	23.7	12.9	0	1.8	0	0	0	0.8	CON	CON
-461	107	Norfolk Mid	George Freeman	80026	69.6	60	22.8	16.2	0	0	0	0	0	0.9	CON	CON
-462	106	Suffolk South	James Cartlidge	75967	71.4	58	20.8	18	0	3.2	0	0	0	0	CON	CON
-463	105	Dartford	Gareth Johnson	78506	69.1	61.1	23.8	12.7	0	2.4	0	0	0	0	CON	CON
-464	104	Bedfordshire North East	Alistair Burt	86988	73.8	58.4	21.1	16.7	0	2.9	0	0	0	1	CON	CON
-465	103	Somerton and Frome	David Warburton	84435	75.3	52.2	14.8	29.7	0	3.3	0	0	0	0	CON	CON
-466	102	Wiltshire South West	Andrew Murrison	76898	71.2	57.5	20.1	19.2	0	3.2	0	0	0	0	CON	CON
-467	101	Bridgwater and West Somerset	Ian Liddell-Grainger	89294	65.3	58	20.5	17.8	0	2.8	0	0	0	1	CON	CON
-468	100	Tiverton and Honiton	Neil Parish	80731	71.6	57.6	20.1	18.9	0	3.4	0	0	0	0	CON	CON
-469	99	Cleethorpes	Martin Vickers	73047	65.5	63.6	26	8.5	0	2	0	0	0	0	CON	CON
-470	98	Ashford	Damian Green	87396	68.5	59.3	21.6	15.1	0	3	0	0	0	0.9	CON	CON
-471	97	Wyre Forest	Mark Garnier	77734	65.8	60.8	23.1	13.7	0	2.4	0	0	0	0	CON	CON
-472	96	Windsor	Adam Afriyie	73595	73.3	56	18.3	21.3	0	3.5	0	0	0	1	CON	CON
-473	95	Chesham and Amersham	Cheryl Gillan	71465	77.3	54.9	17.1	24.5	0	3.6	0	0	0	0	CON	CON
-474	94	Solihull	Julian Knight	77784	73	54.7	16.8	25.8	0	2.6	0	0	0	0	CON	CON
-475	93	Horsham	Jeremy Quin	82773	74.9	55.1	17.2	23.2	0	3.4	0	0	0	1.1	CON	CON
-476	92	Spelthorne	Kwasi Kwarteng	72641	69	59.6	21.7	15.9	0	2.8	0	0	0	0	CON	CON
-477	91	Maidstone and The Weald	Helen Grant	75334	68.6	55	17	24.2	0	2.8	0	0	0	1	CON	CON
-478	90	Devon West and Torridge	Geoffrey Cox	80527	73.9	55	16.9	23.8	0	3.1	0	0	0	1.2	CON	CON
-479	89	Hertsmere	Oliver Dowden	73554	71	57.6	19.3	20.1	0	3	0	0	0	0	CON	CON
-480	88	Charnwood	Edward Argar	78071	70.7	62.5	24.1	11	0	2.4	0	0	0	0	CON	CON
-481	87	Hereford and South Herefordshire	Jesse Norman	71088	71	57.9	19.4	19.4	0	3.3	0	0	0	0	CON	CON
-482	86	Skipton and Ripon	Julian Smith	78108	74.4	61.2	22.6	10.5	0	4.9	0	0	0	0.9	CON	CON
-483	85	Chichester	Gillian Keegan	84996	70.5	56.3	17.7	21.6	0	3.5	0	0	0	1	CON	CON
-484	84	Cornwall North	Scott Mann	68850	74	51	12.3	35.6	0	0	0	0	0	1.1	CON	CON
-485	83	Dumfriesshire, Clydesdale and Tweeddale	David Mundell	67672	72.4	49.1	10.3	7.9	0	0	32.7	0	0	0	CON	CON
-486	82	Sittingbourne and Sheppey	Gordon Henderson	81715	62.9	61.1	22.4	12.6	0	2.4	0	0	0	1.5	CON	CON
-487	81	Norfolk North West	Henry Bellingham	72062	67.7	61.9	22.6	13.1	0	2.4	0	0	0	0	CON	CON
-488	80	Tewkesbury	Laurence Robertson	81442	72.5	56.4	17.1	23.4	0	3.1	0	0	0	0	CON	CON
-489	79	Bosworth	David Tredinnick	80633	69.7	59.4	19.9	18	0	2.7	0	0	0	0	CON	CON
-490	78	Northamptonshire South	Andrea Leadsom	85756	75.8	61.8	22.3	12.2	0	3.1	0	0	0	0.7	CON	CON
-491	77	Stratford-on-Avon	Nadhim Zahawi	72609	72.3	56.8	17.3	23	0	2.9	0	0	0	0	CON	CON
-492	76	Lichfield	Michael Fabricant	74430	71.9	60.1	20.6	15.6	0	2.8	0	0	0	0.9	CON	CON
-493	75	Gainsborough	Edward Leigh	75893	67.8	62.9	23.3	13.2	0	0	0	0	0	0.7	CON	CON
-494	74	Worcestershire West	Harriett Baldwin	74385	75.9	57.6	18	21.3	0	3.1	0	0	0	0	CON	CON
-495	73	Cotswolds, The	Geoffrey Clifton-Brown	80446	74.2	54.9	15.3	26.6	0	3.2	0	0	0	0	CON	CON
-496	72	Torbay	Kevin Foster	75936	67.4	54.2	14.5	27.8	0	2.4	0	0	0	1	CON	CON
-497	71	Arundel and South Downs	Nick Herbert	80766	74.6	57.4	17.7	20.2	0	3.7	0	0	0	1	CON	CON
-498	70	Maidenhead	Theresa May	76276	76.4	56.8	17	23.2	0	3	0	0	0	0	CON	CON
-499	69	Faversham and Kent Mid	Helen Whately	76008	65.5	59.8	19.7	16.3	0	3.3	0	0	0	0.9	CON	CON
-500	68	Newark	Robert Jenrick	75526	72.9	63.5	23.4	11.2	0	1.8	0	0	0	0	CON	CON
-501	67	Moray	Douglas Ross	70649	67.4	47.1	7	5.2	0	0	40.7	0	0	0	CON	CON
-502	66	Hampshire North West	Kit Malthouse	81430	72.2	58.6	18.5	19.8	0	3	0	0	0	0	CON	CON
-503	65	Penrith and The Border	Rory Stewart	65139	71.3	61.7	21.5	13.2	0	2.8	0	0	0	0.8	CON	CON
-504	64	Wiltshire North	James Gray	71408	75.2	55.2	14.9	27	0	3	0	0	0	0	CON	CON
-505	63	Fareham	Suella Fernandes	79495	71.7	59.5	19.2	18.2	0	3.1	0	0	0	0	CON	CON
-506	62	Aberdeenshire West and Kincardine	Andrew Bowie	72477	71.2	47.3	6.9	11.4	0	0	34.4	0	0	0	CON	CON
-507	61	Newbury	Richard Benyon	82923	73.4	53.7	13.3	28.9	0	3.1	0	0	0	1	CON	CON
-508	60	Surrey Heath	Michael Gove	80537	71.8	57.7	17.2	21.4	0	3.7	0	0	0	0	CON	CON
-509	59	Ludlow	Philip Dunne	68034	73.4	58.7	18.2	20.5	0	2.6	0	0	0	0	CON	CON
-510	58	Wealden	Nus Ghani	81425	74.3	58.2	17.7	20.5	0	3.5	0	0	0	0	CON	CON
-511	57	Leicestershire South	Alberto Costa	78895	71.9	63.5	22.9	11.2	0	2.5	0	0	0	0	CON	CON
-512	56	Meriden	Caroline Spelman	81437	67.1	61.1	20.4	15.4	0	3.1	0	0	0	0	CON	CON
-513	55	Witham	Priti Patel	69137	71.2	60.6	19.9	15.9	0	3.6	0	0	0	0	CON	CON
-514	54	Yorkshire East	Greg Knight	81065	66.6	63.8	23.1	9.8	0	2.5	0	0	0	0.8	CON	CON
-515	53	Old Bexley and Sidcup	James Brokenshire	66005	72.8	62.1	21.3	13.1	0	2.6	0	0	0	1	CON	CON
-516	52	Brigg and Goole	Andrew Percy	66069	68.2	65.4	24.5	8.2	0	2	0	0	0	0	CON	CON
-517	51	Basildon South and East Thurrock	Stephen Metcalfe	73541	64.1	64.4	23.5	11.2	0	0	0	0	0	0.8	CON	CON
-518	50	Saffron Walden	Kemi Badenoch	83690	72.8	57.7	16.8	23.2	0	2.3	0	0	0	0	CON	CON
-519	49	Basildon and Billericay	John Baron	69149	65	63.1	21.9	12.4	0	1.8	0	0	0	0.8	CON	CON
-520	48	Braintree	James Cleverly	75316	69.5	62.7	21.5	15	0	0	0	0	0	0.9	CON	CON
-521	47	Hampshire East	Damian Hinds	74148	74.7	56	14.8	24.7	0	3.5	0	0	0	1.1	CON	CON
-522	46	Thirsk and Malton	Kevin Hollinrake	78670	71.1	62.4	21.3	12.6	0	2.7	0	0	0	0.9	CON	CON
-523	45	Yeovil	Marcus Fysh	82911	71.6	52.7	11.4	32.3	0	2.5	0	0	0	1.1	CON	CON
-524	44	Romford	Andrew Rosindell	73516	67.9	63.7	22.4	11.5	0	2.4	0	0	0	0	CON	CON
-525	43	Banff and Buchan	David Duguid	67601	61.6	47.3	5.9	5.9	0	0	40.8	0	0	0	CON	CON
-526	42	Havant	Alan Mak	72464	63.9	61.1	19.6	15.2	0	3	0	0	0	1.2	CON	CON
-527	41	Tonbridge and Malling	Tom Tugendhat	77234	73.7	59.7	18.1	18.2	0	3.9	0	0	0	0	CON	CON
-528	40	Gosport	Caroline Dinenage	73886	67	62	20.4	14.8	0	2.8	0	0	0	0	CON	CON
-529	39	Suffolk West	Matt Hancock	76984	67.2	62.5	20.8	14.1	0	2.6	0	0	0	0	CON	CON
-530	38	Orpington	Jo Johnson	67906	74.3	60.6	18.8	17.5	0	3	0	0	0	0	CON	CON
-531	37	Mole Valley	Paul Beresford	74545	76.1	54.8	12.9	28	0	3.2	0	0	0	1	CON	CON
-532	36	Stone	Bill Cash	67824	73.8	62	20.1	15.6	0	2.3	0	0	0	0	CON	CON
-533	35	Devizes	Claire Perry	72184	70.1	59.4	17.2	19.7	0	3.7	0	0	0	0	CON	CON
-534	34	Bexhill and Battle	Huw Merriman	78512	75.7	61	18.7	17.5	0	2.8	0	0	0	0	CON	CON
-535	33	Broxbourne	Charles Walker	73502	64.6	63.7	21.3	12.6	0	2.4	0	0	0	0	CON	CON
-536	32	Hampshire North East	Ranil Jayawardena	75476	76.4	57.3	14.8	23.6	0	3.2	0	0	0	1	CON	CON
-537	31	Dorset Mid and Poole North	Michael Tomlinson	65054	74.2	54.5	11.9	31.6	0	2	0	0	0	0	CON	CON
-538	30	Surrey East	Sam Gyimah	82004	72.2	58.8	16.2	20.3	0	3	0	0	0	1.6	CON	CON
-539	29	Herefordshire North	Bill Wiggin	67751	74.1	58.7	15.9	21.2	0	4.2	0	0	0	0	CON	CON
-540	28	New Forest East	Julian Lewis	72602	70.8	58.9	15.9	21.3	0	3	0	0	0	1	CON	CON
-541	27	Rutland and Melton	Alan Duncan	78463	73.4	62.6	19.5	13.8	0	3.4	0	0	0	0.7	CON	CON
-542	26	Epping Forest	Eleanor Laing	74737	67.9	61.8	18.7	15.5	0	3.1	0	0	0	0.9	CON	CON
-543	25	Richmond	Rishi Sunak	80920	70.5	63.1	19.9	12.2	0	3.7	0	0	0	1	CON	CON
-544	24	Sevenoaks	Michael Fallon	71061	72.1	60.2	16.9	18.5	0	3.4	0	0	0	1	CON	CON
-545	23	Grantham and Stamford	Nick Boles	81762	69.2	64.8	21.4	11.3	0	2.4	0	0	0	0	CON	CON
-546	22	Bognor Regis and Littlehampton	Nick Gibb	75827	67.7	62.3	18.8	14.8	0	2.7	0	0	0	1.4	CON	CON
-547	21	Dorset North	Simon Hoare	76385	73	59.3	15.3	22.3	0	3.1	0	0	0	0	CON	CON
-548	20	Daventry	Chris Heaton-Harris	75335	73.9	64.6	20.5	12.2	0	2.7	0	0	0	0	CON	CON
-549	19	Aldridge-Brownhills	Wendy Morton	60363	66.7	64.6	20.4	12.3	0	1.7	0	0	0	0.9	CON	CON
-550	18	Meon Valley	George Hollingbery	74246	73	59.9	15.5	21.7	0	2.9	0	0	0	0	CON	CON
-551	17	Norfolk South West	Elizabeth Truss	77874	67.3	64.8	19.9	12.7	0	1.8	0	0	0	0.8	CON	CON
-552	16	Hornchurch and Upminster	Julia Dockerill	80821	69.4	65.3	20.2	11.2	0	2.4	0	0	0	0.8	CON	CON
-553	15	Worcestershire Mid	Nigel Huddleston	76065	72.4	62.9	17.4	16.1	0	2.8	0	0	0	0.8	CON	CON
-554	14	New Forest West	Desmond Swayne	68787	72.1	61.6	16.1	19.2	0	3.1	0	0	0	0	CON	CON
-555	13	Sleaford and North Hykeham	Caroline Johnson	90925	72.4	66.6	20.4	10.2	0	2.1	0	0	0	0.7	CON	CON
-556	12	Louth and Horncastle	Victoria Atkins	79006	66.8	68.6	21	9.7	0	0	0	0	0	0.6	CON	CON
-557	11	Cambridgeshire North East	Stephen Barclay	84404	63.1	66.3	18.6	12.8	0	2.4	0	0	0	0	CON	CON
-558	10	Berwickshire, Roxburgh and Selkirk	John Lamont	73191	71.5	53.2	5.4	7	0	0	34.3	0	0	0	CON	CON
-559	9	Brentwood and Ongar	Alex Burghart	74911	70.6	63.6	15.7	17	0	2.7	0	0	0	1	CON	CON
-560	8	Staffordshire South	Gavin Williamson	73453	69.6	66.3	18.3	13.1	0	2.3	0	0	0	0	CON	CON
-561	7	Maldon	John Whittingdale	66960	75	65.4	17.1	14.9	0	2.6	0	0	0	0	CON	CON
-562	6	Christchurch	Christopher Chope	70329	72	64.2	15.7	17.4	0	2.7	0	0	0	0	CON	CON
-563	5	Rayleigh and Wickford	Mark Francois	78556	70.4	67.1	18	12.7	0	2.3	0	0	0	0	CON	CON
-564	4	Clacton	Giles Watling	69263	63.7	68.7	18.4	9.9	0	2	0	0	0	1	CON	CON
-565	3	Castle Point	Rebecca Harris	69470	64.4	69.7	18.8	11.5	0	0	0	0	0	0	CON	CON
-566	2	Boston and Skegness	Matt Warman	68391	62.7	72.7	19.5	7.3	0	0	0	0	0	0.5	CON	CON
-567	1	South Holland and The Deepings	John Hayes	76381	65.9	73.1	16.6	7.7	0	2.1	0	0	0	0.5	CON	CON
+1	567	Liverpool Walton	Dan Carden	62628	65.1	6.6	82	2.3	3.5	4	0	0	1.6	LAB	LAB
+2	566	Birmingham Ladywood	Shabana Mahmood	74912	56.2	7.2	81.7	1	2.9	6.8	0	0	0.4	LAB	LAB
+3	565	Manchester Gorton	Afzal Khan	76419	58.3	6.5	79.5	1.1	3.9	8.6	0	0	0.5	LAB	LAB
+4	564	Liverpool Riverside	Kim Johnson	80310	65.7	6.4	77.7	3.2	3.5	7.9	0	0	1.3	LAB	LAB
+5	563	Bradford West	Naz Shah	70694	62.6	8.5	79.5	0.4	5.1	6.3	0	0	0.3	LAB	LAB
+6	562	Birmingham Hodge Hill	Liam Byrne	78295	57.5	8.9	79.9	0.8	4	6.1	0	0	0.3	LAB	LAB
+7	561	Liverpool West Derby	Ian Byrne	65640	67	7.7	78.7	2.8	4.8	4.1	0	0	1.8	LAB	LAB
+8	560	Knowsley	George Howarth	84082	65.3	7.4	78.3	3.1	4.7	4.6	0	0	1.9	LAB	LAB
+9	559	Bootle	Peter Dowd	74832	65.7	7.6	77.7	3.7	4.6	4.7	0	0	1.7	LAB	LAB
+10	558	East Ham	Stephen Timms	88319	61.9	9.3	79.3	0.7	3.7	6.6	0	0	0.4	LAB	LAB
+11	557	Bethnal Green and Bow	Rushanara Ali	88262	68.6	7.5	76	0.8	3.7	11.8	0	0	0.2	LAB	LAB
+12	556	Tottenham	David Lammy	75740	61.9	8.6	76.2	2.5	3.7	8.3	0	0	0.8	LAB	LAB
+13	555	Manchester Central	Lucy Powell	92247	56.7	8.4	75.2	2.7	4.3	8.3	0	0	1.1	LAB	LAB
+14	554	Walthamstow	Stella Creasy	70267	68.8	9.4	75.9	1.9	3.8	8.4	0	0	0.6	LAB	LAB
+15	553	Liverpool Wavertree	Paula Barker	63458	68.4	8.4	74.9	5.2	4.1	6.1	0	0	1.3	LAB	LAB
+16	552	West Ham	Lyn Brown	97947	61.5	10.2	75.8	1.4	4.2	7.8	0	0	0.6	LAB	LAB
+17	551	Birmingham Hall Green	Tahir Ali	80283	65.9	10.7	75.6	1.1	4.7	7.6	0	0	0.3	LAB	LAB
+18	550	Hackney South and Shoreditch	Meg Hillier	89387	60.9	8.3	73.1	3.2	3.6	11.1	0	0	0.7	LAB	LAB
+19	549	Lewisham Deptford	Vicky Foxcroft	80631	68.7	8.6	71.4	5	3.7	10.4	0	0	0.9	LAB	LAB
+20	548	Camberwell and Peckham	Harriet Harman	88971	63.5	9	71.7	4.3	3.9	10.3	0	0	0.8	LAB	LAB
+21	547	Nottingham East	Nadia Whittome	66262	60.4	10.6	73.2	2.7	4.8	7.5	0	0	1.3	LAB	LAB
+22	546	Poplar and Limehouse	Apsana Begum	91836	66.7	10.4	72.7	1.9	3.9	10.8	0	0	0.3	LAB	LAB
+23	545	Manchester Withington	Jeff Smith	76530	69.2	8.5	70.7	6.5	3.8	9.9	0	0	0.7	LAB	LAB
+24	544	Leeds Central	Hilary Benn	90971	54.2	10.6	71.9	2.8	5.2	8.1	0	0	1.3	LAB	LAB
+25	543	Ilford South	Sam Tarry	84972	62.9	12.8	74.1	0.6	4.7	7.4	0	0	0.5	LAB	LAB
+26	542	Hackney North and Stoke Newington	Diane Abbott	92462	61.5	8.5	69.5	3.5	3.5	14.2	0	0	0.8	LAB	LAB
+27	541	Sheffield Central	Paul Blomfield	89849	56.7	7.8	68.9	4.2	3.9	14	0	0	1.1	LAB	LAB
+28	540	Garston and Halewood	Maria Eagle	76116	70.1	10.3	71.2	5.8	5.5	5.7	0	0	1.6	LAB	LAB
+29	539	Leicester South	Jonathan Ashworth	77708	64.5	11.5	72.3	2.8	4.6	7.9	0	0	0.9	LAB	LAB
+30	538	Chorley	Lindsay Hoyle	78177	51	8.8	69	4.4	6.5	7.7	0	0	3.6	LAB	LAB
+31	537	Birkenhead	Mick Whitley	63762	66.4	10.3	69.8	4.4	6.7	5.3	0	0	3.4	LAB	LAB
+32	536	Islington North	Jeremy Corbyn	75162	71.6	8.4	67.3	5.9	3.7	14	0	0	0.7	LAB	LAB
+33	535	Blackley and Broughton	Graham Stringer	73372	52.6	12.5	71.1	2.3	6.3	6.6	0	0	1.2	LAB	LAB
+34	534	Blackburn	Kate Hollern	71234	62.8	14	71.8	1.8	6	5.5	0	0	0.9	LAB	LAB
+35	533	Croydon North	Steve Reed	88468	62.9	13.5	71.1	3.5	4.2	6.8	0	0	0.9	LAB	LAB
+36	532	Bradford East	Imran Hussain	73206	60.4	12.6	69.4	4.4	6.7	6.2	0	0	0.6	LAB	LAB
+37	531	Leyton and Wanstead	John Cryer	64852	68.7	12.7	69.4	3.2	4.5	9.6	0	0	0.6	LAB	LAB
+38	530	Holborn and St Pancras	Keir Starmer	86061	66	10.9	66.9	4.2	3.8	13.6	0	0	0.6	LAB	LAB
+39	529	Brent Central	Dawn Butler	84032	58.5	14	69.9	2.8	4.2	8.5	0	0	0.5	LAB	LAB
+40	528	Birmingham Perry Barr	Khalid Mahmood	72006	58.5	15	70.7	2.6	4.7	6.2	0	0	0.8	LAB	LAB
+41	527	Edmonton	Kate Osamor	65747	61.4	15.6	71	1.9	4.4	6.5	0	0	0.6	LAB	LAB
+42	526	Wallasey	Angela Eagle	66310	70.1	13.9	68.9	4.5	5.7	5	0	0	1.9	LAB	LAB
+43	525	Newcastle upon Tyne East	Nick Brown	63796	68	12.1	67	6.6	4.1	8.9	0	0	1.2	LAB	LAB
+44	524	Preston	Mark Hendrick	59672	56.6	14.1	68.9	4.2	5.6	5.9	0	0	1.3	LAB	LAB
+45	523	Halton	Derek Twigg	71930	64.2	13.8	68.1	4.6	6.5	5	0	0	2.1	LAB	LAB
+46	522	Barking	Margaret Hodge	77953	57.1	15.3	69	1.4	6.2	7.5	0	0	0.7	LAB	LAB
+47	521	Ealing Southall	Virendra Sharma	64581	65.4	14.3	67.8	3.9	4.6	8.6	0	0	0.8	LAB	LAB
+48	520	Sheffield Brightside and Hillsborough	Gill Furniss	69333	57.1	13	66.4	3.6	8.5	7	0	0	1.5	LAB	LAB
+49	519	Newcastle upon Tyne Central	Chi Onwurah	57845	64.8	13.5	66.8	4.3	6.6	7.6	0	0	1.1	LAB	LAB
+50	518	Vauxhall	Florence Eshalomi	88659	63.5	11.7	64.9	8.9	3.6	10.2	0	0	0.8	LAB	LAB
+51	517	Edinburgh South	Ian Murray	66188	75.1	8.3	60.8	4.9	2.2	4.5	17	0	2.3	LAB	LAB
+52	516	Dulwich and West Norwood	Helen Hayes	80331	69.4	11	63.2	4.6	3.9	16.3	0	0	1	LAB	LAB
+53	515	Mitcham and Morden	Siobhain McDonagh	70021	65.3	15.8	67.9	3.7	4.7	7	0	0	1	LAB	LAB
+54	514	Cardiff Central	Jo Stevens	64037	65.3	14.6	66.7	6.2	3.5	5.4	3.2	0	0.4	LAB	LAB
+55	513	Nottingham South	Lilian Greenwood	79485	60.6	15	66.7	4.2	4.6	8.1	0	0	1.3	LAB	LAB
+56	512	Salford and Eccles	Rebecca Long-Bailey	82202	61.6	13.9	65.2	4.8	6.7	7.9	0	0	1.6	LAB	LAB
+57	511	Leeds North East	Fabian Hamilton	70580	71.6	15.1	66.4	4.4	5.6	7.7	0	0	1	LAB	LAB
+58	510	Streatham	Bell Ribeiro-Addy	84783	66.7	11.8	63	10.2	3.8	10.4	0	0	0.8	LAB	LAB
+59	509	St Helens South and Whiston	Marie Rimmer	79061	63.6	13.3	64.4	6.3	7.5	6.4	0	0	2.1	LAB	LAB
+60	508	Lewisham West and Penge	Ellie Reeves	74617	69.8	13.4	64.2	7.8	4.7	9	0	0	1	LAB	LAB
+61	507	Lewisham East	Janet Daby	67857	66	14.4	65	6.7	4.8	8	0	0	1.1	LAB	LAB
+62	506	Leeds West	Rachel Reeves	67727	59.5	14.1	64.5	4.4	7.5	7.6	0	0	1.9	LAB	LAB
+63	505	Middlesbrough	Andy McDonald	60764	56.1	15.3	65.6	2.9	8.6	5.4	0	0	2.2	LAB	LAB
+64	504	Greenwich and Woolwich	Matthew Pennycook	79997	66.4	14	64.3	6.7	4.6	9.4	0	0	1	LAB	LAB
+65	503	Islington South and Finsbury	Emily Thornberry	70489	67.8	12.1	62.3	8.5	4.1	12.4	0	0	0.7	LAB	LAB
+66	502	Hammersmith	Andy Slaughter	74759	69.5	15.5	65	5.3	4	9.3	0	0	0.8	LAB	LAB
+67	501	Stretford and Urmston	Kate Green	72372	69.2	17.1	66.6	3.7	5.6	5	0	0	1.9	LAB	LAB
+68	500	Oxford East	Anneliese Dodds	78303	63	13.1	62.4	8.6	4.1	10.9	0	0	0.9	LAB	LAB
+69	499	Slough	Tan Dhesi	86818	58.8	17.9	67	2	5.2	7.2	0	0	0.6	LAB	LAB
+70	498	Oldham West and Royton	Jim McMahon	72999	60.9	16.6	65.5	2.7	7.9	6.1	0	0	1.2	LAB	LAB
+71	497	Leicester East	Claudia Webbe	78433	63	17.7	66.5	1.6	6.5	6.7	0	0	1	LAB	LAB
+72	496	Glasgow North East	Anne McLaughlin	61075	55.5	2.5	50.9	2.1	1.7	2.3	38.5	0	2.1	NAT	LAB
+73	495	Birmingham Selly Oak	Steve McCabe	82665	59.8	17.1	65	4.5	4.7	7.6	0	0	1	LAB	LAB
+74	494	Warley	John Spellar	62357	59.7	16.9	64.7	4.5	5.8	7.1	0	0	1.1	LAB	LAB
+75	493	Bristol West	Thangam Debbonaire	99253	76.1	7.1	54.8	5.3	3.2	28.8	0	0	0.9	LAB	LAB
+76	492	Hornsey and Wood Green	Catherine West	81814	74.7	10.5	57.8	17.3	3.7	10.2	0	0	0.6	LAB	LAB
+77	491	Luton North	Sarah Owen	68185	62.5	19.2	66.4	1.7	5.6	6.4	0	0	0.7	LAB	LAB
+78	490	Ealing North	James Murray	74473	66.6	18.7	65.7	2.9	4.7	7.4	0	0	0.7	LAB	LAB
+79	489	Hayes and Harlington	John McDonnell	72357	60.8	19.1	66.1	2.1	5.3	6.5	0	0	0.9	LAB	LAB
+80	488	York Central	Rachael Maskell	74899	66.1	15.5	62.2	7.9	5	7.8	0	0	1.7	LAB	LAB
+81	487	Gateshead	Ian Mearns	64449	59.2	16.5	63.2	6	6.3	6.5	0	0	1.5	LAB	LAB
+82	486	Leicester West	Liz Kendall	64940	53.5	17.2	63.8	3.5	6.9	7.2	0	0	1.5	LAB	LAB
+83	485	Hull North	Diana Johnson	65515	52.2	14.8	61.2	6.8	8.2	6.9	0	0	2.2	LAB	LAB
+84	484	Bermondsey and Old Southwark	Neil Coyle	93248	62.9	12.4	58.8	16	4	8.3	0	0	0.6	LAB	LAB
+85	483	Birmingham Yardley	Jess Phillips	74704	57.1	17.8	64.1	4	6.3	7.2	0	0	0.5	LAB	LAB
+86	482	Aberavon	Stephen Kinnock	50750	62.3	14	60.1	3.1	6.9	3.3	11.5	0	1	LAB	LAB
+87	481	Rhondda	Chris Bryant	50262	59	10.3	56	1.8	6.3	2	22.3	0	1.3	LAB	LAB
+88	480	Bolton South East	Yasmin Qureshi	69163	58.7	17.8	63.5	3	8	6.5	0	0	1.2	LAB	LAB
+89	479	Wythenshawe and Sale East	Mike Kane	76313	58.7	16.9	62.3	5.3	7.1	6.8	0	0	1.6	LAB	LAB
+90	478	Luton South	Rachel Hopkins	69338	60.7	19.1	64.5	2.4	6.3	6.4	0	0	1.4	LAB	LAB
+91	477	Westminster North	Karen Buck	65519	65.5	18.3	63.7	3.6	4.3	9.6	0	0	0.6	LAB	LAB
+92	476	Nottingham North	Alex Norris	66495	53.1	17.4	62.5	4.3	7.9	6.1	0	0	1.9	LAB	LAB
+93	475	Merthyr Tydfil and Rhymney	Gerald Jones	56322	57.3	14	59	3.9	7.5	3.2	11.3	0	1.1	LAB	LAB
+94	474	Blaenau Gwent	Nick Smith	50739	59.6	13.3	58.1	3	9.8	3.2	11.3	0	1.2	LAB	LAB
+95	473	Derby South	Margaret Beckett	73062	58.1	18.6	63.3	4.2	7.2	5.4	0	0	1.4	LAB	LAB
+96	472	South Shields	Emma Lewell-Buck	62793	60.3	14.2	58.7	5	12.3	7	0	0	2.8	LAB	LAB
+97	471	Tooting	Rosena Allin-Khan	76954	76	17.7	62	6.5	3.9	9.1	0	0	0.8	LAB	LAB
+98	470	Glasgow South West	Chris Stephens	64575	57.1	3.5	47.7	2.5	1.8	2.6	39.4	0	2.4	NAT	LAB
+99	469	Huddersfield	Barry Sheerman	65525	63.9	18.1	62.2	3.8	7.3	7.5	0	0	1.2	LAB	LAB
+100	468	Coventry North East	Colleen Fletcher	76006	58.5	19.3	63.3	4.4	5.6	6.1	0	0	1.3	LAB	LAB
+101	467	Norwich South	Clive Lewis	77845	66.4	14.9	58.8	9.6	5	10.3	0	0	1.4	LAB	LAB
+102	466	Easington	Grahame Morris	61182	56.5	16.2	59.9	5.7	10.7	4.6	0	0	2.9	LAB	LAB
+103	465	St Helens North	Conor McGinn	75593	62.9	16.5	60	6.7	8.4	6.3	0	0	2.2	LAB	LAB
+104	464	Tyneside North	Mary Glindon	78902	63.9	17	60.2	6.5	8.4	5.9	0	0	2.1	LAB	LAB
+105	463	Rochdale	Tony Lloyd	78909	60.1	17.8	60.7	5.4	8.4	6.8	0	0	0.9	LAB	LAB
+106	462	Feltham and Heston	Seema Malhotra	80934	59.1	20.1	62.9	3.2	5.7	7.2	0	0	0.9	LAB	LAB
+107	461	Swansea East	Carolyn Harris	58450	57.4	17.1	59.9	3.5	6.2	3.6	8.7	0	0.9	LAB	LAB
+108	460	Cynon Valley	Beth Winter	51134	59.1	14.3	57.1	2.7	6.9	2.3	15.4	0	1.3	LAB	LAB
+109	459	Cardiff South and Penarth	Stephen Doughty	78837	64.2	18.9	61.6	3.6	5.3	4.9	5.3	0	0.6	LAB	LAB
+110	458	Sheffield Heeley	Louise Haigh	66940	63.8	16.4	59	6.8	8.7	7.6	0	0	1.6	LAB	LAB
+111	457	Coatbridge, Chryston and Bellshill	Steven Bonnar	72943	66.1	4.7	47.1	2.1	1.9	3.5	38.6	0	2.1	NAT	LAB
+112	456	Sefton Central	Bill Esterson	69760	72.9	18.8	61.1	7	6.1	5.4	0	0	1.7	LAB	LAB
+113	455	Brent North	Barry Gardiner	83788	61.9	21.1	63.3	3.2	4.7	6.7	0	0	0.9	LAB	LAB
+114	454	Glasgow Central	Alison Thewliss	69230	57.9	2.4	44.7	3.1	2.1	4.8	40.8	0	2	NAT	LAB
+115	453	Bristol East	Kerry McCarthy	73867	70.6	18.3	60.5	6.3	5.8	7.9	0	0	1.2	LAB	LAB
+116	452	Leeds East	Richard Burgon	67286	58	18.8	60.9	4.6	8.1	6	0	0	1.6	LAB	LAB
+117	451	Ealing Central and Acton	Rupa Huq	75510	72.6	18.3	60.4	7.5	4.3	8.9	0	0	0.7	LAB	LAB
+118	450	Jarrow	Kate Osborne	65103	62.6	16.9	58.8	6.2	9.7	5.5	0	0	2.9	LAB	LAB
+119	449	Stockport	Navendu Mishra	65391	63.8	16.9	58.8	9.2	6.6	7.1	0	0	1.3	LAB	LAB
+120	448	Denton and Reddish	Andrew Gwynne	66234	58.3	18.3	59.9	5.1	8.2	6.5	0	0	2	LAB	LAB
+121	447	Glasgow North	Patrick Grady	57130	63.3	3	44.5	4.2	2.3	5.2	38.5	0	2.3	NAT	LAB
+122	446	Birmingham Edgbaston	Preet Gill	68828	61.5	20.9	62.2	4.6	4.8	6.5	0	0	1	LAB	LAB
+123	445	Harrow West	Gareth Thomas	72464	66.1	21	62	4.3	4.7	7.1	0	0	0.9	LAB	LAB
+124	444	Hove	Peter Kyle	74313	75.9	15.8	56.8	6.5	6.1	13.3	0	0	1.5	LAB	LAB
+125	443	Hampstead and Kilburn	Tulip Siddiq	86571	66.3	17.4	58.2	9.3	4.2	10.3	0	0	0.7	LAB	LAB
+126	442	Exeter	Ben Bradshaw	82054	68.5	19.1	59.4	5.3	5	9.6	0	0	1.7	LAB	LAB
+127	441	Cardiff West	Kevin Brennan	68508	67.4	18.8	58.9	3.5	5	4.2	8.9	0	0.7	LAB	LAB
+128	440	Rutherglen and Hamilton West	Margaret Ferrier	80918	66.5	6.7	46.8	3.3	1.9	2.4	35.8	0	3.1	NAT	LAB
+129	439	Cambridge	Daniel Zeichner	79951	67.2	11.3	51.2	21.9	3.7	11.2	0	0	0.7	LAB	LAB
+130	438	Ogmore	Chris Elmore	57581	61.5	17.3	57.2	3.5	6.4	3.4	11	0	1	LAB	LAB
+131	437	Southampton Test	Alan Whitehead	70116	64.2	19.7	59.5	7.4	5.4	6.7	0	0	1.4	LAB	LAB
+132	436	Swansea West	Geraint Davies	57078	62.8	19	58.8	5.1	4.8	3.9	7.7	0	0.6	LAB	LAB
+133	435	Ashton under Lyne	Angela Rayner	67978	56.8	19.5	59.2	4.2	8.6	6.8	0	0	1.7	LAB	LAB
+134	434	Bradford South	Judith Cummins	69046	57.6	20.2	59.9	3.4	8.7	6.4	0	0	1.4	LAB	LAB
+135	433	Bristol South	Karin Smyth	84079	65.6	17.5	57	8.5	6.1	9.5	0	0	1.4	LAB	LAB
+136	432	Ellesmere Port and Neston	Justin Madders	70327	69.3	21	60	5.8	6.4	5	0	0	1.8	LAB	LAB
+137	431	Glasgow East	David Linden	67381	57.1	6.5	45.2	2.7	1.8	2.4	39.3	0	2.1	NAT	LAB
+138	430	Walsall South	Valerie Vaz	68024	62.4	22.7	61.4	3	5.9	6.1	0	0	1	LAB	LAB
+139	429	Brentford and Isleworth	Ruth Cadbury	85775	68	20.8	59.5	6	5	8	0	0	0.8	LAB	LAB
+140	428	Washington and Sunderland West	Sharon Hodgson	66278	56.6	18.4	56.8	6.7	9.7	5.7	0	0	2.7	LAB	LAB
+141	427	Barnsley Central	Dan Jarvis	65277	56.5	15.5	54	6.3	14.1	7.1	0	0	3.1	LAB	LAB
+142	426	Rotherham	Sarah Champion	61688	57.8	18.7	56.8	5	11.8	6	0	0	1.8	LAB	LAB
+143	425	Stalybridge and Hyde	Jonathan Reynolds	73064	58	19.9	57.8	4.9	8.7	6.6	0	0	2	LAB	LAB
+144	424	Enfield North	Feryal Clark	68301	66	22.8	60.7	4.1	5.1	6.4	0	0	0.9	LAB	LAB
+145	423	Durham North	Kevan Jones	66796	63.2	18.9	56.7	7.7	8.8	5.5	0	0	2.4	LAB	LAB
+146	422	Wigan	Lisa Nandy	75680	59.5	19.2	56.6	6.7	9.2	6.1	0	0	2.2	LAB	LAB
+147	421	Sheffield South East	Clive Betts	67832	61.9	19.8	57.2	6.2	9.5	5.4	0	0	1.9	LAB	LAB
+148	420	Hull West and Hessle	Emma Hardy	60192	52.1	18.5	55.8	7.2	10.8	5.5	0	0	2.2	LAB	LAB
+149	419	Lancaster and Fleetwood	Cat Smith	70059	64.5	21.4	58.6	5.5	6.2	6.4	0	0	1.9	LAB	LAB
+150	418	Makerfield	Yvonne Fovargue	74190	59.7	20.1	57.1	5.8	9.5	5.3	0	0	2.2	LAB	LAB
+151	417	Plymouth Sutton and Devonport	Luke Pollard	77852	68.3	20.8	57.8	7.7	5.3	6.6	0	0	1.7	LAB	LAB
+152	416	Glasgow South	Stewart McDonald	70891	66.9	5.3	42.3	3.8	2.2	4.5	39.7	0	2.3	NAT	LAB
+153	415	Erith and Thamesmead	Abena Oppong-Asare	65399	63.3	22.4	59.2	4.8	6	6.3	0	0	1.4	LAB	LAB
+154	414	Sunderland Central	Julie Elliott	72680	59.8	20	56.7	6.5	8.6	5.9	0	0	2.2	LAB	LAB
+155	413	Brighton Kemptown	Lloyd Russell-Moyle	69833	69.5	19.3	55.9	6.9	6.3	10.1	0	0	1.5	LAB	LAB
+156	412	Motherwell and Wishaw	Marion Fellows	68856	64.5	7.8	44.4	2.4	1.9	2.4	38	0	3.2	NAT	LAB
+157	411	Worsley and Eccles South	Barbara Keeley	75219	59.4	20.8	57.3	5.9	7.9	6.1	0	0	1.9	LAB	LAB
+158	410	Durham, City of	Mary Foy	71271	68.6	17.9	54.4	12.4	6.5	7.1	0	0	1.6	LAB	LAB
+159	409	Halifax	Holly Lynch	71887	64.6	22.1	58.5	4.6	7.8	5.3	0	0	1.6	LAB	LAB
+160	408	Ilford North	Wes Streeting	72973	68.7	24.2	60.5	2.6	5.3	6.7	0	0	0.7	LAB	LAB
+161	407	Houghton and Sunderland South	Bridget Phillipson	68835	57.8	18.9	55.2	6.6	10.6	6.1	0	0	2.6	LAB	LAB
+162	406	Islwyn	Chris Evans	55423	62	18.2	54.3	3.6	8.3	3.7	10.9	0	1.1	LAB	LAB
+163	405	Hull East	Karl Turner	65745	49.3	18.3	54.4	7.4	10.9	6.4	0	0	2.6	LAB	LAB
+164	404	Leeds North West	Alex Sobel	67741	72.8	16.6	52.4	16.6	5.6	7.9	0	0	0.9	LAB	LAB
+165	403	Newcastle upon Tyne North	Catherine McKinnell	68486	68.6	19.5	55.2	8.5	8.3	6.8	0	0	1.6	LAB	LAB
+166	402	Wirral South	Alison McGovern	57280	76	22.3	57.9	7	6.1	5.2	0	0	1.6	LAB	LAB
+167	401	Kirkcaldy and Cowdenbeath	Neale Hanvey	72853	64.5	11.8	47.2	4	2.3	5.4	26.8	0	2.6	NAT	LAB
+168	400	Battersea	Marsha De Cordova	79350	75.6	21.6	57	8.2	4.1	8.3	0	0	0.8	LAB	LAB
+169	399	Tynemouth	Alan Campbell	77261	72.5	22.1	57.3	6.6	6.8	5.6	0	0	1.7	LAB	LAB
+170	398	Barnsley East	Stephanie Peacock	69504	54.8	17.5	52.6	6.4	14	6.6	0	0	2.8	LAB	LAB
+171	397	Lancashire West	Rosie Cooper	73347	71.8	24.5	59.6	4.9	6	3.8	0	0	1.3	LAB	LAB
+172	396	Wolverhampton South East	Pat McFadden	62883	53.2	22.7	57.6	6.1	6.4	5.4	0	0	1.9	LAB	LAB
+173	395	Croydon Central	Sarah Jones	81407	66.4	23.8	58.8	5	5.2	6.2	0	0	1.1	LAB	LAB
+174	394	Inverclyde	Ronnie Cowan	60622	65.8	7.3	42.1	4.1	1.8	2.5	39.9	0	2.2	NAT	LAB
+175	393	Chester, City of	Chris Matheson	76057	71.7	23.6	58.2	7.3	5	4.1	0	0	1.8	LAB	LAB
+176	392	Portsmouth South	Stephen Morgan	74186	63.9	20.9	55.3	11.7	4.7	6.4	0	0	1	LAB	LAB
+176	391	Dunbartonshire West	Martin Docherty	66517	67.9	6.3	40.6	2.7	2.1	3.8	41.2	0	3.3	NAT	NAT
+177	391	Blaydon	Liz Twist	67853	67.3	19	53.3	9.5	9.9	6.2	0	0	2.1	LAB	LAB
+177	390	Glasgow North West	Carol Monaghan	63402	62.7	6.8	41.1	4.4	1.8	2.5	41.1	0	2.3	NAT	NAT
+178	390	Normanton, Pontefract and Castleford	Yvette Cooper	84527	57.1	20.4	54.5	6.5	10.9	4.9	0	0	2.8	LAB	LAB
+178	389	Dundee West	Chris Law	64431	64.5	4.5	38.6	3.8	2	2.9	45.3	0	3	NAT	NAT
+179	389	Stockton North	Alex Cunningham	66649	61.8	22.4	56.5	5.4	9.1	4.3	0	0	2.4	LAB	LAB
+180	388	Doncaster North	Ed Miliband	72362	56.2	20.1	53.9	6	11.9	5.2	0	0	2.9	LAB	LAB
+181	387	Caerphilly	Wayne David	63166	63.5	17.2	51	2.3	7.4	2.6	18.3	0	1.2	LAB	LAB
+182	386	Doncaster Central	Rosie Winterton	71389	58.2	20.6	54.3	5.5	11.3	6	0	0	2.3	LAB	LAB
+183	385	Warrington North	Charlotte Nichols	72235	64.6	22.5	56	6.5	7.6	5.4	0	0	1.9	LAB	LAB
+183	384	Edinburgh East	Tommy Sheppard	69424	68.9	6	39.4	4.4	2.3	5.6	40	0	2.2	NAT	NAT
+184	384	Bolton North East	Mark Logan	67564	64.5	23.9	57.3	4.1	7.6	5.6	0	0	1.4	CON	LAB
+185	383	Hemsworth	Jon Trickett	73726	59.6	20.8	54.1	5.2	11.4	5.6	0	0	2.8	LAB	LAB
+186	382	Wentworth and Dearne	John Healey	74536	55.8	20.5	53.7	7.1	10.9	5.2	0	0	2.6	LAB	LAB
+187	381	Reading East	Matt Rodda	77152	72.5	23.1	56.3	7.7	4.8	7	0	0	1	LAB	LAB
+188	380	Neath	Christina Rees	56419	65.1	17.6	50.5	3.1	7.3	2.8	17.5	0	1.2	LAB	LAB
+189	379	Stoke-on-Trent Central	Jo Gideon	55419	57.9	24	56.8	5	7	5.8	0	0	1.4	CON	LAB
+190	378	Derby North	Amanda Solloway	73199	64.2	23.3	55.9	6.4	6.8	5.8	0	0	1.8	CON	LAB
+191	377	Bury South	Christian Wakeford	75152	66.9	24	56.6	4.7	7.4	5.5	0	0	1.8	CON	LAB
+192	376	Eltham	Clive Efford	64086	68.2	24	56.3	5.9	5.8	6.9	0	0	1.2	LAB	LAB
+193	375	Cardiff North	Anna McMorrin	68438	77	24.6	56.6	4.7	4.7	4.2	4.6	0	0.6	LAB	LAB
+194	374	Bristol North West	Darren Jones	76273	73.3	23.1	55	9.1	4.7	7.1	0	0	1	LAB	LAB
+195	373	Pontypridd	Alex Davies-Jones	60327	64.7	19.3	51.2	3.4	6.7	2.9	15.5	0	1.1	LAB	LAB
+196	372	Putney	Fleur Anderson	65556	77	22.8	54.6	9.2	4.3	8.3	0	0	0.7	LAB	LAB
+197	371	Torfaen	Nick Thomas-Symonds	62330	59.6	20.8	52.5	4.8	8.8	4.3	7.8	0	1	LAB	LAB
+198	370	Oldham East and Saddleworth	Debbie Abrahams	72120	64	23	54.5	6.2	8.7	6	0	0	1.6	LAB	LAB
+199	369	West Bromwich East	Nicola Richards	62046	58	25.3	56.7	4.4	6.6	5.5	0	0	1.5	CON	LAB
+200	368	Birmingham Northfield	Gary Sambrook	73694	58.5	25	55.9	5.8	6.2	5.6	0	0	1.6	CON	LAB
+201	367	Wansbeck	Ian Lavery	63339	64	22.1	53.1	8.3	8.8	5.7	0	0	2	LAB	LAB
+202	366	Lincoln	Karl McCartney	74942	67.6	24.7	55.6	5.9	6.2	5.5	0	0	2	CON	LAB
+203	365	Gedling	Tom Randall	71366	70	24.3	55.2	5.9	7.3	5.5	0	0	1.8	CON	LAB
+204	364	Coventry South	Zarah Sultana	70979	63.5	24.6	55.5	7.2	4.8	6.6	0	0	1.3	LAB	LAB
+205	363	Coventry North West	Taiwo Owatemi	75247	63.4	24.7	55.4	6.2	6	6.4	0	0	1.3	LAB	LAB
+206	362	Bury North	James Daly	68802	68.1	26	56.7	4.3	6.8	4.9	0	0	1.3	CON	LAB
+207	361	Hyndburn	Sara Britcliffe	70842	59.9	25.2	55.7	4.1	8.4	5.2	0	0	1.6	CON	LAB
+208	360	Wirral West	Margaret Greenwood	55550	77.3	25.3	55.6	6.8	6	4.8	0	0	1.5	LAB	LAB
+209	359	Blyth Valley	Ian Levy	64429	63.4	22.7	52.8	7.6	9.1	5.8	0	0	2	CON	LAB
+210	358	Enfield Southgate	Bambos Charalambous	65525	72.1	26	56.1	5.3	4.9	6.8	0	0	0.9	LAB	LAB
+211	357	Airdrie and Shotts	Neil Gray	64011	62.1	11.6	41.6	1.6	1.7	1.8	40.2	0	1.5	NAT	LAB
+212	356	Chesterfield	Toby Perkins	71034	63.6	21.1	51.1	10.1	9.7	6.2	0	0	2	LAB	LAB
+213	355	Midlothian	Owen Thompson	70544	68.4	12.8	42.8	4.5	1.9	2.6	33.1	0	2.3	NAT	LAB
+214	354	Dewsbury	Mark Eastwood	81253	69.4	25.6	55.5	4.5	7.7	5.4	0	0	1.3	CON	LAB
+215	353	Leigh	James Grundy	77417	60.7	24.7	54.5	5.9	8.4	4.5	0	0	2.1	CON	LAB
+216	352	Heywood and Middleton	Chris Clarkson	80162	59.2	23.7	53.5	5.4	9.2	6.6	0	0	1.6	CON	LAB
+217	351	West Bromwich West	Shaun Bailey	64517	53.4	25.9	55.6	4.1	7.2	5.7	0	0	1.5	CON	LAB
+218	350	Durham North West	Richard Holden	72166	66	22.9	52.3	8.1	9.3	5.2	0	0	2.2	CON	LAB
+218	349	Cumbernauld, Kilsyth and Kirkintilloch East	Stuart McDonald	66079	69.1	7.7	37.1	4.2	1.8	2.5	44.4	0	2.2	NAT	NAT
+218	349	Paisley and Renfrewshire South	Mhairi Black	64385	66.9	9	38.2	4.4	1.9	2.5	41.8	0	2.3	NAT	NAT
+218	349	Glenrothes	Peter Grant	65672	63.3	8.3	37.4	4.1	2	2.9	42.7	0	2.6	NAT	NAT
+219	349	Bedford	Mohammad Yasin	71581	66.1	25.3	54.2	8	5.5	5.8	0	0	1.2	LAB	LAB
+220	348	Blackpool South	Scott Benton	57690	56.8	25	53.8	5.3	8.7	4.7	0	0	2.5	CON	LAB
+221	347	Newport East	Jessica Morden	58554	62	24.8	53.6	5	6.8	4.4	4.8	0	0.6	LAB	LAB
+222	346	Dagenham and Rainham	Jon Cruddas	71045	61.6	26.1	54.7	3.4	7.7	7.1	0	0	1.1	LAB	LAB
+223	345	Llanelli	Nia Griffith	60518	63.2	17.8	46.3	1.7	7.2	1.7	24.1	0	1.3	LAB	LAB
+224	344	Keighley	Robbie Moore	72778	72.3	26.7	54.9	5.4	7.1	4.5	0	0	1.4	CON	LAB
+225	343	Birmingham Erdington	Jack Dromey	66148	53.3	29.8	57.9	2.1	4.4	3.2	0	1.1	1.4	LAB	LAB
+226	342	Darlington	Peter Gibson	66397	65.5	25.6	53.5	6.6	7.4	4.9	0	0	2	CON	LAB
+227	341	Na h-Eileanan An Iar (Western Isles)	Angus MacNeil	21106	68.6	13.2	40.8	2.8	1.8	2.5	36.7	0	2.2	NAT	LAB
+228	340	Pudsey	Stuart Andrew	73212	74.1	26.7	54.2	6.2	6.3	5.1	0	0	1.5	CON	LAB
+229	339	Weaver Vale	Mike Amesbury	70551	71.9	25.5	53	7.7	6.8	5.3	0	0	1.7	LAB	LAB
+230	338	High Peak	Robert Largan	74265	72.9	25.7	53.1	7.4	6.9	5.2	0	0	1.7	CON	LAB
+231	337	Southampton Itchen	Royston Smith	72299	65.6	26.4	53.6	7.1	5.8	5.5	0	0	1.5	CON	LAB
+232	336	Newport West	Ruth Jones	66657	65.2	25.8	53	4.8	6.1	4.4	5.3	0	0.6	LAB	LAB
+233	335	Warwick and Leamington	Matt Western	76362	71	25.1	52.2	10.1	4.8	6.5	0	0	1.4	LAB	LAB
+234	334	Peterborough	Paul Bristow	72560	65.9	27	53.7	5.6	6.9	5.6	0	0	1.2	CON	LAB
+235	333	Wolverhampton South West	Stuart Anderson	60534	68	28.3	54.9	6	5.2	4.3	0	0	1.3	CON	LAB
+236	332	Burnley	Antony Higginbotham	64345	60.6	22.8	48.9	10.3	10.8	5.6	0	0	1.6	CON	LAB
+237	331	Northampton South	Andrew Lewer	62163	65.7	26.6	52.7	5.7	7.1	6.4	0	0	1.4	CON	LAB
+238	330	Colne Valley	Jason McCartney	84174	72.3	26.5	52.6	6.6	7.5	5.3	0	0	1.5	CON	LAB
+239	329	Edinburgh North and Leith	Deidre Brock	81336	73	10.4	36.5	7.5	2.4	5.2	35.2	0	2.7	NAT	LAB
+240	328	Warrington South	Andy Carter	86015	72	26.5	52.3	8.6	6.6	4.5	0	0	1.5	CON	LAB
+241	327	Loughborough	Jane Hunt	79764	68.5	26.8	52.6	7	5.7	6.2	0	0	1.6	CON	LAB
+242	326	Pendle	Andrew Stephenson	65289	68.1	28.3	54	4.2	7.7	4.6	0	0	1.3	CON	LAB
+243	325	East Lothian	Kenny MacAskill	81600	71.7	17.3	42.9	4.5	2	2.7	27.7	0	3	NAT	LAB
+244	324	Bolsover	Mark Fletcher	74292	61.8	25.5	51	6.3	9.7	5	0	0	2.5	CON	LAB
+245	323	Stockton South	Matt Vickers	76870	71.3	28.1	53.6	5.4	7.2	3.9	0	0	1.7	CON	LAB
+246	322	Sedgefield	Paul Howell	64325	64.6	25.5	50.9	7.1	9.2	5.1	0	0	2.3	CON	LAB
+247	321	Dunfermline and West Fife	Douglas Chapman	76652	69.8	12.4	37.7	5.1	2.2	4.3	35.9	0	2.4	NAT	LAB
+248	320	Don Valley	Nick Fletcher	75356	60.3	24.9	50.2	6.3	10.8	5.3	0	0	2.5	CON	LAB
+249	319	Broxtowe	Darren Henry	73052	75.7	27	52.1	4.7	7.8	5.8	0	0	2.6	CON	LAB
+250	318	Hendon	Matthew Offord	82661	66.6	29.1	54.2	4.6	4.7	6.6	0	0	0.9	CON	LAB
+251	317	Calder Valley	Craig Whittaker	79287	72.9	27.7	52.8	6.6	7	4.3	0	0	1.6	CON	LAB
+252	316	Wolverhampton North East	Jane Stevenson	61660	55.6	27.7	52.6	6.5	6.7	4.8	0	0	1.7	CON	LAB
+253	315	Barrow and Furness	Simon Fell	70158	65.6	27.7	52.3	6.3	7.3	4.3	0	0	2	CON	LAB
+254	314	Ipswich	Tom Hunt	75525	65.6	27.6	52.2	7	6.1	5.6	0	0	1.6	CON	LAB
+255	313	Alyn and Deeside	Mark Tami	62789	68.5	26.8	51.2	5.3	6.5	3.2	6.1	0	0.8	LAB	LAB
+256	312	Gower	Tonia Antoniazzi	61762	72	27.1	51.4	4.7	5.5	2.9	7.7	0	0.7	LAB	LAB
+257	311	Canterbury	Rosie Duffield	80203	75	27.5	51.7	9.3	4.8	5.6	0	0	1.1	LAB	LAB
+258	310	Northampton North	Michael Ellis	58768	67.3	27.8	51.8	5.7	7.3	5.9	0	0	1.5	CON	LAB
+259	309	Sheffield Hallam	Olivia Blake	72763	78.2	17.4	41.1	27.5	5.7	7.6	0	0	0.7	LAB	LAB
+260	308	Redcar	Jacob Young	65864	62	25.2	48.6	9.6	9.9	4.8	0	0	2	CON	LAB
+261	307	Stoke-on-Trent North	Jonathan Gullis	68298	58.8	28.3	51.7	5.7	7.9	4.8	0	0	1.6	CON	LAB
+262	306	Chingford and Woodford Green	Iain Duncan Smith	65393	74.1	30	53.4	4.5	5.5	5.8	0	0	0.8	CON	LAB
+263	305	Shipley	Philip Davies	74029	72.9	28.3	51.6	6.3	7	5.2	0	0	1.6	CON	LAB
+263	304	East Kilbride, Strathaven and Lesmahagow	Lisa Cameron	81224	69.4	12.7	35.8	4.3	2.2	4.1	37.9	0	3.1	NAT	NAT
+264	304	Scunthorpe	Holly Mumby-Croft	61955	60.9	28	51.1	5.2	8.8	4.8	0	0	2	CON	LAB
+265	303	Workington	Mark Jenkinson	61370	67.8	27.6	50.4	6.8	8.6	4.6	0	0	2	CON	LAB
+266	302	Milton Keynes South	Iain Stewart	96363	66.4	28.6	51.4	6.9	5.7	6.2	0	0	1.2	CON	LAB
+267	301	Bridgend	Jamie Wallis	63303	66.7	26.7	49.5	5.2	6.3	3.7	7.9	0	0.7	CON	LAB
+267	300	Paisley and Renfrewshire North	Gavin Newlands	72007	69	13.6	36.2	4.7	1.9	2.6	38.6	0	2.4	NAT	NAT
+268	300	Reading West	Alok Sharma	74137	68	28.6	51.2	7.9	5.4	5.8	0	0	1.1	CON	LAB
+269	299	Copeland	Trudy Harrison	61693	68.9	29	51.6	6.1	7.3	4.2	0	0	1.7	CON	LAB
+270	298	Chipping Barnet	Theresa Villiers	79960	72	28.5	50.9	7.4	5.2	7.2	0	0	0.9	CON	LAB
+271	297	Clwyd South	Simon Baynes	53919	67.3	27	49.2	4.1	6.5	2.6	9.8	0	0.8	CON	LAB
+272	296	Great Grimsby	Lia Nici	61409	53.9	27.2	49.2	6.6	9.7	5.1	0	0	2.2	CON	LAB
+273	295	Norwich North	Chloe Smith	67172	68.9	28.5	50.5	8.2	5.9	5.4	0	0	1.5	CON	LAB
+274	294	Carlisle	John Stevenson	65105	65.9	29.1	50.9	7	7.2	3.7	0	0	2.1	CON	LAB
+274	293	Arfon	Hywel Williams	42215	68.9	9.1	30.9	0.6	3.8	0.7	53.9	0	1.1	NAT	NAT
+275	293	Kensington	Felicity Buchan	64609	67.7	27	48.5	9.7	4.7	9.4	0	0	0.7	CON	LAB
+276	292	Rossendale and Darwen	Jake Berry	72770	67.1	29.6	51	5.8	7.3	4.7	0	0	1.7	CON	LAB
+277	291	Bishop Auckland	Dehenna Davison	68170	65.7	28.7	50.1	6.7	8.8	3.7	0	0	2	CON	LAB
+278	290	Hastings and Rye	Sally-Ann Hart	80524	67.4	29.5	50.9	8.3	5.6	4.4	0	0	1.4	CON	LAB
+279	289	Vale of Clwyd	James Davies	56649	65.7	28.8	50.1	4.1	5.9	2.5	7.8	0	0.8	CON	LAB
+279	288	Livingston	Hannah Bardell	82285	66.3	13.6	34.9	4.1	2.2	4.5	38.5	0	2.3	NAT	NAT
+280	288	Delyn	Rob Roberts	54560	70.3	28.5	49.7	5.4	6.2	2.9	6.5	0	0.8	CON	LAB
+281	287	Morecambe and Lunesdale	David Morris	67397	67.2	29.1	50.2	7	7	4.7	0	0	1.9	CON	LAB
+282	286	Worcester	Robin Walker	73485	69.3	29	49.9	8	5.6	6.1	0	0	1.4	CON	LAB
+283	285	Wycombe	Steve Baker	78098	70.1	28.6	49.6	7.9	5.9	7.2	0	0	0.9	CON	LAB
+284	284	Morley and Outwood	Andrea Jenkyns	78803	65.9	29.3	50.3	6.1	7.5	5	0	0	1.9	CON	LAB
+285	283	Milton Keynes North	Ben Everitt	91545	68.3	29	49.8	8.2	5.6	6.2	0	0	1.1	CON	LAB
+286	282	Erewash	Maggie Throup	72523	67.3	28.9	49.6	6.7	7.7	5	0	0	2	CON	LAB
+287	281	Stroud	Siobhan Baillie	84537	78	28.6	49.4	6.6	6.3	7.5	0	0	1.6	CON	LAB
+288	280	Bolton West	Chris Green	73191	67.4	29.9	50.6	5.9	7.1	5.1	0	0	1.4	CON	LAB
+289	279	Corby	Tom Pursglove	86153	70.2	30	50.7	6.7	6.8	4.1	0	0	1.7	CON	LAB
+290	278	Crawley	Henry Smith	74207	67.2	30.8	51	5.3	5.9	5.9	0	0	1.1	CON	LAB
+291	277	Crewe and Nantwich	Kieran Mullan	80321	67.3	30	49.9	6.6	7	4.6	0	0	1.9	CON	LAB
+292	276	Swindon South	Robert Buckland	73118	69.4	30.1	49.9	8.9	5.3	4.5	0	0	1.3	CON	LAB
+293	275	Watford	Dean Russell	83359	69.7	28.2	48	11.5	5.5	5.9	0	0	0.9	CON	LAB
+294	274	Wakefield	Imran Ahmad-Khan	70192	64.1	29.2	49	3.6	6.6	3.3	0	3.8	4.5	CON	LAB
+294	273	Orkney and Shetland	Alistair Carmichael	34211	67.7	2.5	22.2	41.1	2.2	3.1	25.6	0	3.3	LIB	LIB
+295	273	Rother Valley	Alexander Stafford	74804	65.1	26.5	46.1	7.6	11.2	6.5	0	0	2.2	CON	LAB
+296	272	Wrexham	Sarah Atherton	49737	67.4	28.3	47.6	4.5	6.5	3.2	9.1	0	0.8	CON	LAB
+297	271	Blackpool North and Cleveleys	Paul Maynard	63692	60.9	30.2	49.5	6.1	7.8	4.3	0	0	2	CON	LAB
+298	270	Filton and Bradley Stoke	Jack Lopresti	74016	72.6	28.9	47.6	10.6	5.3	6.4	0	0	1.2	CON	LAB
+299	269	Vale of Glamorgan	Alun Cairns	76508	71.6	30.6	49.1	3.8	5.5	4.8	5.5	0	0.7	CON	LAB
+300	268	Cities of London and Westminster	Nickie Aiken	63700	67.1	26.6	45.1	11.9	4.5	11.3	0	0	0.6	CON	LAB
+301	267	Harrow East	Bob Blackman	72106	68.6	33	51.3	4.3	5.1	5.4	0	0	0.9	CON	LAB
+302	266	Middlesbrough South and Cleveland East	Simon Clarke	72348	66.1	30.7	49	6.1	7.9	4.5	0	0	1.8	CON	LAB
+303	265	Rushcliffe	Ruth Edwards	77047	78.5	28.3	46.5	11.7	6.3	5.8	0	0	1.4	CON	LAB
+304	264	Altrincham and Sale West	Graham Brady	73107	74.9	29.6	47.7	8.5	6.4	6.7	0	0	1.1	CON	LAB
+305	263	Telford	Lucy Allan	68921	62.1	31.4	48.8	8	6	4.2	0	0	1.6	CON	LAB
+306	262	Newcastle-under-Lyme	Aaron Bell	68211	65.6	30.7	48.1	8.4	6.1	5.2	0	0	1.6	CON	LAB
+306	261	Linlithgow and East Falkirk	Martyn Day	87044	66.4	16	33.2	4.9	2.3	4.4	35.8	0	3.4	NAT	NAT
+307	261	Stevenage	Stephen McPartland	71562	66.6	30.3	47.5	8.9	6	6.1	0	0	1.3	CON	LAB
+308	260	Batley and Spen	Tracy Brabin	79558	66.5	28.7	45.7	3.7	5.2	2.7	0	11	3	LAB	LAB
+309	259	Penistone and Stocksbridge	Miriam Cates	70925	69.8	28.7	45.5	9.9	9.3	4.8	0	0	1.7	CON	LAB
+309	258	Kilmarnock and Loudoun	Alan Brown	74517	63.9	15.2	31.7	3.3	1.9	2.5	42.4	0	2.9	NAT	NAT
+310	258	Gloucester	Richard Graham	80901	66.5	30.8	47.3	9.6	5.6	5.3	0	0	1.3	CON	LAB
+310	257	Aberdeen North	Kirsty Blackman	62489	59.9	11.7	28.2	4.9	2.3	4.7	45.6	0	2.7	NAT	NAT
+310	257	Brighton Pavilion	Caroline Lucas	79057	73.4	6.8	23.2	4.3	6.4	57.6	0	0	1.6	Green	Green
+311	257	Aberconwy	Robin Millar	44699	71.3	29	45.4	4.2	5.6	2.2	12.8	0	0.7	CON	LAB
+312	256	Stoke-on-Trent South	Jack Brereton	64491	61.4	32.9	49.2	5.9	6.8	3.8	0	0	1.3	CON	LAB
+312	255	Dunbartonshire East	Amy Callaghan	66075	80.3	6.3	22.6	33.1	2.3	3.9	28.7	0	3.3	NAT	LIB
+313	255	Scarborough and Whitby	Robert Goodwill	74404	66.8	30.9	46.7	7.7	8.6	4.2	0	0	2	CON	LAB
+314	254	Preseli Pembrokeshire	Stephen Crabb	59606	71.2	30.4	45.8	4	6.1	2.4	10.6	0	0.7	CON	LAB
+315	253	Mansfield	Ben Bradley	77131	63.9	31.9	46.8	5.7	9.3	4.4	0	0	1.9	CON	LAB
+316	252	Ashfield	Lee Anderson	78204	62.6	17.8	32.7	5	10.3	3.7	0	27.6	2.8	CON	LAB
+317	251	Ribble South	Katherine Fletcher	75351	71.4	32	46.9	7.8	6.9	4.7	0	0	1.6	CON	LAB
+318	250	Finchley and Golders Green	Mike Freer	77573	71	29.3	44	14	4.6	7.2	0	0	0.8	CON	LAB
+319	249	Truro and Falmouth	Cherilyn Mackrory	76719	77.2	28	42.8	15.8	5.8	6.5	0	0	1.1	CON	LAB
+320	248	Southport	Damien Moore	70837	68	27.7	42.4	17.2	7.1	4.6	0	0	1	CON	LAB
+321	247	York Outer	Julian Sturdy	74673	74.1	29.3	43.5	14.4	6.6	4.9	0	0	1.3	CON	LAB
+322	246	Ynys Mon	Virginia Crosbie	51925	70.4	21.7	35.8	1.9	7.2	1.6	30.7	0	1.2	CON	LAB
+323	245	Bassetlaw	Brendan Clarke-Smith	80024	63.5	31.3	45.1	7.2	9.8	4.1	0	0	2.5	CON	LAB
+324	244	Walsall North	Eddie Hughes	67177	54.4	33.4	47.1	6.4	6.9	4.7	0	0	1.5	CON	LAB
+324	243	Caithness Sutherland and Easter Ross	Jamie Stone	46930	67	8.3	22	33.5	2.1	3.2	28.1	0	2.8	LIB	LIB
+325	243	Sherwood	Mark Spencer	77888	67.7	32.2	45.8	7.1	8	5	0	0	2	CON	LAB
+326	242	Colchester	Will Quince	82625	64.6	28.1	41.7	17.2	5.5	6.4	0	0	1	CON	LAB
+326	241	Edinburgh South West	Joanna Cherry	73501	70.9	15.9	29.1	6.1	2.3	4.7	39.2	0	2.8	NAT	NAT
+327	241	Camborne and Redruth	George Eustice	70250	71.7	30.1	43.3	12.9	6.7	5.6	0	0	1.3	CON	LAB
+328	240	Worthing East and Shoreham	Tim Loughton	75194	70.7	30.7	43.9	10.9	6.5	6.8	0	0	1.2	CON	LAB
+329	239	Kingswood	Chris Skidmore	68972	71.5	32.5	45.6	9.2	5.9	5.4	0	0	1.4	CON	LAB
+329	238	Edinburgh West	Christine Jardine	72507	75.2	8.9	21.7	36.2	2.2	4	24.6	0	2.4	LIB	LIB
+330	238	Macclesfield	David Rutley	76216	70.7	30.9	43.5	10.3	7.3	6.5	0	0	1.4	CON	LAB
+331	237	Derbyshire North East	Lee Rowley	72345	68	32.3	44.9	8	8	5.2	0	0	1.6	CON	LAB
+332	236	Wimbledon	Stephen Hammond	68240	77.7	26.8	39.2	22	4.6	6.8	0	0	0.7	CON	LAB
+333	235	Plymouth Moor View	Johnny Mercer	69430	63.7	32.9	44.8	8.6	6.9	5.3	0	0	1.5	CON	LAB
+333	234	Fife North East	Wendy Chamberlain	60905	75.3	5	16.9	39.3	2	2.6	31.8	0	2.4	LIB	LIB
+334	234	Thurrock	Jackie Doyle-Price	79659	59.6	33.4	45.2	6.2	7	7	0	0	1.2	CON	LAB
+335	233	Bournemouth East	Tobias Ellwood	74125	66.5	30.3	42.1	12.9	6.2	7.2	0	0	1.3	CON	LAB
+335	232	Ross Skye and Lochaber	Ian Blackford	54230	73.5	9.2	20.9	20.9	2.3	2.9	39.9	0	4	NAT	NAT
+335	232	Dundee East	Stewart Hosie	66210	68.4	15.2	26.8	5.1	2	2.7	45.4	0	2.9	NAT	NAT
+336	232	Bournemouth West	Conor Burns	74205	62	30.2	41.8	13.5	5.8	7.4	0	0	1.3	CON	LAB
+337	231	Halesowen and Rowley Regis	James Morris	68300	62	34.7	46.1	6.2	6.4	5.1	0	0	1.4	CON	LAB
+338	230	Lanark and Hamilton East	Angela Crawley	77659	68.3	22.3	33.6	3.7	1.9	2.7	33.5	0	2.4	NAT	LAB
+339	229	Kettering	Philip Hollobone	73164	67.5	32.6	43.9	7.5	8.2	5.5	0	0	2.2	CON	LAB
+340	228	Amber Valley	Nigel Mills	69976	65.1	33	44.2	7.4	8.4	5.1	0	0	1.9	CON	LAB
+341	227	Nuneaton	Marcus Jones	70226	64.3	34.3	45.5	7	6.3	5.4	0	0	1.5	CON	LAB
+342	226	Dudley North	Marco Longhi	61936	59.2	34.9	45.8	6.1	6.8	5.1	0	0	1.3	CON	LAB
+343	225	Shrewsbury and Atcham	Daniel Kawczynski	82238	71.8	31.7	42.4	13	6	5.6	0	0	1.3	CON	LAB
+344	224	Welwyn Hatfield	Grant Shapps	74892	69.5	31.9	42.5	12.4	5.4	6.8	0	0	1.1	CON	LAB
+345	223	Swindon North	Justin Tomlinson	82441	66.9	33.5	43.8	9.6	6.1	5.5	0	0	1.4	CON	LAB
+346	222	Rochford and Southend East	James Duddridge	75624	61	33.9	44.1	8.2	6.9	5.4	0	0	1.5	CON	LAB
+347	221	Clwyd West	David Jones	57714	69.7	31.8	41.9	4.1	5.7	2	13.6	0	0.8	CON	LAB
+348	220	Wellingborough	Peter Bone	80765	64.3	32.7	42.8	8.2	8.4	6.1	0	0	1.8	CON	LAB
+349	219	Hexham	Guy Opperman	61324	75.3	32.3	42.1	11	7.6	5.7	0	0	1.3	CON	LAB
+350	218	Carmarthen West and Pembrokeshire South	Simon Hart	59158	71.2	32.5	42.3	4	6	2.3	12.2	0	0.8	CON	LAB
+351	217	Croydon South	Chris Philp	83982	70.7	33.7	42.7	10.1	5.7	6.7	0	0	1	CON	LAB
+352	216	Dover	Natalie Elphicke	76355	66.4	34.2	43.2	9.1	6.6	5.3	0	0	1.6	CON	LAB
+353	215	Basingstoke	Maria Miller	82928	66	32.3	41.2	13.2	5.8	6.3	0	0	1.3	CON	LAB
+354	214	Elmet and Rothwell	Alec Shelbrooke	80957	71.9	34.1	42.9	8.7	7.4	5.3	0	0	1.7	CON	LAB
+355	213	Rugby	Mark Pawsey	72292	70.3	34.3	43	10	6	5.4	0	0	1.4	CON	LAB
+356	212	Derbyshire South	Heather Wheeler	79331	67.3	34	42.6	8.4	7.7	5.6	0	0	1.8	CON	LAB
+357	211	Burton	Kate Griffiths	75036	65	35.8	44.2	7	6.4	5.3	0	0	1.3	CON	LAB
+358	210	Harlow	Robert Halfon	68078	63.7	36.3	44.4	7	6.3	4.6	0	0	1.4	CON	LAB
+358	209	Falkirk	Johnny McNally	84472	66.1	16.9	24.7	4.6	2.3	5.1	44.1	0	2.4	NAT	NAT
+359	209	Hemel Hempstead	Mike Penning	74035	69.3	33.9	41.4	11.1	6.2	6.3	0	0	1.1	CON	LAB
+360	208	Derbyshire Mid	Pauline Latham	67442	73.2	33.8	41.4	9.8	7.5	5.9	0	0	1.6	CON	LAB
+361	207	Stourbridge	Suzanne Webb	69891	65.4	36	43.5	7.5	6.6	5.2	0	0	1.3	CON	LAB
+362	206	Stafford	Theo Clarke	72572	70.5	35.1	42.6	9	6.2	5.7	0	0	1.4	CON	LAB
+363	205	Thanet South	Craig Mackinlay	73223	65.9	34.2	41.6	9.6	6.6	6.7	0	0	1.2	CON	LAB
+363	204	Ceredigion	Ben Lake	56386	71.1	14.9	22	8.1	6.7	1.9	45.8	0	0.7	NAT	NAT
+364	204	Banbury	Victoria Prentis	90116	69.8	33	39.8	13.5	6.1	6.6	0	0	1.1	CON	LAB
+365	203	Chelsea and Fulham	Greg Hands	67110	69.8	33.5	40.3	13.2	4.7	7.4	0	0	0.8	CON	LAB
+366	202	Leicestershire North West	Andrew Bridgen	78935	68.2	34.4	41.1	8.4	8.1	6.1	0	0	1.8	CON	LAB
+367	201	Wyre and Preston North	Ben Wallace	74775	70.8	35.4	41.9	8.1	7.7	5.5	0	0	1.4	CON	LAB
+368	200	Rochester and Strood	Kelly Tolhurst	82056	63.3	34.8	41.3	9.3	7	6.1	0	0	1.6	CON	LAB
+369	199	Monmouth	David Davies	67098	74.8	34.6	41	7.8	5.9	4.1	6	0	0.6	CON	LAB
+370	198	Bromley and Chislehurst	Bob Neill	66697	68.3	33.3	39.6	12.9	6	7.1	0	0	1.1	CON	LAB
+371	197	Portsmouth North	Penny Mordaunt	71299	64.4	34.8	41.1	10	6.8	5.8	0	0	1.5	CON	LAB
+372	196	Harborough	Neil O'Brien	80151	71.5	32.7	38.8	12.9	7.6	6.7	0	0	1.2	CON	LAB
+372	195	Ayrshire North and Arran	Patricia Gibson	73534	65.5	21.3	27.1	2.8	2.1	4.3	40.1	0	2.3	NAT	NAT
+373	195	Gillingham and Rainham	Rehman Chishti	73549	62.5	36.2	41.9	8.5	6.4	5.4	0	0	1.6	CON	LAB
+374	194	Somerset North East	Jacob Rees-Mogg	73692	76.4	31.3	36.9	19.2	5.7	5.7	0	0	1.2	CON	LAB
+374	193	Carmarthen East and Dinefwr	Jonathan Edwards	57419	71.4	18.6	24.2	1	6.8	0.8	47.4	0	1.2	NAT	NAT
+375	193	Selby and Ainsty	Nigel Adams	78398	72	36.3	41.5	6.3	6.7	4.7	0	2.1	2.4	CON	LAB
+376	192	Uxbridge and South Ruislip	Boris Johnson	70365	68.5	40	44.8	3.6	3.7	4.6	0	1.2	2.1	CON	LAB
+377	191	Bexleyheath and Crayford	David Evennett	65466	66.1	36.6	41.3	7.8	6.6	6.3	0	0	1.3	CON	LAB
+378	190	Congleton	Fiona Bruce	80930	70.7	34.4	38.9	12.1	7.6	5.4	0	0	1.5	CON	LAB
+379	189	Isle of Wight	Bob Seely	113021	65.9	29.1	33.6	9.6	11.4	14.3	0	0	1.9	CON	LAB
+380	188	Ribble Valley	Nigel Evans	79247	69.8	35.5	39.9	9.7	7.9	5.4	0	0	1.6	CON	LAB
+381	187	Waveney	Peter Aldous	82791	61.8	35.3	39.6	9.8	7.3	6.4	0	0	1.6	CON	LAB
+382	186	Gravesham	Adam Holloway	73242	64.9	37	41.3	8.1	6.5	5.7	0	0	1.4	CON	LAB
+383	185	Eddisbury	Edward Timpson	73700	71.9	34	38.2	14.1	7.2	5.1	0	0	1.5	CON	LAB
+384	184	Redditch	Rachel Maclean	65391	67.4	37.2	41.2	8.3	6.6	5.4	0	0	1.3	CON	LAB
+385	183	Fylde	Mark Menzies	66847	69.8	35.7	39.3	8.9	8.9	5.5	0	0	1.7	CON	LAB
+385	182	Inverness Nairn Badenoch and Strathspey	Drew Hendry	78059	70.2	19.8	23.2	7.1	2.4	5.3	39.4	0	2.8	NAT	NAT
+386	182	Forest of Dean	Mark Harper	71438	72.1	35.4	38.6	8.4	7.6	8.3	0	0	1.7	CON	LAB
+387	181	Bedfordshire South West	Andrew Selous	79926	66.7	35.8	39	11.3	6.5	6.1	0	0	1.3	CON	LAB
+388	180	Beverley and Holderness	Graham Stuart	79696	67.2	35.5	38.7	10.1	8.9	5	0	0	1.8	CON	LAB
+389	179	Warwickshire North	Craig Tracey	70271	65.3	37.9	41.1	7.8	6.7	4.9	0	0	1.6	CON	LAB
+389	178	Ayrshire Central	Philippa Whitford	69742	66.7	24.7	27.5	3.2	1.9	2.7	37.7	0	2.4	NAT	NAT
+390	178	Dartford	Gareth Johnson	82209	65.7	37.6	40.2	8.6	6.4	5.9	0	0	1.3	CON	LAB
+391	177	Cannock Chase	Amanda Milling	74813	61.9	37.6	40.2	7	7.2	6.1	0	0	1.7	CON	LAB
+391	176	Bath	Wera Hobhouse	67805	76.9	19	21.5	49.5	3.8	5.6	0	0	0.5	LIB	LIB
+392	176	Aylesbury	Rob Butler	86665	69.9	34.3	36.6	14	6.6	7.7	0	0	0.9	CON	LAB
+393	175	Worthing West	Peter Bottomley	78585	69.5	34.6	36.8	13.9	7	6.5	0	0	1.2	CON	LAB
+394	174	Derbyshire Dales	Sarah Dines	65080	76.9	35.1	37.1	12.2	8.1	6.1	0	0	1.4	CON	LAB
+395	173	Weston-Super-Mare	John Penrose	82526	67.4	33.7	35.7	17.3	6.5	5.6	0	0	1.1	CON	LAB
+396	172	Chatham and Aylesford	Tracey Crouch	71642	60.5	37.5	39.4	9.4	6.7	5.5	0	0	1.5	CON	LAB
+397	171	Aldershot	Leo Docherty	72617	66	33.9	35.7	16.3	6.4	6.6	0	0	1.2	CON	LAB
+398	170	Dorset South	Richard Drax	73809	69.2	35.2	36.9	13.2	7.2	5.9	0	0	1.4	CON	LAB
+399	169	Charnwood	Edward Argar	79534	69.6	36.4	38	9.7	7.9	6.5	0	0	1.6	CON	LAB
+400	168	Tatton	Esther McVey	69018	70.9	35.3	36.9	12.6	7.4	6.5	0	0	1.2	CON	LAB
+401	167	Hartlepool	Mike Hill	70855	57.9	37	38.5	4.2	8	3.5	0	4.9	4	LAB	LAB
+402	166	Beckenham	Bob Stewart	68662	73.6	35.3	36.6	14.1	5.8	7.1	0	0	1	CON	LAB
+402	165	Renfrewshire East	Kirsten Oswald	72232	76.6	25.1	26.4	4.8	1.9	2.8	36.5	0	2.5	NAT	NAT
+403	165	Huntingdon	Jonathan Djanogly	84657	69.9	33.7	35	16.9	6.5	6.6	0	0	1.3	CON	LAB
+404	164	St Austell and Newquay	Steve Double	79930	69.8	33.7	34.9	17.2	7.6	5.3	0	0	1.3	CON	LAB
+405	163	Leicestershire South	Alberto Costa	80520	71.4	36.4	37.5	10.5	7.8	6.2	0	0	1.5	CON	LAB
+406	162	Cleethorpes	Martin Vickers	73689	62.9	37.9	38.7	8.1	8.7	4.9	0	0	1.8	CON	LAB
+407	161	Ruislip, Northwood and Pinner	David Simmonds	72816	72.7	37.3	38	10.1	6.2	7.3	0	0	1	CON	LAB
+408	160	Hertford and Stortford	Julie Marson	81765	73.5	34.9	35.6	15	6.2	7.1	0	0	1.2	CON	LAB
+409	159	Wyre Forest	Mark Garnier	78077	64.8	38	38.6	8.3	8.3	5.6	0	0	1.1	CON	LAB
+410	158	Great Yarmouth	Brandon Lewis	71957	60.4	38.4	38.8	8.6	7.5	4.9	0	0	1.8	CON	LAB
+411	157	Newark	Robert Jenrick	75850	72.2	37.3	37.7	10.4	7.6	5.4	0	0	1.6	CON	LAB
+412	156	Haltemprice and Howden	David Davis	71083	70	36.7	36.9	10.9	8.4	5.5	0	0	1.6	CON	LAB
+413	155	Penrith and The Border	Neil Hudson	67555	70.8	35.5	35.7	12.7	8.8	5.6	0	0	1.7	CON	LAB
+414	154	Yorkshire East	Greg Knight	80923	65.2	36.5	36.7	9.7	10	5.3	0	0	1.9	CON	LAB
+415	153	Wrekin, The	Mark Pritchard	70693	69.2	38.3	38.5	10.4	6.1	5.4	0	0	1.3	CON	LAB
+416	152	Dudley South	Mike Wood	60731	60.2	39.4	39.5	8.1	6.7	4.9	0	0	1.4	CON	LAB
+417	151	Hertfordshire North East	Oliver Heald	76123	72.7	34.7	34.8	16.1	6.3	6.9	0	0	1.1	CON	LAB
+418	150	Bracknell	James Sunderland	78978	68.8	35.7	35.7	14.7	6.2	6.5	0	0	1.2	CON	LAB
+419	149	Berwick-upon-Tweed	Anne-Marie Trevelyan	59939	70.3	32.5	32.5	20.1	8.7	5	0	0	1.1	CON	CON
+419	148	Dwyfor Meirionnydd	Liz Saville Roberts	44362	67.5	15.9	15.8	0.7	6.5	0.5	59.7	0	1	NAT	NAT
+420	148	Norfolk South	Richard Bacon	86214	72.5	35.1	34.9	16.3	6.5	6	0	0	1.2	CON	CON
+421	147	Bury St Edmunds	Jo Churchill	89644	69.1	33.7	33.5	9.9	8.1	13	0	0	1.8	CON	CON
+422	146	Northamptonshire South	Andrea Leadsom	90842	73.7	36.5	36.1	11.5	7.8	6.6	0	0	1.6	CON	CON
+423	145	Somerset North	Liam Fox	80194	77.4	33.6	33.1	19.4	6.3	6.7	0	0	0.9	CON	CON
+424	144	Romford	Andrew Rosindell	72350	65.3	39.6	39.1	6.6	7	6.6	0	0	1.1	CON	CON
+424	143	Kingston and Surbiton	Ed Davey	81975	74.2	23.7	23.1	41.1	5	6.5	0	0	0.5	LIB	LIB
+425	143	Devon Central	Mel Stride	74926	77.5	33.6	33	18.8	7	6.6	0	0	1.1	CON	CON
+426	142	Tamworth	Christopher Pincher	71572	64.3	39.6	38.4	9.1	6.4	4.7	0	0	1.8	CON	CON
+426	141	Ayr Carrick and Cumnock	Allan Dorans	71970	64.7	28.1	26.9	3	1.9	2.7	35.1	0	2.4	NAT	NAT
+427	141	Hitchin and Harpenden	Bim Afolami	76323	77.1	31.8	30.6	26.4	5	5.3	0	0	0.8	CON	CON
+428	140	Thanet North	Roger Gale	72756	66.2	38	36.7	11.1	6.9	6.1	0	0	1.3	CON	CON
+429	139	Woking	Jonathan Lord	75454	71.5	32.8	31.4	22.4	5.8	6.9	0	0	0.7	CON	CON
+430	138	Staffordshire Moorlands	Karen Bradley	65485	66.7	39.5	38	9.8	6.6	4.6	0	0	1.4	CON	CON
+431	137	Skipton and Ripon	Julian Smith	78673	74.6	35.3	33.6	13.9	9.2	6.5	0	0	1.6	CON	CON
+432	136	Brigg and Goole	Andrew Percy	65939	65.8	39.5	37.8	7.4	8.8	4.5	0	0	1.9	CON	CON
+432	135	Hazel Grove	William Wragg	63346	69.9	28.7	27	32.2	6.9	4.4	0	0	0.8	CON	LIB
+433	135	Basildon South and East Thurrock	Stephen Metcalfe	74441	60.8	39.8	37.8	8.1	7.5	4.8	0	0	1.9	CON	CON
+434	134	Bedfordshire North East	Richard Fuller	90678	71.7	37.2	35.2	14	6.3	5.7	0	0	1.5	CON	CON
+435	133	Cambridgeshire North West	Shailesh Vara	94909	68	37.3	35.3	12.9	6.6	6.7	0	0	1.2	CON	CON
+435	132	Stirling	Alyn Smith	68473	76.8	23.7	21.7	3.5	2.1	4	42.7	0	2.4	NAT	NAT
+436	132	Cheadle	Mary Robinson	74577	75	30.6	28.3	29.1	6.4	5.1	0	0	0.6	CON	CON
+436	131	St Albans	Daisy Cooper	73727	78.1	27.2	24.9	36.1	4.9	6.4	0	0	0.5	LIB	LIB
+437	131	Runnymede and Weybridge	Ben Spencer	77196	69	36	33.6	16	6	7.2	0	0	1.2	CON	CON
+438	130	Sutton Coldfield	Andrew Mitchell	75638	69.2	38.9	36.4	11.5	6	6.2	0	0	1	CON	CON
+439	129	Bedfordshire Mid	Nadine Dorries	87795	73.7	37.1	34.5	14.3	6.3	6.5	0	0	1.3	CON	CON
+440	128	Gainsborough	Edward Leigh	76343	66.9	38.7	36.1	11.2	8.5	3.8	0	0	1.7	CON	CON
+441	127	Chelmsford	Vicky Ford	80394	71.1	34.7	32	21.5	5.8	5.1	0	0	1	CON	CON
+442	126	Grantham and Stamford	Gareth Davies	81502	68.7	37.8	35	11.1	8.8	5.8	0	0	1.5	CON	CON
+443	125	Wantage	David Johnston	90867	73.9	31.5	28.7	28.1	5.8	5	0	0	1	CON	CON
+443	124	Aberdeen South	Stephen Flynn	65719	69.4	25.9	23	7.4	2	2.9	36.2	0	2.6	NAT	NAT
+444	124	Folkestone and Hythe	Damian Collins	88272	66.8	36.5	33.6	14	7.7	6.8	0	0	1.3	CON	CON
+445	123	Richmond	Rishi Sunak	82569	69.9	37	33.9	12	9.3	5.8	0	0	1.9	CON	CON
+446	122	Reigate	Crispin Blunt	74242	71.6	34.4	31.3	18	6.5	8.6	0	0	1	CON	CON
+447	121	Ashford	Damian Green	89553	67.1	37.7	34.5	12.9	6.9	6.6	0	0	1.4	CON	CON
+448	120	Cambridgeshire South East	Lucy Frazer	86769	74.2	31.6	28.3	29.1	5.5	4.5	0	0	0.9	CON	CON
+449	119	Suffolk Coastal	Therese Coffey	81910	71.2	35.3	31.9	17.4	7.4	6.7	0	0	1.3	CON	CON
+450	118	Poole	Robert Syms	73989	68.2	36.3	32.9	16.6	6.9	6	0	0	1.2	CON	CON
+451	117	Sittingbourne and Sheppey	Gordon Henderson	83917	61.2	39.8	36.3	9.8	7.2	5.2	0	0	1.7	CON	CON
+451	116	Carshalton and Wallington	Elliot Colburn	72941	67.3	27.6	24.2	35.4	6.4	5.9	0	0	0.6	CON	LIB
+452	116	Harwich and North Essex	Bernard Jenkin	74153	70.1	37.6	34.1	14.3	6.6	6.1	0	0	1.3	CON	CON
+453	115	Daventry	Chris Heaton-Harris	77423	74.1	37.7	34.1	12	8.3	6.4	0	0	1.5	CON	CON
+454	114	Norfolk Mid	George Freeman	82203	68.4	37.9	34.2	15.1	6.8	4.5	0	0	1.4	CON	CON
+454	113	Cambridgeshire South	Anthony Browne	87288	76.7	29.7	25.8	33.7	5	5.1	0	0	0.7	CON	LIB
+455	113	Thirsk and Malton	Kevin Hollinrake	80991	69.9	37.2	33.3	12.6	9.5	5.9	0	0	1.6	CON	CON
+455	112	Argyll and Bute	Brendan O'Hara	66525	72.2	25.3	21.3	10.5	2.1	2.9	35.3	0	2.6	NAT	NAT
+456	112	Meriden	Saqib Bhatti	85368	63.4	39	35.1	11.6	6.6	6.5	0	0	1.2	CON	CON
+457	111	Spelthorne	Kwasi Kwarteng	70929	69.8	37.2	33.1	14.6	6.8	7.3	0	0	1	CON	CON
+458	110	Sussex Mid	Mims Davies	85146	73.7	34.2	29.9	22.5	6.1	6.3	0	0	1	CON	CON
+459	109	Hereford and South Herefordshire	Jesse Norman	72085	68.9	36.7	32.4	15.8	7.6	6.3	0	0	1.1	CON	CON
+460	108	Suffolk West	Matt Hancock	80193	64.1	38.5	34.2	12.5	6.9	6.5	0	0	1.3	CON	CON
+461	107	Sleaford and North Hykeham	Caroline Johnson	94761	70.2	39.7	35.2	9.1	9.2	4.9	0	0	1.8	CON	CON
+462	106	Suffolk Central and Ipswich North	Dan Poulter	80037	70.3	37.9	33.3	14.2	6.8	6.5	0	0	1.3	CON	CON
+463	105	Wokingham	John Redwood	83953	73.8	32.8	28.1	26.9	5.3	6.2	0	0	0.8	CON	CON
+464	104	Broxbourne	Charles Walker	73182	63.8	40.9	36	9.2	6.6	6	0	0	1.2	CON	CON
+465	103	Devon South West	Gary Streeter	72535	73.6	38.2	33.2	15.2	6.5	5.7	0	0	1.2	CON	CON
+466	102	Bosworth	Luke Evans	81542	69.2	36.7	31.8	16.7	8.3	5.2	0	0	1.2	CON	CON
+467	101	Salisbury	John Glen	74556	72.1	35.4	30.4	20.4	6.5	6.2	0	0	1.1	CON	CON
+467	100	Oxford West and Abingdon	Layla Moran	76951	76.4	24.9	19.7	45.3	4.7	4.9	0	0	0.5	LIB	LIB
+468	100	Wiltshire South West	Andrew Murrison	77969	70.4	36.6	31.4	17.9	6.9	6	0	0	1.1	CON	CON
+469	99	Broadland	Jerome Mayhew	78151	72.9	36.8	31.5	18.6	6.6	5.3	0	0	1.1	CON	CON
+470	98	Hertsmere	Oliver Dowden	73971	70.6	40	34.7	12	5.6	6.5	0	0	1.1	CON	CON
+471	97	Rutland and Melton	Alicia Kearns	82705	70.5	37.2	31.6	14.1	8.7	6.8	0	0	1.6	CON	CON
+472	96	Bridgwater and West Somerset	Ian Liddell-Grainger	85327	67.6	37.1	31.5	17.3	7.5	5.3	0	0	1.3	CON	CON
+473	95	Norfolk North West	James Wild	72080	64.7	40.2	34.6	11.4	7.3	5.3	0	0	1.4	CON	CON
+474	94	Epsom and Ewell	Chris Grayling	81138	73.3	36.4	30.8	19.1	6	6.7	0	0	1	CON	CON
+475	93	Basildon and Billericay	John Baron	69906	63.1	41	35.3	10.3	6.4	5.7	0	0	1.3	CON	CON
+476	92	Totnes	Anthony Mangnall	69863	74.7	33.3	27.5	26.4	7	4.8	0	0	1	CON	CON
+476	91	Ochil and South Perthshire	John Nicolson	78776	73.4	28.3	22.4	3.6	2	2.8	38.1	0	3	NAT	NAT
+476	91	Twickenham	Munira Wilson	84906	76	23.2	17.2	50.1	4.5	4.7	0	0	0.3	LIB	LIB
+477	91	Sutton and Cheam	Paul Scully	71779	70.3	33	26.8	27.5	6	6.1	0	0	0.6	CON	CON
+478	90	Witney	Robert Courts	83845	73.1	35	28.7	25	5.7	4.6	0	0	1	CON	CON
+479	89	Devon East	Simon Jupp	87168	73.5	37.8	31.5	8.9	13.7	5.3	0	0	2.8	CON	CON
+480	88	Bromsgrove	Sajid Javid	75078	72.3	40.1	33.6	13.3	6.3	5.6	0	0	1.1	CON	CON
+481	87	Stone	Bill Cash	69378	71.8	40.5	34.1	12.4	6.5	5.3	0	0	1.2	CON	CON
+482	86	Tunbridge Wells	Greg Clark	74823	73	35.8	29.3	23	5.8	5.1	0	0	1	CON	CON
+483	85	Faversham and Kent Mid	Helen Whately	73403	68.7	39	32.4	14.1	7	6.3	0	0	1.3	CON	CON
+484	84	Hertfordshire South West	Gagan Mohindra	80449	76.1	37.3	30.6	14.6	8.2	6.7	0	0	2.5	CON	CON
+485	83	Hornchurch and Upminster	Julia Lopez	80765	66.8	41.3	34.6	8.8	7.3	6.8	0	0	1.2	CON	CON
+486	82	Cornwall South East	Sheryll Murray	71825	74.7	36.1	29.2	21.1	7.5	5	0	0	1.1	CON	CON
+487	81	Southend West	David Amess	69043	67.4	41.2	34.3	11.7	6	4.7	0	0	2.2	CON	CON
+487	80	Guildford	Angela Richardson	77729	75.5	31.6	24.6	32.2	5.2	5.3	0	0	1.1	CON	LIB
+488	80	Kenilworth and Southam	Jeremy Wright	68154	77.2	37.3	30.3	19.2	5.8	6.2	0	0	1.1	CON	CON
+488	79	Perth and North Perthshire	Pete Wishart	72600	74.5	26.5	19.3	4.5	2	3	42.2	0	2.7	NAT	NAT
+489	79	Newton Abbot	Anne Marie Morris	72529	72.5	34.2	27	25.7	6.9	5.1	0	0	1	CON	CON
+490	78	Gosport	Caroline Dinenage	73541	65.9	39.8	32.6	13.8	7	5.6	0	0	1.3	CON	CON
+491	77	Suffolk South	James Cartlidge	76201	70.2	38.1	30.8	16.3	6.9	6.8	0	0	1.1	CON	CON
+492	76	Lichfield	Michael Fabricant	76616	70.5	40.6	33.2	13.2	6.5	5.2	0	0	1.4	CON	CON
+493	75	Maidstone and The Weald	Helen Grant	76109	67.9	37	29.5	19.8	6.6	6.2	0	0	1	CON	CON
+494	74	Solihull	Julian Knight	78760	70.3	38.5	31	17.1	6.3	6.4	0	0	0.7	CON	CON
+495	73	Havant	Alan Mak	72103	63.7	39	31.3	15.1	7.4	5.9	0	0	1.3	CON	CON
+496	72	Bognor Regis and Littlehampton	Nick Gibb	77446	66.1	39.6	31.7	13.9	7.7	5.8	0	0	1.4	CON	CON
+497	71	Buckingham	Greg Smith	83146	76.3	35.7	27.8	17.9	9.3	8.3	0	0	1	CON	CON
+498	70	Harrogate and Knaresborough	Andrew Jones	77941	73.1	32.9	24.9	29.8	7	4.4	0	0	1	CON	CON
+499	69	Epping Forest	Eleanor Laing	74304	67.7	40.5	32.5	11.7	6.9	7.3	0	0	1.1	CON	CON
+500	68	Braintree	James Cleverly	75208	67.1	41.4	33.2	12.1	7	4.6	0	0	1.7	CON	CON
+501	67	Tewkesbury	Laurence Robertson	83958	72.8	36.2	27.9	22.7	6.4	5.9	0	0	1	CON	CON
+502	66	Horsham	Jeremy Quin	86730	72.9	36	27.5	22.8	6.3	6.6	0	0	1	CON	CON
+503	65	Witham	Priti Patel	70402	70.1	40.1	31.4	12.9	7.1	7	0	0	1.4	CON	CON
+504	64	Eastleigh	Paul Holmes	83880	70.3	32.9	24	31	6.1	5.2	0	0	0.8	CON	CON
+505	63	Devizes	Danny Kruger	73372	69.4	37.8	28.8	18.4	7	6.8	0	0	1.2	CON	CON
+506	62	Aldridge-Brownhills	Wendy Morton	60138	65.4	43.6	34.3	9.5	6.8	4.3	0	0	1.5	CON	CON
+507	61	Hampshire North West	Kit Malthouse	83083	70.9	38.6	29.2	18.6	6.4	6.1	0	0	1.1	CON	CON
+508	60	Fareham	Suella Braverman	78337	73.1	39.7	30.2	16.3	6.6	6	0	0	1.1	CON	CON
+509	59	Norfolk South West	Liz Truss	78455	65.6	41.4	31.8	12.3	7.7	5.4	0	0	1.5	CON	CON
+510	58	Dumfries and Galloway	Alister Jack	74580	69	33.2	23.4	3.9	1.9	2.8	32.1	0	2.6	CON	CON
+511	57	Windsor	Adam Afriyie	75038	71.6	38.8	29.1	18.9	5.9	6.3	0	0	1	CON	CON
+512	56	Louth and Horncastle	Victoria Atkins	79634	65.7	42.6	32.4	9.7	9.9	3.7	0	0	1.7	CON	CON
+512	55	Richmond Park	Sarah Olney	82699	78.7	28.9	18.7	41.8	4.6	5.5	0	0	0.4	LIB	LIB
+513	55	Devon West and Torridge	Geoffrey Cox	80403	74.3	36.9	26.6	22.3	7.6	5.5	0	0	1	CON	CON
+514	54	Bexhill and Battle	Huw Merriman	81963	72.1	40.3	30.1	15.3	7.3	5.9	0	0	1.1	CON	CON
+515	53	Maidenhead	Theresa May	76668	73.7	39	28.6	19.1	5.9	6.6	0	0	0.8	CON	CON
+515	52	Gordon	Richard Thomson	79629	70.2	30.7	20.4	7	2	3	34.3	0	2.7	NAT	NAT
+516	52	Montgomeryshire	Craig Williams	48997	69.8	37.7	27.4	18	7.2	2.6	6.6	0	0.5	CON	CON
+517	51	Chichester	Gillian Keegan	85499	71.6	37.2	26.8	22.1	6.5	6.5	0	0	1	CON	CON
+518	50	Tonbridge and Malling	Tom Tugendhat	79278	71.9	39	28.3	16.4	6.9	8.2	0	0	1.1	CON	CON
+519	49	Romsey and Southampton North	Caroline Nokes	68228	75.3	35.3	24.5	29.9	5.2	4.3	0	0	0.8	CON	CON
+519	48	Chippenham	Michelle Donelan	77221	73.9	33.1	22.1	34.6	5.6	3.9	0	0	0.7	CON	LIB
+519	48	Angus	Dave Doogan	63952	67.5	29.8	18.7	3.7	1.9	2.8	40.7	0	2.5	NAT	NAT
+520	48	Orpington	Gareth Bacon	68877	70.7	41	29.8	15.3	6.4	6.5	0	0	1	CON	CON
+521	47	Worcestershire West	Harriett Baldwin	76241	75.5	38.9	27.5	19.9	6.7	6	0	0	1	CON	CON
+522	46	Boston and Skegness	Matt Warman	69381	60.1	43.2	31.6	8.1	10.9	4.3	0	0	2	CON	CON
+523	45	Surrey South West	Jeremy Hunt	79096	76.3	36.6	24.9	27.1	5.7	5.1	0	0	0.6	CON	CON
+524	44	Arundel and South Downs	Andrew Griffith	81726	75.1	38.3	26.6	21.1	6.5	6.5	0	0	1	CON	CON
+524	43	Westmorland and Lonsdale	Tim Farron	67789	77.8	26.9	15.1	47.1	7	3.3	0	0	0.6	LIB	LIB
+525	43	Torbay	Kevin Foster	75054	67.2	35.2	23.4	28.8	7.2	4.5	0	0	0.9	CON	CON
+526	42	Cambridgeshire North East	Steve Barclay	83699	63.3	42.7	30.9	12.1	7.6	5.3	0	0	1.5	CON	CON
+527	41	Henley	John Howell	76646	76.7	35.8	23.9	26.7	6.1	6.6	0	0	0.8	CON	CON
+528	40	Dumfriesshire, Clydesdale and Tweeddale	David Mundell	68330	71.9	34.9	23.1	4.6	2	2.9	29.9	0	2.6	CON	CON
+528	39	St Ives	Derek Thomas	68795	74.7	29.5	17.6	41.3	6.6	4.3	0	0	0.7	CON	LIB
+529	39	Wealden	Nus Ghani	82992	73.4	38.7	26.7	20.1	6.8	6.7	0	0	1	CON	CON
+529	38	Cheltenham	Alex Chalk	81044	73.2	28.8	16.8	45.3	4.8	3.7	0	0	0.6	CON	LIB
+530	38	Surrey East	Claire Coutinho	83148	71.8	39.2	27.2	19	6.8	6.7	0	0	1.1	CON	CON
+531	37	Sevenoaks	Laura Trott	71757	71	39.5	27.2	18.9	6.8	6.6	0	0	1.1	CON	CON
+532	36	Worcestershire Mid	Nigel Huddleston	78220	71.8	41.9	29.5	14.7	7	5.7	0	0	1.3	CON	CON
+532	35	Aberdeenshire West and Kincardine	Andrew Bowie	72640	73.4	32	19.6	8.1	2.1	3	32.6	0	2.7	CON	NAT
+533	35	Brecon and Radnorshire	Fay Jones	55490	74.5	35.3	22.8	27.8	6.6	2.6	4.5	0	0.4	CON	CON
+533	34	Taunton Deane	Rebecca Pow	88676	71.9	33.2	20.5	35.3	6.4	3.7	0	0	0.9	CON	LIB
+534	34	Wiltshire North	James Gray	73280	74.7	36.9	23.9	26.8	6.1	5.4	0	0	0.9	CON	CON
+535	33	Herefordshire North	Bill Wiggin	70252	72.6	38.3	25.3	18.6	8.3	8.3	0	0	1.2	CON	CON
+536	32	South Holland and The Deepings	John Hayes	75975	64.7	43.4	30	9.3	10.1	5.3	0	0	1.9	CON	CON
+536	31	Eastbourne	Caroline Ansell	79307	69.5	30.8	17.4	41.3	6.4	3.5	0	0	0.6	CON	LIB
+537	31	New Forest East	Julian Lewis	73549	69.1	40.3	26.8	18	7.4	6.3	0	0	1.2	CON	CON
+538	30	Surrey Heath	Michael Gove	81349	72.1	38.3	24.8	23.1	6.3	6.4	0	0	1	CON	CON
+539	29	Esher and Walton	Dominic Raab	81184	77.7	34.9	21.4	32.7	5.2	5.1	0	0	0.7	CON	CON
+540	28	Cotswolds, The	Geoffrey Clifton-Brown	81939	74.7	37.3	23.7	25.4	6.5	6.3	0	0	0.9	CON	CON
+541	27	Saffron Walden	Kemi Badenoch	87017	72.5	39.9	26.2	20.1	6.3	6.6	0	0	0.9	CON	CON
+542	26	Hampshire East	Damian Hinds	76478	74.4	38.3	24.5	23.6	6.4	6.2	0	0	1	CON	CON
+542	25	Winchester	Steve Brine	75582	77.9	31.9	17.8	40.8	4.6	4.3	0	0	0.6	CON	LIB
+543	25	Hampshire North East	Ranil Jayawardena	78954	75.1	39	24.9	23.5	5.9	5.6	0	0	1.1	CON	CON
+544	24	Newbury	Laura Farris	83414	71.9	36.1	22	29.3	6	5.7	0	0	0.9	CON	CON
+545	23	Dorset West	Chris Loder	81897	74.4	34.9	20.5	32.2	6.6	5	0	0	0.8	CON	CON
+546	22	Ludlow	Philip Dunne	69444	72.3	40.6	26.2	20	7.1	5.1	0	0	1	CON	CON
+546	21	Wells	James Heappey	84124	73.3	33.7	19.3	36.6	6.1	3.5	0	0	0.8	CON	LIB
+546	21	Lewes	Maria Caulfield	71503	76.7	29.9	15.3	44	5.8	4.5	0	0	0.5	CON	LIB
+546	21	Devon North	Selaine Saxby	75859	73.3	33.3	18.7	35.1	7.2	4.9	0	0	0.7	CON	LIB
+547	21	Stratford-on-Avon	Nadhim Zahawi	74037	74.4	39.4	24.7	22.8	6.5	5.7	0	0	0.9	CON	CON
+548	20	Shropshire North	Owen Paterson	83258	67.9	36.2	21.1	29.9	6.3	4.4	0	0	2.1	CON	CON
+549	19	Old Bexley and Sidcup	James Brokenshire	66104	69.8	47.3	32.2	6.1	7.4	4.6	0	0	2.4	CON	CON
+550	18	Yeovil	Marcus Fysh	82468	71.9	34.6	19.4	33.8	6.9	4.4	0	0	0.8	CON	CON
+551	17	Staffordshire South	Gavin Williamson	73668	67.9	45.6	30.4	10.6	7	5	0	0	1.4	CON	CON
+551	16	Moray	Douglas Ross	71035	68.7	34.3	19	3	2	2.8	35.8	0	3.1	CON	NAT
+552	16	Clacton	Giles Watling	70930	61.3	44.2	28.8	10.7	9.2	5.7	0	0	1.5	CON	CON
+553	15	Rayleigh and Wickford	Mark Francois	78930	69.6	45.1	29.4	11	7.2	6.1	0	0	1.2	CON	CON
+554	14	New Forest West	Desmond Swayne	70866	71	40.9	25.2	17.6	7.7	7.4	0	0	1.1	CON	CON
+555	13	Castle Point	Rebecca Harris	69608	63.6	46.8	30.9	8.9	7.8	4.5	0	0	1.1	CON	CON
+556	12	Dorset North	Simon Hoare	76765	73.1	39.9	23.5	23	7.1	5.5	0	0	1	CON	CON
+556	11	Thornbury and Yate	Luke Hall	69492	75.2	35	18.5	36.8	5.6	3.5	0	0	0.6	CON	LIB
+557	11	Meon Valley	Flick Drummond	75737	72.4	40.8	23.7	22.5	6.4	5.6	0	0	1	CON	CON
+558	10	Berwickshire, Roxburgh and Selkirk	John Lamont	74518	71.3	37.2	19.6	5.2	2	3	30.3	0	2.7	CON	CON
+559	9	Cornwall North	Scott Mann	69935	73.9	36.2	18.4	34.4	6.9	3.3	0	0	0.7	CON	CON
+560	8	Brentwood and Ongar	Alex Burghart	75255	70.4	44.6	26.4	15	6.7	6.1	0	0	1.1	CON	CON
+561	7	Maldon	John Whittingdale	72438	69.6	45.5	26.9	13.9	6.9	5.7	0	0	1.2	CON	CON
+562	6	Mole Valley	Paul Beresford	74665	76.5	37.5	18.9	30.7	6.1	6	0	0	0.8	CON	CON
+563	5	Dorset Mid and Poole North	Michael Tomlinson	65427	74.8	38.1	18.5	31.9	6.2	4.5	0	0	0.7	CON	CON
+564	4	Christchurch	Christopher Chope	71520	72.6	43.5	23.4	19.2	7.1	5.8	0	0	1	CON	CON
+565	3	Banff and Buchan	David Duguid	66655	63.4	38.6	18.5	3.5	1.9	2.9	31.9	0	2.6	CON	CON
+566	2	Beaconsfield	Joy Morrissey	77720	74.5	41.2	20.7	25.8	6.1	4.4	0	0	1.8	CON	CON
+566	1	Somerton and Frome	David Warburton	85866	75.6	32.1	11.4	41.7	6.3	6.9	0	0	1.7	CON	LIB
+566	1	Norfolk North	Duncan Baker	70729	71.9	35.5	14.7	38.2	7.8	3.2	0	0	0.6	CON	LIB
+567	1	Tiverton and Honiton	Neil Parish	82953	71.9	39	15.7	35.3	5	3.9	0	0	1.2	CON	CON
+567	0	Chesham and Amersham	Cheryl Gillan	72542	76.8	37.8	12	39.4	4.5	5.4	0	0	0.9	CON	LIB

--- a/db/fixtures/electoral_calculus_constituencies_tsv.rb
+++ b/db/fixtures/electoral_calculus_constituencies_tsv.rb
@@ -22,10 +22,9 @@ class ElectoralCalculusConstituenciesTsv
       "green"  => Party.find_by(name: "Green Party"),
       "lab"    => Party.find_by(name: "Labour"),
       "libdem" => Party.find_by(name: "Liberal Democrats"),
-      "ukip"   => Party.find_by(name: "UKIP"),
       "snp"    => Party.find_by(name: "SNP"),
       "plaid"  => Party.find_by(name: "Plaid Cymru"),
-      "brexit" => Party.find_by(name: "Brexit Party")
+      "reform" => Party.find_by(name: "Reform Party")
     }
 
     missing_parties = @parties_by_party_code.select{ |_key, value| value.nil? }
@@ -36,8 +35,8 @@ class ElectoralCalculusConstituenciesTsv
   # rubocop:disable Metrics/MethodLength
   def each
     CSV.foreach(TSV_FILE_NAME, headers: false, col_sep: "\t") do |data|
-      unless data.length == 17
-        raise ArgumentError, "Input fields #{data.to_h.keys} do not have expected length 17"
+      unless data.length == 16
+        raise ArgumentError, "Input fields #{data} do not have expected length 16"
       end
 
       constituency_name = data[2]
@@ -51,9 +50,8 @@ class ElectoralCalculusConstituenciesTsv
         "con" => { percent: data[6] },
         "lab" => { percent: data[7] },
         "libdem" => { percent: data[8] },
-        "brexit" => { percent: data[9] },
-        "green" => { percent: data[10] },
-        "ukip" => { percent: data[12] }
+        "reform" => { percent: data[9] },
+        "green" => { percent: data[10] }
       }
 
       if country == "S"

--- a/db/seeds_for_general_election.rb
+++ b/db/seeds_for_general_election.rb
@@ -15,10 +15,9 @@ Party.find_or_create_by(name: "Conservatives", color: "#0087DC")
 Party.find_or_create_by(name: "Green Party", color: "#6AB023")
 Party.find_or_create_by(name: "Labour", color: "#DC241f")
 Party.find_or_create_by(name: "Liberal Democrats", color: "#FFB602")
-Party.find_or_create_by(name: "UKIP", color: "#70147A")
 Party.find_or_create_by(name: "SNP", color: "#FFF95D")
 Party.find_or_create_by(name: "Plaid Cymru", color: "#008142")
-Party.find_or_create_by(name: "Brexit Party", color: "#5bc0de")
+Party.find_or_create_by(name: "Reform Party", color: "#5bc0de")
 
 # ---------------------------------------------------------------------------------
 


### PR DESCRIPTION
Addresses #720 - and brings electoral calculus data up to date.

It looks like they haven't yet taken account of new constituencies boundaries.

To see the update you will need to run

    bundle exec rake db:schema:load
    ELECTION_TYPE=g bundle exec rake db:seed

THIS WILL DESTROY YOUR CURRENT DEV DATABASE ! !

