### PR TITLE
update the postcodes.io lookup to ge2024 boundaries

### DIFF
--- a/app/javascript/packs/postcodesHelper.js
+++ b/app/javascript/packs/postcodesHelper.js
@@ -30,8 +30,8 @@ $(document).ready(() => {
   };
 
   const handlePostcodeLookup = postcode => {
-    const onsId = postcode.result.codes.parliamentary_constituency;
-    const name = postcode.result.parliamentary_constituency;
+    const onsId = postcode.result.codes.parliamentary_constituency_2024;
+    const name = postcode.result.parliamentary_constituency_2024;
 
     const hasOption = $('select#user_constituency_ons_id option[value="' + onsId + '"]');
     if (hasOption.length == 0) {


### PR DESCRIPTION
Unexpectedly, postcode.io have updated despite there being no canonical source for the new constituency ids.
