### PR TITLE
fix for missing poll data 

### DIFF
--- a/app/views/user/swaps/_swap_profile.html.haml
+++ b/app/views/user/swaps/_swap_profile.html.haml
@@ -5,6 +5,8 @@
   .profile
     = render partial: "user/swaps/swap_profile_inner", locals: { other_user: other_user }
 
-- if !hide_polls? && !other_user.constituency.nil?
+- poll_data = poll_data_for(other_user.constituency)
+
+- if !hide_polls? && !other_user.constituency.nil? && poll_data != "" and poll_data != "[]"
   :javascript
-    drawPollChart("poll_#{other_user.id}", #{poll_data_for(other_user.constituency)});
+    drawPollChart("poll_#{other_user.id}", #{poll_data});


### PR DESCRIPTION
This fixes #724, the issue of missing poll data creating an error visible to users

No explanation is given. It could be
- we have hit on an NI constituency which we know has no poll data from electoral calculus
- we have hit on a new constituency, which has no poll data from electoral calculus
- we haven't yet fixed the code for matching poll data to new constituencies

I think it's important to merge the fix, the explanations can came later after we fix the code to accommodate boundary changes and everything else needed for the next general election. Depending on the fixes, we may never need the explanation.
