### PR TITLE
issue 722 party names inconsistent

### DIFF
--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -5,7 +5,7 @@ class Party < ApplicationRecord
     lab: { name: "Labour", color: "#DC241f" },
     libdem: { name: "Liberal Democrats", color: "#FFB602" },
     green: { name: "Green", color: "#6AB023" },
-    con: { name: "Conservative", color: "#0087DC" },
+    con: { name: "Conservatives", color: "#0087DC" },
     ukip: { name: "UKIP", color: "#70147A" },
     snp: { name: "SNP", color: "#FFF95D" },
     plaid: { name: "Plaid Cymru", color: "#008142" },

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -14,7 +14,7 @@ class Party < ApplicationRecord
     for_britain: { name: "For Britain" },
     freedom_alliance: { name: "Freedom Alliance" },
     independent: { name: "Independent" },
-    reform_uk: { name: "Reform uk" },
+    reform: { name: "Reform" },
     rejoin_eu: { name: "Rejoin eu" },
     workers: { name: "Workers" },
     yorkshire: { name: "Yorkshire" },

--- a/app/views/static_pages/api.html.haml
+++ b/app/views/static_pages/api.html.haml
@@ -117,7 +117,7 @@
       %li
         %code conservatives
       %li
-        %code reform_uk
+        %code reform
       %li
         %code ukip
 

--- a/app/views/static_pages/api.html.haml
+++ b/app/views/static_pages/api.html.haml
@@ -115,7 +115,7 @@
       %li
         %code green
       %li
-        %code conservative
+        %code conservatives
       %li
         %code reform_uk
       %li

--- a/db/fixtures/electoral_calculus_constituencies_tsv.rb
+++ b/db/fixtures/electoral_calculus_constituencies_tsv.rb
@@ -19,7 +19,7 @@ class ElectoralCalculusConstituenciesTsv
   def initialize
     @parties_by_party_code = {
       "con"    => Party.find_by(name: "Conservatives"),
-      "green"  => Party.find_by(name: "Green Party"),
+      "green"  => Party.find_by(name: "Green"),
       "lab"    => Party.find_by(name: "Labour"),
       "libdem" => Party.find_by(name: "Liberal Democrats"),
       "snp"    => Party.find_by(name: "SNP"),

--- a/db/fixtures/electoral_calculus_constituencies_tsv.rb
+++ b/db/fixtures/electoral_calculus_constituencies_tsv.rb
@@ -24,7 +24,7 @@ class ElectoralCalculusConstituenciesTsv
       "libdem" => Party.find_by(name: "Liberal Democrats"),
       "snp"    => Party.find_by(name: "SNP"),
       "plaid"  => Party.find_by(name: "Plaid Cymru"),
-      "reform" => Party.find_by(name: "Reform Party")
+      "reform" => Party.find_by(name: "Reform")
     }
 
     missing_parties = @parties_by_party_code.select{ |_key, value| value.nil? }

--- a/db/seeds_for_general_election.rb
+++ b/db/seeds_for_general_election.rb
@@ -12,7 +12,7 @@ require_relative "fixtures/ons_constituencies_csv"
 require_relative "fixtures/electoral_calculus_constituencies_tsv"
 
 Party.find_or_create_by(name: "Conservatives", color: "#0087DC")
-Party.find_or_create_by(name: "Green Party", color: "#6AB023")
+Party.find_or_create_by(name: "Green", color: "#6AB023")
 Party.find_or_create_by(name: "Labour", color: "#DC241f")
 Party.find_or_create_by(name: "Liberal Democrats", color: "#FFB602")
 Party.find_or_create_by(name: "SNP", color: "#FFF95D")

--- a/db/seeds_for_general_election.rb
+++ b/db/seeds_for_general_election.rb
@@ -17,7 +17,7 @@ Party.find_or_create_by(name: "Labour", color: "#DC241f")
 Party.find_or_create_by(name: "Liberal Democrats", color: "#FFB602")
 Party.find_or_create_by(name: "SNP", color: "#FFF95D")
 Party.find_or_create_by(name: "Plaid Cymru", color: "#008142")
-Party.find_or_create_by(name: "Reform Party", color: "#5bc0de")
+Party.find_or_create_by(name: "Reform", color: "#5bc0de")
 
 # ---------------------------------------------------------------------------------
 

--- a/spec/models/party_spec.rb
+++ b/spec/models/party_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Party, type: :model do
        liberal_democrats
        green
        conservatives
-       reform_uk
+       reform
        ukip
     ].each do |canonical_name|
       it "includes #{canonical_name.inspect} mentioned in api docs" do

--- a/spec/models/party_spec.rb
+++ b/spec/models/party_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Party, type: :model do
        labour
        liberal_democrats
        green
-       conservative
+       conservatives
        reform_uk
        ukip
     ].each do |canonical_name|
@@ -41,7 +41,7 @@ RSpec.describe Party, type: :model do
 
   describe ".names" do
     [
-      "Conservative",
+      "Conservatives",
       "Green",
       "Labour",
       "Liberal Democrats",

--- a/spec/views/static_pages/__snapshots__/api_by_election.snap
+++ b/spec/views/static_pages/__snapshots__/api_by_election.snap
@@ -98,7 +98,7 @@ of spaces; here are the available options:
 <code>conservatives</code>
 </li>
 <li>
-<code>reform_uk</code>
+<code>reform</code>
 </li>
 <li>
 <code>ukip</code>

--- a/spec/views/static_pages/__snapshots__/api_by_election.snap
+++ b/spec/views/static_pages/__snapshots__/api_by_election.snap
@@ -95,7 +95,7 @@ of spaces; here are the available options:
 <code>green</code>
 </li>
 <li>
-<code>conservative</code>
+<code>conservatives</code>
 </li>
 <li>
 <code>reform_uk</code>

--- a/spec/views/static_pages/__snapshots__/api_general.snap
+++ b/spec/views/static_pages/__snapshots__/api_general.snap
@@ -98,7 +98,7 @@ of spaces; here are the available options:
 <code>conservatives</code>
 </li>
 <li>
-<code>reform_uk</code>
+<code>reform</code>
 </li>
 <li>
 <code>ukip</code>

--- a/spec/views/static_pages/__snapshots__/api_general.snap
+++ b/spec/views/static_pages/__snapshots__/api_general.snap
@@ -95,7 +95,7 @@ of spaces; here are the available options:
 <code>green</code>
 </li>
 <li>
-<code>conservative</code>
+<code>conservatives</code>
 </li>
 <li>
 <code>reform_uk</code>


### PR DESCRIPTION
Use party names consistently.

I think in the case of the newly added reform party there was a risk of two parties being created, depending on which scripts were run.

- consistently use conservatives rather than a mix of plural and singular
- consistently use green rather than green party
- consistently use reform rather than reform party or reform uk

Closes #722

To see the update you will need to run

    bundle exec rake db:schema:load
    ELECTION_TYPE=g bundle exec rake db:seed

THIS WILL DESTROY YOUR CURRENT DEV DATABASE !

Not ideal maybe, but we're at a stage in the election cycle where I don't think this matters much.
