### PR TITLE
ec update ge2024

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -241,8 +241,7 @@ module ApplicationHelper
   end
 
   def hide_polls?
-    return true # emergency fix for boundary changes - no ONS ids means no immediate tie-in to polling data
-    # return @hide_polls if defined?(@hide_polls)
-    # @hide_polls = OnsConstituency.count == 2
+    return @hide_polls if defined?(@hide_polls)
+    @hide_polls = OnsConstituency.count == 2
   end
 end

--- a/db/fixtures/electoral_calculus_constituencies.tsv
+++ b/db/fixtures/electoral_calculus_constituencies.tsv
@@ -1,632 +1,632 @@
-1	567	Liverpool Walton	Dan Carden	62628	65.1	6.6	82	2.3	3.5	4	0	0	1.6	LAB	LAB
-2	566	Birmingham Ladywood	Shabana Mahmood	74912	56.2	7.2	81.7	1	2.9	6.8	0	0	0.4	LAB	LAB
-3	565	Manchester Gorton	Afzal Khan	76419	58.3	6.5	79.5	1.1	3.9	8.6	0	0	0.5	LAB	LAB
-4	564	Liverpool Riverside	Kim Johnson	80310	65.7	6.4	77.7	3.2	3.5	7.9	0	0	1.3	LAB	LAB
-5	563	Bradford West	Naz Shah	70694	62.6	8.5	79.5	0.4	5.1	6.3	0	0	0.3	LAB	LAB
-6	562	Birmingham Hodge Hill	Liam Byrne	78295	57.5	8.9	79.9	0.8	4	6.1	0	0	0.3	LAB	LAB
-7	561	Liverpool West Derby	Ian Byrne	65640	67	7.7	78.7	2.8	4.8	4.1	0	0	1.8	LAB	LAB
-8	560	Knowsley	George Howarth	84082	65.3	7.4	78.3	3.1	4.7	4.6	0	0	1.9	LAB	LAB
-9	559	Bootle	Peter Dowd	74832	65.7	7.6	77.7	3.7	4.6	4.7	0	0	1.7	LAB	LAB
-10	558	East Ham	Stephen Timms	88319	61.9	9.3	79.3	0.7	3.7	6.6	0	0	0.4	LAB	LAB
-11	557	Bethnal Green and Bow	Rushanara Ali	88262	68.6	7.5	76	0.8	3.7	11.8	0	0	0.2	LAB	LAB
-12	556	Tottenham	David Lammy	75740	61.9	8.6	76.2	2.5	3.7	8.3	0	0	0.8	LAB	LAB
-13	555	Manchester Central	Lucy Powell	92247	56.7	8.4	75.2	2.7	4.3	8.3	0	0	1.1	LAB	LAB
-14	554	Walthamstow	Stella Creasy	70267	68.8	9.4	75.9	1.9	3.8	8.4	0	0	0.6	LAB	LAB
-15	553	Liverpool Wavertree	Paula Barker	63458	68.4	8.4	74.9	5.2	4.1	6.1	0	0	1.3	LAB	LAB
-16	552	West Ham	Lyn Brown	97947	61.5	10.2	75.8	1.4	4.2	7.8	0	0	0.6	LAB	LAB
-17	551	Birmingham Hall Green	Tahir Ali	80283	65.9	10.7	75.6	1.1	4.7	7.6	0	0	0.3	LAB	LAB
-18	550	Hackney South and Shoreditch	Meg Hillier	89387	60.9	8.3	73.1	3.2	3.6	11.1	0	0	0.7	LAB	LAB
-19	549	Lewisham Deptford	Vicky Foxcroft	80631	68.7	8.6	71.4	5	3.7	10.4	0	0	0.9	LAB	LAB
-20	548	Camberwell and Peckham	Harriet Harman	88971	63.5	9	71.7	4.3	3.9	10.3	0	0	0.8	LAB	LAB
-21	547	Nottingham East	Nadia Whittome	66262	60.4	10.6	73.2	2.7	4.8	7.5	0	0	1.3	LAB	LAB
-22	546	Poplar and Limehouse	Apsana Begum	91836	66.7	10.4	72.7	1.9	3.9	10.8	0	0	0.3	LAB	LAB
-23	545	Manchester Withington	Jeff Smith	76530	69.2	8.5	70.7	6.5	3.8	9.9	0	0	0.7	LAB	LAB
-24	544	Leeds Central	Hilary Benn	90971	54.2	10.6	71.9	2.8	5.2	8.1	0	0	1.3	LAB	LAB
-25	543	Ilford South	Sam Tarry	84972	62.9	12.8	74.1	0.6	4.7	7.4	0	0	0.5	LAB	LAB
-26	542	Hackney North and Stoke Newington	Diane Abbott	92462	61.5	8.5	69.5	3.5	3.5	14.2	0	0	0.8	LAB	LAB
-27	541	Sheffield Central	Paul Blomfield	89849	56.7	7.8	68.9	4.2	3.9	14	0	0	1.1	LAB	LAB
-28	540	Garston and Halewood	Maria Eagle	76116	70.1	10.3	71.2	5.8	5.5	5.7	0	0	1.6	LAB	LAB
-29	539	Leicester South	Jonathan Ashworth	77708	64.5	11.5	72.3	2.8	4.6	7.9	0	0	0.9	LAB	LAB
-30	538	Chorley	Lindsay Hoyle	78177	51	8.8	69	4.4	6.5	7.7	0	0	3.6	LAB	LAB
-31	537	Birkenhead	Mick Whitley	63762	66.4	10.3	69.8	4.4	6.7	5.3	0	0	3.4	LAB	LAB
-32	536	Islington North	Jeremy Corbyn	75162	71.6	8.4	67.3	5.9	3.7	14	0	0	0.7	LAB	LAB
-33	535	Blackley and Broughton	Graham Stringer	73372	52.6	12.5	71.1	2.3	6.3	6.6	0	0	1.2	LAB	LAB
-34	534	Blackburn	Kate Hollern	71234	62.8	14	71.8	1.8	6	5.5	0	0	0.9	LAB	LAB
-35	533	Croydon North	Steve Reed	88468	62.9	13.5	71.1	3.5	4.2	6.8	0	0	0.9	LAB	LAB
-36	532	Bradford East	Imran Hussain	73206	60.4	12.6	69.4	4.4	6.7	6.2	0	0	0.6	LAB	LAB
-37	531	Leyton and Wanstead	John Cryer	64852	68.7	12.7	69.4	3.2	4.5	9.6	0	0	0.6	LAB	LAB
-38	530	Holborn and St Pancras	Keir Starmer	86061	66	10.9	66.9	4.2	3.8	13.6	0	0	0.6	LAB	LAB
-39	529	Brent Central	Dawn Butler	84032	58.5	14	69.9	2.8	4.2	8.5	0	0	0.5	LAB	LAB
-40	528	Birmingham Perry Barr	Khalid Mahmood	72006	58.5	15	70.7	2.6	4.7	6.2	0	0	0.8	LAB	LAB
-41	527	Edmonton	Kate Osamor	65747	61.4	15.6	71	1.9	4.4	6.5	0	0	0.6	LAB	LAB
-42	526	Wallasey	Angela Eagle	66310	70.1	13.9	68.9	4.5	5.7	5	0	0	1.9	LAB	LAB
-43	525	Newcastle upon Tyne East	Nick Brown	63796	68	12.1	67	6.6	4.1	8.9	0	0	1.2	LAB	LAB
-44	524	Preston	Mark Hendrick	59672	56.6	14.1	68.9	4.2	5.6	5.9	0	0	1.3	LAB	LAB
-45	523	Halton	Derek Twigg	71930	64.2	13.8	68.1	4.6	6.5	5	0	0	2.1	LAB	LAB
-46	522	Barking	Margaret Hodge	77953	57.1	15.3	69	1.4	6.2	7.5	0	0	0.7	LAB	LAB
-47	521	Ealing Southall	Virendra Sharma	64581	65.4	14.3	67.8	3.9	4.6	8.6	0	0	0.8	LAB	LAB
-48	520	Sheffield Brightside and Hillsborough	Gill Furniss	69333	57.1	13	66.4	3.6	8.5	7	0	0	1.5	LAB	LAB
-49	519	Newcastle upon Tyne Central	Chi Onwurah	57845	64.8	13.5	66.8	4.3	6.6	7.6	0	0	1.1	LAB	LAB
-50	518	Vauxhall	Florence Eshalomi	88659	63.5	11.7	64.9	8.9	3.6	10.2	0	0	0.8	LAB	LAB
-51	517	Edinburgh South	Ian Murray	66188	75.1	8.3	60.8	4.9	2.2	4.5	17	0	2.3	LAB	LAB
-52	516	Dulwich and West Norwood	Helen Hayes	80331	69.4	11	63.2	4.6	3.9	16.3	0	0	1	LAB	LAB
-53	515	Mitcham and Morden	Siobhain McDonagh	70021	65.3	15.8	67.9	3.7	4.7	7	0	0	1	LAB	LAB
-54	514	Cardiff Central	Jo Stevens	64037	65.3	14.6	66.7	6.2	3.5	5.4	3.2	0	0.4	LAB	LAB
-55	513	Nottingham South	Lilian Greenwood	79485	60.6	15	66.7	4.2	4.6	8.1	0	0	1.3	LAB	LAB
-56	512	Salford and Eccles	Rebecca Long-Bailey	82202	61.6	13.9	65.2	4.8	6.7	7.9	0	0	1.6	LAB	LAB
-57	511	Leeds North East	Fabian Hamilton	70580	71.6	15.1	66.4	4.4	5.6	7.7	0	0	1	LAB	LAB
-58	510	Streatham	Bell Ribeiro-Addy	84783	66.7	11.8	63	10.2	3.8	10.4	0	0	0.8	LAB	LAB
-59	509	St Helens South and Whiston	Marie Rimmer	79061	63.6	13.3	64.4	6.3	7.5	6.4	0	0	2.1	LAB	LAB
-60	508	Lewisham West and Penge	Ellie Reeves	74617	69.8	13.4	64.2	7.8	4.7	9	0	0	1	LAB	LAB
-61	507	Lewisham East	Janet Daby	67857	66	14.4	65	6.7	4.8	8	0	0	1.1	LAB	LAB
-62	506	Leeds West	Rachel Reeves	67727	59.5	14.1	64.5	4.4	7.5	7.6	0	0	1.9	LAB	LAB
-63	505	Middlesbrough	Andy McDonald	60764	56.1	15.3	65.6	2.9	8.6	5.4	0	0	2.2	LAB	LAB
-64	504	Greenwich and Woolwich	Matthew Pennycook	79997	66.4	14	64.3	6.7	4.6	9.4	0	0	1	LAB	LAB
-65	503	Islington South and Finsbury	Emily Thornberry	70489	67.8	12.1	62.3	8.5	4.1	12.4	0	0	0.7	LAB	LAB
-66	502	Hammersmith	Andy Slaughter	74759	69.5	15.5	65	5.3	4	9.3	0	0	0.8	LAB	LAB
-67	501	Stretford and Urmston	Kate Green	72372	69.2	17.1	66.6	3.7	5.6	5	0	0	1.9	LAB	LAB
-68	500	Oxford East	Anneliese Dodds	78303	63	13.1	62.4	8.6	4.1	10.9	0	0	0.9	LAB	LAB
-69	499	Slough	Tan Dhesi	86818	58.8	17.9	67	2	5.2	7.2	0	0	0.6	LAB	LAB
-70	498	Oldham West and Royton	Jim McMahon	72999	60.9	16.6	65.5	2.7	7.9	6.1	0	0	1.2	LAB	LAB
-71	497	Leicester East	Claudia Webbe	78433	63	17.7	66.5	1.6	6.5	6.7	0	0	1	LAB	LAB
-72	496	Glasgow North East	Anne McLaughlin	61075	55.5	2.5	50.9	2.1	1.7	2.3	38.5	0	2.1	NAT	LAB
-73	495	Birmingham Selly Oak	Steve McCabe	82665	59.8	17.1	65	4.5	4.7	7.6	0	0	1	LAB	LAB
-74	494	Warley	John Spellar	62357	59.7	16.9	64.7	4.5	5.8	7.1	0	0	1.1	LAB	LAB
-75	493	Bristol West	Thangam Debbonaire	99253	76.1	7.1	54.8	5.3	3.2	28.8	0	0	0.9	LAB	LAB
-76	492	Hornsey and Wood Green	Catherine West	81814	74.7	10.5	57.8	17.3	3.7	10.2	0	0	0.6	LAB	LAB
-77	491	Luton North	Sarah Owen	68185	62.5	19.2	66.4	1.7	5.6	6.4	0	0	0.7	LAB	LAB
-78	490	Ealing North	James Murray	74473	66.6	18.7	65.7	2.9	4.7	7.4	0	0	0.7	LAB	LAB
-79	489	Hayes and Harlington	John McDonnell	72357	60.8	19.1	66.1	2.1	5.3	6.5	0	0	0.9	LAB	LAB
-80	488	York Central	Rachael Maskell	74899	66.1	15.5	62.2	7.9	5	7.8	0	0	1.7	LAB	LAB
-81	487	Gateshead	Ian Mearns	64449	59.2	16.5	63.2	6	6.3	6.5	0	0	1.5	LAB	LAB
-82	486	Leicester West	Liz Kendall	64940	53.5	17.2	63.8	3.5	6.9	7.2	0	0	1.5	LAB	LAB
-83	485	Hull North	Diana Johnson	65515	52.2	14.8	61.2	6.8	8.2	6.9	0	0	2.2	LAB	LAB
-84	484	Bermondsey and Old Southwark	Neil Coyle	93248	62.9	12.4	58.8	16	4	8.3	0	0	0.6	LAB	LAB
-85	483	Birmingham Yardley	Jess Phillips	74704	57.1	17.8	64.1	4	6.3	7.2	0	0	0.5	LAB	LAB
-86	482	Aberavon	Stephen Kinnock	50750	62.3	14	60.1	3.1	6.9	3.3	11.5	0	1	LAB	LAB
-87	481	Rhondda	Chris Bryant	50262	59	10.3	56	1.8	6.3	2	22.3	0	1.3	LAB	LAB
-88	480	Bolton South East	Yasmin Qureshi	69163	58.7	17.8	63.5	3	8	6.5	0	0	1.2	LAB	LAB
-89	479	Wythenshawe and Sale East	Mike Kane	76313	58.7	16.9	62.3	5.3	7.1	6.8	0	0	1.6	LAB	LAB
-90	478	Luton South	Rachel Hopkins	69338	60.7	19.1	64.5	2.4	6.3	6.4	0	0	1.4	LAB	LAB
-91	477	Westminster North	Karen Buck	65519	65.5	18.3	63.7	3.6	4.3	9.6	0	0	0.6	LAB	LAB
-92	476	Nottingham North	Alex Norris	66495	53.1	17.4	62.5	4.3	7.9	6.1	0	0	1.9	LAB	LAB
-93	475	Merthyr Tydfil and Rhymney	Gerald Jones	56322	57.3	14	59	3.9	7.5	3.2	11.3	0	1.1	LAB	LAB
-94	474	Blaenau Gwent	Nick Smith	50739	59.6	13.3	58.1	3	9.8	3.2	11.3	0	1.2	LAB	LAB
-95	473	Derby South	Margaret Beckett	73062	58.1	18.6	63.3	4.2	7.2	5.4	0	0	1.4	LAB	LAB
-96	472	South Shields	Emma Lewell-Buck	62793	60.3	14.2	58.7	5	12.3	7	0	0	2.8	LAB	LAB
-97	471	Tooting	Rosena Allin-Khan	76954	76	17.7	62	6.5	3.9	9.1	0	0	0.8	LAB	LAB
-98	470	Glasgow South West	Chris Stephens	64575	57.1	3.5	47.7	2.5	1.8	2.6	39.4	0	2.4	NAT	LAB
-99	469	Huddersfield	Barry Sheerman	65525	63.9	18.1	62.2	3.8	7.3	7.5	0	0	1.2	LAB	LAB
-100	468	Coventry North East	Colleen Fletcher	76006	58.5	19.3	63.3	4.4	5.6	6.1	0	0	1.3	LAB	LAB
-101	467	Norwich South	Clive Lewis	77845	66.4	14.9	58.8	9.6	5	10.3	0	0	1.4	LAB	LAB
-102	466	Easington	Grahame Morris	61182	56.5	16.2	59.9	5.7	10.7	4.6	0	0	2.9	LAB	LAB
-103	465	St Helens North	Conor McGinn	75593	62.9	16.5	60	6.7	8.4	6.3	0	0	2.2	LAB	LAB
-104	464	Tyneside North	Mary Glindon	78902	63.9	17	60.2	6.5	8.4	5.9	0	0	2.1	LAB	LAB
-105	463	Rochdale	Tony Lloyd	78909	60.1	17.8	60.7	5.4	8.4	6.8	0	0	0.9	LAB	LAB
-106	462	Feltham and Heston	Seema Malhotra	80934	59.1	20.1	62.9	3.2	5.7	7.2	0	0	0.9	LAB	LAB
-107	461	Swansea East	Carolyn Harris	58450	57.4	17.1	59.9	3.5	6.2	3.6	8.7	0	0.9	LAB	LAB
-108	460	Cynon Valley	Beth Winter	51134	59.1	14.3	57.1	2.7	6.9	2.3	15.4	0	1.3	LAB	LAB
-109	459	Cardiff South and Penarth	Stephen Doughty	78837	64.2	18.9	61.6	3.6	5.3	4.9	5.3	0	0.6	LAB	LAB
-110	458	Sheffield Heeley	Louise Haigh	66940	63.8	16.4	59	6.8	8.7	7.6	0	0	1.6	LAB	LAB
-111	457	Coatbridge, Chryston and Bellshill	Steven Bonnar	72943	66.1	4.7	47.1	2.1	1.9	3.5	38.6	0	2.1	NAT	LAB
-112	456	Sefton Central	Bill Esterson	69760	72.9	18.8	61.1	7	6.1	5.4	0	0	1.7	LAB	LAB
-113	455	Brent North	Barry Gardiner	83788	61.9	21.1	63.3	3.2	4.7	6.7	0	0	0.9	LAB	LAB
-114	454	Glasgow Central	Alison Thewliss	69230	57.9	2.4	44.7	3.1	2.1	4.8	40.8	0	2	NAT	LAB
-115	453	Bristol East	Kerry McCarthy	73867	70.6	18.3	60.5	6.3	5.8	7.9	0	0	1.2	LAB	LAB
-116	452	Leeds East	Richard Burgon	67286	58	18.8	60.9	4.6	8.1	6	0	0	1.6	LAB	LAB
-117	451	Ealing Central and Acton	Rupa Huq	75510	72.6	18.3	60.4	7.5	4.3	8.9	0	0	0.7	LAB	LAB
-118	450	Jarrow	Kate Osborne	65103	62.6	16.9	58.8	6.2	9.7	5.5	0	0	2.9	LAB	LAB
-119	449	Stockport	Navendu Mishra	65391	63.8	16.9	58.8	9.2	6.6	7.1	0	0	1.3	LAB	LAB
-120	448	Denton and Reddish	Andrew Gwynne	66234	58.3	18.3	59.9	5.1	8.2	6.5	0	0	2	LAB	LAB
-121	447	Glasgow North	Patrick Grady	57130	63.3	3	44.5	4.2	2.3	5.2	38.5	0	2.3	NAT	LAB
-122	446	Birmingham Edgbaston	Preet Gill	68828	61.5	20.9	62.2	4.6	4.8	6.5	0	0	1	LAB	LAB
-123	445	Harrow West	Gareth Thomas	72464	66.1	21	62	4.3	4.7	7.1	0	0	0.9	LAB	LAB
-124	444	Hove	Peter Kyle	74313	75.9	15.8	56.8	6.5	6.1	13.3	0	0	1.5	LAB	LAB
-125	443	Hampstead and Kilburn	Tulip Siddiq	86571	66.3	17.4	58.2	9.3	4.2	10.3	0	0	0.7	LAB	LAB
-126	442	Exeter	Ben Bradshaw	82054	68.5	19.1	59.4	5.3	5	9.6	0	0	1.7	LAB	LAB
-127	441	Cardiff West	Kevin Brennan	68508	67.4	18.8	58.9	3.5	5	4.2	8.9	0	0.7	LAB	LAB
-128	440	Rutherglen and Hamilton West	Margaret Ferrier	80918	66.5	6.7	46.8	3.3	1.9	2.4	35.8	0	3.1	NAT	LAB
-129	439	Cambridge	Daniel Zeichner	79951	67.2	11.3	51.2	21.9	3.7	11.2	0	0	0.7	LAB	LAB
-130	438	Ogmore	Chris Elmore	57581	61.5	17.3	57.2	3.5	6.4	3.4	11	0	1	LAB	LAB
-131	437	Southampton Test	Alan Whitehead	70116	64.2	19.7	59.5	7.4	5.4	6.7	0	0	1.4	LAB	LAB
-132	436	Swansea West	Geraint Davies	57078	62.8	19	58.8	5.1	4.8	3.9	7.7	0	0.6	LAB	LAB
-133	435	Ashton under Lyne	Angela Rayner	67978	56.8	19.5	59.2	4.2	8.6	6.8	0	0	1.7	LAB	LAB
-134	434	Bradford South	Judith Cummins	69046	57.6	20.2	59.9	3.4	8.7	6.4	0	0	1.4	LAB	LAB
-135	433	Bristol South	Karin Smyth	84079	65.6	17.5	57	8.5	6.1	9.5	0	0	1.4	LAB	LAB
-136	432	Ellesmere Port and Neston	Justin Madders	70327	69.3	21	60	5.8	6.4	5	0	0	1.8	LAB	LAB
-137	431	Glasgow East	David Linden	67381	57.1	6.5	45.2	2.7	1.8	2.4	39.3	0	2.1	NAT	LAB
-138	430	Walsall South	Valerie Vaz	68024	62.4	22.7	61.4	3	5.9	6.1	0	0	1	LAB	LAB
-139	429	Brentford and Isleworth	Ruth Cadbury	85775	68	20.8	59.5	6	5	8	0	0	0.8	LAB	LAB
-140	428	Washington and Sunderland West	Sharon Hodgson	66278	56.6	18.4	56.8	6.7	9.7	5.7	0	0	2.7	LAB	LAB
-141	427	Barnsley Central	Dan Jarvis	65277	56.5	15.5	54	6.3	14.1	7.1	0	0	3.1	LAB	LAB
-142	426	Rotherham	Sarah Champion	61688	57.8	18.7	56.8	5	11.8	6	0	0	1.8	LAB	LAB
-143	425	Stalybridge and Hyde	Jonathan Reynolds	73064	58	19.9	57.8	4.9	8.7	6.6	0	0	2	LAB	LAB
-144	424	Enfield North	Feryal Clark	68301	66	22.8	60.7	4.1	5.1	6.4	0	0	0.9	LAB	LAB
-145	423	Durham North	Kevan Jones	66796	63.2	18.9	56.7	7.7	8.8	5.5	0	0	2.4	LAB	LAB
-146	422	Wigan	Lisa Nandy	75680	59.5	19.2	56.6	6.7	9.2	6.1	0	0	2.2	LAB	LAB
-147	421	Sheffield South East	Clive Betts	67832	61.9	19.8	57.2	6.2	9.5	5.4	0	0	1.9	LAB	LAB
-148	420	Hull West and Hessle	Emma Hardy	60192	52.1	18.5	55.8	7.2	10.8	5.5	0	0	2.2	LAB	LAB
-149	419	Lancaster and Fleetwood	Cat Smith	70059	64.5	21.4	58.6	5.5	6.2	6.4	0	0	1.9	LAB	LAB
-150	418	Makerfield	Yvonne Fovargue	74190	59.7	20.1	57.1	5.8	9.5	5.3	0	0	2.2	LAB	LAB
-151	417	Plymouth Sutton and Devonport	Luke Pollard	77852	68.3	20.8	57.8	7.7	5.3	6.6	0	0	1.7	LAB	LAB
-152	416	Glasgow South	Stewart McDonald	70891	66.9	5.3	42.3	3.8	2.2	4.5	39.7	0	2.3	NAT	LAB
-153	415	Erith and Thamesmead	Abena Oppong-Asare	65399	63.3	22.4	59.2	4.8	6	6.3	0	0	1.4	LAB	LAB
-154	414	Sunderland Central	Julie Elliott	72680	59.8	20	56.7	6.5	8.6	5.9	0	0	2.2	LAB	LAB
-155	413	Brighton Kemptown	Lloyd Russell-Moyle	69833	69.5	19.3	55.9	6.9	6.3	10.1	0	0	1.5	LAB	LAB
-156	412	Motherwell and Wishaw	Marion Fellows	68856	64.5	7.8	44.4	2.4	1.9	2.4	38	0	3.2	NAT	LAB
-157	411	Worsley and Eccles South	Barbara Keeley	75219	59.4	20.8	57.3	5.9	7.9	6.1	0	0	1.9	LAB	LAB
-158	410	Durham, City of	Mary Foy	71271	68.6	17.9	54.4	12.4	6.5	7.1	0	0	1.6	LAB	LAB
-159	409	Halifax	Holly Lynch	71887	64.6	22.1	58.5	4.6	7.8	5.3	0	0	1.6	LAB	LAB
-160	408	Ilford North	Wes Streeting	72973	68.7	24.2	60.5	2.6	5.3	6.7	0	0	0.7	LAB	LAB
-161	407	Houghton and Sunderland South	Bridget Phillipson	68835	57.8	18.9	55.2	6.6	10.6	6.1	0	0	2.6	LAB	LAB
-162	406	Islwyn	Chris Evans	55423	62	18.2	54.3	3.6	8.3	3.7	10.9	0	1.1	LAB	LAB
-163	405	Hull East	Karl Turner	65745	49.3	18.3	54.4	7.4	10.9	6.4	0	0	2.6	LAB	LAB
-164	404	Leeds North West	Alex Sobel	67741	72.8	16.6	52.4	16.6	5.6	7.9	0	0	0.9	LAB	LAB
-165	403	Newcastle upon Tyne North	Catherine McKinnell	68486	68.6	19.5	55.2	8.5	8.3	6.8	0	0	1.6	LAB	LAB
-166	402	Wirral South	Alison McGovern	57280	76	22.3	57.9	7	6.1	5.2	0	0	1.6	LAB	LAB
-167	401	Kirkcaldy and Cowdenbeath	Neale Hanvey	72853	64.5	11.8	47.2	4	2.3	5.4	26.8	0	2.6	NAT	LAB
-168	400	Battersea	Marsha De Cordova	79350	75.6	21.6	57	8.2	4.1	8.3	0	0	0.8	LAB	LAB
-169	399	Tynemouth	Alan Campbell	77261	72.5	22.1	57.3	6.6	6.8	5.6	0	0	1.7	LAB	LAB
-170	398	Barnsley East	Stephanie Peacock	69504	54.8	17.5	52.6	6.4	14	6.6	0	0	2.8	LAB	LAB
-171	397	Lancashire West	Rosie Cooper	73347	71.8	24.5	59.6	4.9	6	3.8	0	0	1.3	LAB	LAB
-172	396	Wolverhampton South East	Pat McFadden	62883	53.2	22.7	57.6	6.1	6.4	5.4	0	0	1.9	LAB	LAB
-173	395	Croydon Central	Sarah Jones	81407	66.4	23.8	58.8	5	5.2	6.2	0	0	1.1	LAB	LAB
-174	394	Inverclyde	Ronnie Cowan	60622	65.8	7.3	42.1	4.1	1.8	2.5	39.9	0	2.2	NAT	LAB
-175	393	Chester, City of	Chris Matheson	76057	71.7	23.6	58.2	7.3	5	4.1	0	0	1.8	LAB	LAB
-176	392	Portsmouth South	Stephen Morgan	74186	63.9	20.9	55.3	11.7	4.7	6.4	0	0	1	LAB	LAB
-176	391	Dunbartonshire West	Martin Docherty	66517	67.9	6.3	40.6	2.7	2.1	3.8	41.2	0	3.3	NAT	NAT
-177	391	Blaydon	Liz Twist	67853	67.3	19	53.3	9.5	9.9	6.2	0	0	2.1	LAB	LAB
-177	390	Glasgow North West	Carol Monaghan	63402	62.7	6.8	41.1	4.4	1.8	2.5	41.1	0	2.3	NAT	NAT
-178	390	Normanton, Pontefract and Castleford	Yvette Cooper	84527	57.1	20.4	54.5	6.5	10.9	4.9	0	0	2.8	LAB	LAB
-178	389	Dundee West	Chris Law	64431	64.5	4.5	38.6	3.8	2	2.9	45.3	0	3	NAT	NAT
-179	389	Stockton North	Alex Cunningham	66649	61.8	22.4	56.5	5.4	9.1	4.3	0	0	2.4	LAB	LAB
-180	388	Doncaster North	Ed Miliband	72362	56.2	20.1	53.9	6	11.9	5.2	0	0	2.9	LAB	LAB
-181	387	Caerphilly	Wayne David	63166	63.5	17.2	51	2.3	7.4	2.6	18.3	0	1.2	LAB	LAB
-182	386	Doncaster Central	Rosie Winterton	71389	58.2	20.6	54.3	5.5	11.3	6	0	0	2.3	LAB	LAB
-183	385	Warrington North	Charlotte Nichols	72235	64.6	22.5	56	6.5	7.6	5.4	0	0	1.9	LAB	LAB
-183	384	Edinburgh East	Tommy Sheppard	69424	68.9	6	39.4	4.4	2.3	5.6	40	0	2.2	NAT	NAT
-184	384	Bolton North East	Mark Logan	67564	64.5	23.9	57.3	4.1	7.6	5.6	0	0	1.4	CON	LAB
-185	383	Hemsworth	Jon Trickett	73726	59.6	20.8	54.1	5.2	11.4	5.6	0	0	2.8	LAB	LAB
-186	382	Wentworth and Dearne	John Healey	74536	55.8	20.5	53.7	7.1	10.9	5.2	0	0	2.6	LAB	LAB
-187	381	Reading East	Matt Rodda	77152	72.5	23.1	56.3	7.7	4.8	7	0	0	1	LAB	LAB
-188	380	Neath	Christina Rees	56419	65.1	17.6	50.5	3.1	7.3	2.8	17.5	0	1.2	LAB	LAB
-189	379	Stoke-on-Trent Central	Jo Gideon	55419	57.9	24	56.8	5	7	5.8	0	0	1.4	CON	LAB
-190	378	Derby North	Amanda Solloway	73199	64.2	23.3	55.9	6.4	6.8	5.8	0	0	1.8	CON	LAB
-191	377	Bury South	Christian Wakeford	75152	66.9	24	56.6	4.7	7.4	5.5	0	0	1.8	CON	LAB
-192	376	Eltham	Clive Efford	64086	68.2	24	56.3	5.9	5.8	6.9	0	0	1.2	LAB	LAB
-193	375	Cardiff North	Anna McMorrin	68438	77	24.6	56.6	4.7	4.7	4.2	4.6	0	0.6	LAB	LAB
-194	374	Bristol North West	Darren Jones	76273	73.3	23.1	55	9.1	4.7	7.1	0	0	1	LAB	LAB
-195	373	Pontypridd	Alex Davies-Jones	60327	64.7	19.3	51.2	3.4	6.7	2.9	15.5	0	1.1	LAB	LAB
-196	372	Putney	Fleur Anderson	65556	77	22.8	54.6	9.2	4.3	8.3	0	0	0.7	LAB	LAB
-197	371	Torfaen	Nick Thomas-Symonds	62330	59.6	20.8	52.5	4.8	8.8	4.3	7.8	0	1	LAB	LAB
-198	370	Oldham East and Saddleworth	Debbie Abrahams	72120	64	23	54.5	6.2	8.7	6	0	0	1.6	LAB	LAB
-199	369	West Bromwich East	Nicola Richards	62046	58	25.3	56.7	4.4	6.6	5.5	0	0	1.5	CON	LAB
-200	368	Birmingham Northfield	Gary Sambrook	73694	58.5	25	55.9	5.8	6.2	5.6	0	0	1.6	CON	LAB
-201	367	Wansbeck	Ian Lavery	63339	64	22.1	53.1	8.3	8.8	5.7	0	0	2	LAB	LAB
-202	366	Lincoln	Karl McCartney	74942	67.6	24.7	55.6	5.9	6.2	5.5	0	0	2	CON	LAB
-203	365	Gedling	Tom Randall	71366	70	24.3	55.2	5.9	7.3	5.5	0	0	1.8	CON	LAB
-204	364	Coventry South	Zarah Sultana	70979	63.5	24.6	55.5	7.2	4.8	6.6	0	0	1.3	LAB	LAB
-205	363	Coventry North West	Taiwo Owatemi	75247	63.4	24.7	55.4	6.2	6	6.4	0	0	1.3	LAB	LAB
-206	362	Bury North	James Daly	68802	68.1	26	56.7	4.3	6.8	4.9	0	0	1.3	CON	LAB
-207	361	Hyndburn	Sara Britcliffe	70842	59.9	25.2	55.7	4.1	8.4	5.2	0	0	1.6	CON	LAB
-208	360	Wirral West	Margaret Greenwood	55550	77.3	25.3	55.6	6.8	6	4.8	0	0	1.5	LAB	LAB
-209	359	Blyth Valley	Ian Levy	64429	63.4	22.7	52.8	7.6	9.1	5.8	0	0	2	CON	LAB
-210	358	Enfield Southgate	Bambos Charalambous	65525	72.1	26	56.1	5.3	4.9	6.8	0	0	0.9	LAB	LAB
-211	357	Airdrie and Shotts	Neil Gray	64011	62.1	11.6	41.6	1.6	1.7	1.8	40.2	0	1.5	NAT	LAB
-212	356	Chesterfield	Toby Perkins	71034	63.6	21.1	51.1	10.1	9.7	6.2	0	0	2	LAB	LAB
-213	355	Midlothian	Owen Thompson	70544	68.4	12.8	42.8	4.5	1.9	2.6	33.1	0	2.3	NAT	LAB
-214	354	Dewsbury	Mark Eastwood	81253	69.4	25.6	55.5	4.5	7.7	5.4	0	0	1.3	CON	LAB
-215	353	Leigh	James Grundy	77417	60.7	24.7	54.5	5.9	8.4	4.5	0	0	2.1	CON	LAB
-216	352	Heywood and Middleton	Chris Clarkson	80162	59.2	23.7	53.5	5.4	9.2	6.6	0	0	1.6	CON	LAB
-217	351	West Bromwich West	Shaun Bailey	64517	53.4	25.9	55.6	4.1	7.2	5.7	0	0	1.5	CON	LAB
-218	350	Durham North West	Richard Holden	72166	66	22.9	52.3	8.1	9.3	5.2	0	0	2.2	CON	LAB
-218	349	Cumbernauld, Kilsyth and Kirkintilloch East	Stuart McDonald	66079	69.1	7.7	37.1	4.2	1.8	2.5	44.4	0	2.2	NAT	NAT
-218	349	Paisley and Renfrewshire South	Mhairi Black	64385	66.9	9	38.2	4.4	1.9	2.5	41.8	0	2.3	NAT	NAT
-218	349	Glenrothes	Peter Grant	65672	63.3	8.3	37.4	4.1	2	2.9	42.7	0	2.6	NAT	NAT
-219	349	Bedford	Mohammad Yasin	71581	66.1	25.3	54.2	8	5.5	5.8	0	0	1.2	LAB	LAB
-220	348	Blackpool South	Scott Benton	57690	56.8	25	53.8	5.3	8.7	4.7	0	0	2.5	CON	LAB
-221	347	Newport East	Jessica Morden	58554	62	24.8	53.6	5	6.8	4.4	4.8	0	0.6	LAB	LAB
-222	346	Dagenham and Rainham	Jon Cruddas	71045	61.6	26.1	54.7	3.4	7.7	7.1	0	0	1.1	LAB	LAB
-223	345	Llanelli	Nia Griffith	60518	63.2	17.8	46.3	1.7	7.2	1.7	24.1	0	1.3	LAB	LAB
-224	344	Keighley	Robbie Moore	72778	72.3	26.7	54.9	5.4	7.1	4.5	0	0	1.4	CON	LAB
-225	343	Birmingham Erdington	Jack Dromey	66148	53.3	29.8	57.9	2.1	4.4	3.2	0	1.1	1.4	LAB	LAB
-226	342	Darlington	Peter Gibson	66397	65.5	25.6	53.5	6.6	7.4	4.9	0	0	2	CON	LAB
-227	341	Na h-Eileanan An Iar (Western Isles)	Angus MacNeil	21106	68.6	13.2	40.8	2.8	1.8	2.5	36.7	0	2.2	NAT	LAB
-228	340	Pudsey	Stuart Andrew	73212	74.1	26.7	54.2	6.2	6.3	5.1	0	0	1.5	CON	LAB
-229	339	Weaver Vale	Mike Amesbury	70551	71.9	25.5	53	7.7	6.8	5.3	0	0	1.7	LAB	LAB
-230	338	High Peak	Robert Largan	74265	72.9	25.7	53.1	7.4	6.9	5.2	0	0	1.7	CON	LAB
-231	337	Southampton Itchen	Royston Smith	72299	65.6	26.4	53.6	7.1	5.8	5.5	0	0	1.5	CON	LAB
-232	336	Newport West	Ruth Jones	66657	65.2	25.8	53	4.8	6.1	4.4	5.3	0	0.6	LAB	LAB
-233	335	Warwick and Leamington	Matt Western	76362	71	25.1	52.2	10.1	4.8	6.5	0	0	1.4	LAB	LAB
-234	334	Peterborough	Paul Bristow	72560	65.9	27	53.7	5.6	6.9	5.6	0	0	1.2	CON	LAB
-235	333	Wolverhampton South West	Stuart Anderson	60534	68	28.3	54.9	6	5.2	4.3	0	0	1.3	CON	LAB
-236	332	Burnley	Antony Higginbotham	64345	60.6	22.8	48.9	10.3	10.8	5.6	0	0	1.6	CON	LAB
-237	331	Northampton South	Andrew Lewer	62163	65.7	26.6	52.7	5.7	7.1	6.4	0	0	1.4	CON	LAB
-238	330	Colne Valley	Jason McCartney	84174	72.3	26.5	52.6	6.6	7.5	5.3	0	0	1.5	CON	LAB
-239	329	Edinburgh North and Leith	Deidre Brock	81336	73	10.4	36.5	7.5	2.4	5.2	35.2	0	2.7	NAT	LAB
-240	328	Warrington South	Andy Carter	86015	72	26.5	52.3	8.6	6.6	4.5	0	0	1.5	CON	LAB
-241	327	Loughborough	Jane Hunt	79764	68.5	26.8	52.6	7	5.7	6.2	0	0	1.6	CON	LAB
-242	326	Pendle	Andrew Stephenson	65289	68.1	28.3	54	4.2	7.7	4.6	0	0	1.3	CON	LAB
-243	325	East Lothian	Kenny MacAskill	81600	71.7	17.3	42.9	4.5	2	2.7	27.7	0	3	NAT	LAB
-244	324	Bolsover	Mark Fletcher	74292	61.8	25.5	51	6.3	9.7	5	0	0	2.5	CON	LAB
-245	323	Stockton South	Matt Vickers	76870	71.3	28.1	53.6	5.4	7.2	3.9	0	0	1.7	CON	LAB
-246	322	Sedgefield	Paul Howell	64325	64.6	25.5	50.9	7.1	9.2	5.1	0	0	2.3	CON	LAB
-247	321	Dunfermline and West Fife	Douglas Chapman	76652	69.8	12.4	37.7	5.1	2.2	4.3	35.9	0	2.4	NAT	LAB
-248	320	Don Valley	Nick Fletcher	75356	60.3	24.9	50.2	6.3	10.8	5.3	0	0	2.5	CON	LAB
-249	319	Broxtowe	Darren Henry	73052	75.7	27	52.1	4.7	7.8	5.8	0	0	2.6	CON	LAB
-250	318	Hendon	Matthew Offord	82661	66.6	29.1	54.2	4.6	4.7	6.6	0	0	0.9	CON	LAB
-251	317	Calder Valley	Craig Whittaker	79287	72.9	27.7	52.8	6.6	7	4.3	0	0	1.6	CON	LAB
-252	316	Wolverhampton North East	Jane Stevenson	61660	55.6	27.7	52.6	6.5	6.7	4.8	0	0	1.7	CON	LAB
-253	315	Barrow and Furness	Simon Fell	70158	65.6	27.7	52.3	6.3	7.3	4.3	0	0	2	CON	LAB
-254	314	Ipswich	Tom Hunt	75525	65.6	27.6	52.2	7	6.1	5.6	0	0	1.6	CON	LAB
-255	313	Alyn and Deeside	Mark Tami	62789	68.5	26.8	51.2	5.3	6.5	3.2	6.1	0	0.8	LAB	LAB
-256	312	Gower	Tonia Antoniazzi	61762	72	27.1	51.4	4.7	5.5	2.9	7.7	0	0.7	LAB	LAB
-257	311	Canterbury	Rosie Duffield	80203	75	27.5	51.7	9.3	4.8	5.6	0	0	1.1	LAB	LAB
-258	310	Northampton North	Michael Ellis	58768	67.3	27.8	51.8	5.7	7.3	5.9	0	0	1.5	CON	LAB
-259	309	Sheffield Hallam	Olivia Blake	72763	78.2	17.4	41.1	27.5	5.7	7.6	0	0	0.7	LAB	LAB
-260	308	Redcar	Jacob Young	65864	62	25.2	48.6	9.6	9.9	4.8	0	0	2	CON	LAB
-261	307	Stoke-on-Trent North	Jonathan Gullis	68298	58.8	28.3	51.7	5.7	7.9	4.8	0	0	1.6	CON	LAB
-262	306	Chingford and Woodford Green	Iain Duncan Smith	65393	74.1	30	53.4	4.5	5.5	5.8	0	0	0.8	CON	LAB
-263	305	Shipley	Philip Davies	74029	72.9	28.3	51.6	6.3	7	5.2	0	0	1.6	CON	LAB
-263	304	East Kilbride, Strathaven and Lesmahagow	Lisa Cameron	81224	69.4	12.7	35.8	4.3	2.2	4.1	37.9	0	3.1	NAT	NAT
-264	304	Scunthorpe	Holly Mumby-Croft	61955	60.9	28	51.1	5.2	8.8	4.8	0	0	2	CON	LAB
-265	303	Workington	Mark Jenkinson	61370	67.8	27.6	50.4	6.8	8.6	4.6	0	0	2	CON	LAB
-266	302	Milton Keynes South	Iain Stewart	96363	66.4	28.6	51.4	6.9	5.7	6.2	0	0	1.2	CON	LAB
-267	301	Bridgend	Jamie Wallis	63303	66.7	26.7	49.5	5.2	6.3	3.7	7.9	0	0.7	CON	LAB
-267	300	Paisley and Renfrewshire North	Gavin Newlands	72007	69	13.6	36.2	4.7	1.9	2.6	38.6	0	2.4	NAT	NAT
-268	300	Reading West	Alok Sharma	74137	68	28.6	51.2	7.9	5.4	5.8	0	0	1.1	CON	LAB
-269	299	Copeland	Trudy Harrison	61693	68.9	29	51.6	6.1	7.3	4.2	0	0	1.7	CON	LAB
-270	298	Chipping Barnet	Theresa Villiers	79960	72	28.5	50.9	7.4	5.2	7.2	0	0	0.9	CON	LAB
-271	297	Clwyd South	Simon Baynes	53919	67.3	27	49.2	4.1	6.5	2.6	9.8	0	0.8	CON	LAB
-272	296	Great Grimsby	Lia Nici	61409	53.9	27.2	49.2	6.6	9.7	5.1	0	0	2.2	CON	LAB
-273	295	Norwich North	Chloe Smith	67172	68.9	28.5	50.5	8.2	5.9	5.4	0	0	1.5	CON	LAB
-274	294	Carlisle	John Stevenson	65105	65.9	29.1	50.9	7	7.2	3.7	0	0	2.1	CON	LAB
-274	293	Arfon	Hywel Williams	42215	68.9	9.1	30.9	0.6	3.8	0.7	53.9	0	1.1	NAT	NAT
-275	293	Kensington	Felicity Buchan	64609	67.7	27	48.5	9.7	4.7	9.4	0	0	0.7	CON	LAB
-276	292	Rossendale and Darwen	Jake Berry	72770	67.1	29.6	51	5.8	7.3	4.7	0	0	1.7	CON	LAB
-277	291	Bishop Auckland	Dehenna Davison	68170	65.7	28.7	50.1	6.7	8.8	3.7	0	0	2	CON	LAB
-278	290	Hastings and Rye	Sally-Ann Hart	80524	67.4	29.5	50.9	8.3	5.6	4.4	0	0	1.4	CON	LAB
-279	289	Vale of Clwyd	James Davies	56649	65.7	28.8	50.1	4.1	5.9	2.5	7.8	0	0.8	CON	LAB
-279	288	Livingston	Hannah Bardell	82285	66.3	13.6	34.9	4.1	2.2	4.5	38.5	0	2.3	NAT	NAT
-280	288	Delyn	Rob Roberts	54560	70.3	28.5	49.7	5.4	6.2	2.9	6.5	0	0.8	CON	LAB
-281	287	Morecambe and Lunesdale	David Morris	67397	67.2	29.1	50.2	7	7	4.7	0	0	1.9	CON	LAB
-282	286	Worcester	Robin Walker	73485	69.3	29	49.9	8	5.6	6.1	0	0	1.4	CON	LAB
-283	285	Wycombe	Steve Baker	78098	70.1	28.6	49.6	7.9	5.9	7.2	0	0	0.9	CON	LAB
-284	284	Morley and Outwood	Andrea Jenkyns	78803	65.9	29.3	50.3	6.1	7.5	5	0	0	1.9	CON	LAB
-285	283	Milton Keynes North	Ben Everitt	91545	68.3	29	49.8	8.2	5.6	6.2	0	0	1.1	CON	LAB
-286	282	Erewash	Maggie Throup	72523	67.3	28.9	49.6	6.7	7.7	5	0	0	2	CON	LAB
-287	281	Stroud	Siobhan Baillie	84537	78	28.6	49.4	6.6	6.3	7.5	0	0	1.6	CON	LAB
-288	280	Bolton West	Chris Green	73191	67.4	29.9	50.6	5.9	7.1	5.1	0	0	1.4	CON	LAB
-289	279	Corby	Tom Pursglove	86153	70.2	30	50.7	6.7	6.8	4.1	0	0	1.7	CON	LAB
-290	278	Crawley	Henry Smith	74207	67.2	30.8	51	5.3	5.9	5.9	0	0	1.1	CON	LAB
-291	277	Crewe and Nantwich	Kieran Mullan	80321	67.3	30	49.9	6.6	7	4.6	0	0	1.9	CON	LAB
-292	276	Swindon South	Robert Buckland	73118	69.4	30.1	49.9	8.9	5.3	4.5	0	0	1.3	CON	LAB
-293	275	Watford	Dean Russell	83359	69.7	28.2	48	11.5	5.5	5.9	0	0	0.9	CON	LAB
-294	274	Wakefield	Imran Ahmad-Khan	70192	64.1	29.2	49	3.6	6.6	3.3	0	3.8	4.5	CON	LAB
-294	273	Orkney and Shetland	Alistair Carmichael	34211	67.7	2.5	22.2	41.1	2.2	3.1	25.6	0	3.3	LIB	LIB
-295	273	Rother Valley	Alexander Stafford	74804	65.1	26.5	46.1	7.6	11.2	6.5	0	0	2.2	CON	LAB
-296	272	Wrexham	Sarah Atherton	49737	67.4	28.3	47.6	4.5	6.5	3.2	9.1	0	0.8	CON	LAB
-297	271	Blackpool North and Cleveleys	Paul Maynard	63692	60.9	30.2	49.5	6.1	7.8	4.3	0	0	2	CON	LAB
-298	270	Filton and Bradley Stoke	Jack Lopresti	74016	72.6	28.9	47.6	10.6	5.3	6.4	0	0	1.2	CON	LAB
-299	269	Vale of Glamorgan	Alun Cairns	76508	71.6	30.6	49.1	3.8	5.5	4.8	5.5	0	0.7	CON	LAB
-300	268	Cities of London and Westminster	Nickie Aiken	63700	67.1	26.6	45.1	11.9	4.5	11.3	0	0	0.6	CON	LAB
-301	267	Harrow East	Bob Blackman	72106	68.6	33	51.3	4.3	5.1	5.4	0	0	0.9	CON	LAB
-302	266	Middlesbrough South and Cleveland East	Simon Clarke	72348	66.1	30.7	49	6.1	7.9	4.5	0	0	1.8	CON	LAB
-303	265	Rushcliffe	Ruth Edwards	77047	78.5	28.3	46.5	11.7	6.3	5.8	0	0	1.4	CON	LAB
-304	264	Altrincham and Sale West	Graham Brady	73107	74.9	29.6	47.7	8.5	6.4	6.7	0	0	1.1	CON	LAB
-305	263	Telford	Lucy Allan	68921	62.1	31.4	48.8	8	6	4.2	0	0	1.6	CON	LAB
-306	262	Newcastle-under-Lyme	Aaron Bell	68211	65.6	30.7	48.1	8.4	6.1	5.2	0	0	1.6	CON	LAB
-306	261	Linlithgow and East Falkirk	Martyn Day	87044	66.4	16	33.2	4.9	2.3	4.4	35.8	0	3.4	NAT	NAT
-307	261	Stevenage	Stephen McPartland	71562	66.6	30.3	47.5	8.9	6	6.1	0	0	1.3	CON	LAB
-308	260	Batley and Spen	Tracy Brabin	79558	66.5	28.7	45.7	3.7	5.2	2.7	0	11	3	LAB	LAB
-309	259	Penistone and Stocksbridge	Miriam Cates	70925	69.8	28.7	45.5	9.9	9.3	4.8	0	0	1.7	CON	LAB
-309	258	Kilmarnock and Loudoun	Alan Brown	74517	63.9	15.2	31.7	3.3	1.9	2.5	42.4	0	2.9	NAT	NAT
-310	258	Gloucester	Richard Graham	80901	66.5	30.8	47.3	9.6	5.6	5.3	0	0	1.3	CON	LAB
-310	257	Aberdeen North	Kirsty Blackman	62489	59.9	11.7	28.2	4.9	2.3	4.7	45.6	0	2.7	NAT	NAT
-310	257	Brighton Pavilion	Caroline Lucas	79057	73.4	6.8	23.2	4.3	6.4	57.6	0	0	1.6	Green	Green
-311	257	Aberconwy	Robin Millar	44699	71.3	29	45.4	4.2	5.6	2.2	12.8	0	0.7	CON	LAB
-312	256	Stoke-on-Trent South	Jack Brereton	64491	61.4	32.9	49.2	5.9	6.8	3.8	0	0	1.3	CON	LAB
-312	255	Dunbartonshire East	Amy Callaghan	66075	80.3	6.3	22.6	33.1	2.3	3.9	28.7	0	3.3	NAT	LIB
-313	255	Scarborough and Whitby	Robert Goodwill	74404	66.8	30.9	46.7	7.7	8.6	4.2	0	0	2	CON	LAB
-314	254	Preseli Pembrokeshire	Stephen Crabb	59606	71.2	30.4	45.8	4	6.1	2.4	10.6	0	0.7	CON	LAB
-315	253	Mansfield	Ben Bradley	77131	63.9	31.9	46.8	5.7	9.3	4.4	0	0	1.9	CON	LAB
-316	252	Ashfield	Lee Anderson	78204	62.6	17.8	32.7	5	10.3	3.7	0	27.6	2.8	CON	LAB
-317	251	Ribble South	Katherine Fletcher	75351	71.4	32	46.9	7.8	6.9	4.7	0	0	1.6	CON	LAB
-318	250	Finchley and Golders Green	Mike Freer	77573	71	29.3	44	14	4.6	7.2	0	0	0.8	CON	LAB
-319	249	Truro and Falmouth	Cherilyn Mackrory	76719	77.2	28	42.8	15.8	5.8	6.5	0	0	1.1	CON	LAB
-320	248	Southport	Damien Moore	70837	68	27.7	42.4	17.2	7.1	4.6	0	0	1	CON	LAB
-321	247	York Outer	Julian Sturdy	74673	74.1	29.3	43.5	14.4	6.6	4.9	0	0	1.3	CON	LAB
-322	246	Ynys Mon	Virginia Crosbie	51925	70.4	21.7	35.8	1.9	7.2	1.6	30.7	0	1.2	CON	LAB
-323	245	Bassetlaw	Brendan Clarke-Smith	80024	63.5	31.3	45.1	7.2	9.8	4.1	0	0	2.5	CON	LAB
-324	244	Walsall North	Eddie Hughes	67177	54.4	33.4	47.1	6.4	6.9	4.7	0	0	1.5	CON	LAB
-324	243	Caithness Sutherland and Easter Ross	Jamie Stone	46930	67	8.3	22	33.5	2.1	3.2	28.1	0	2.8	LIB	LIB
-325	243	Sherwood	Mark Spencer	77888	67.7	32.2	45.8	7.1	8	5	0	0	2	CON	LAB
-326	242	Colchester	Will Quince	82625	64.6	28.1	41.7	17.2	5.5	6.4	0	0	1	CON	LAB
-326	241	Edinburgh South West	Joanna Cherry	73501	70.9	15.9	29.1	6.1	2.3	4.7	39.2	0	2.8	NAT	NAT
-327	241	Camborne and Redruth	George Eustice	70250	71.7	30.1	43.3	12.9	6.7	5.6	0	0	1.3	CON	LAB
-328	240	Worthing East and Shoreham	Tim Loughton	75194	70.7	30.7	43.9	10.9	6.5	6.8	0	0	1.2	CON	LAB
-329	239	Kingswood	Chris Skidmore	68972	71.5	32.5	45.6	9.2	5.9	5.4	0	0	1.4	CON	LAB
-329	238	Edinburgh West	Christine Jardine	72507	75.2	8.9	21.7	36.2	2.2	4	24.6	0	2.4	LIB	LIB
-330	238	Macclesfield	David Rutley	76216	70.7	30.9	43.5	10.3	7.3	6.5	0	0	1.4	CON	LAB
-331	237	Derbyshire North East	Lee Rowley	72345	68	32.3	44.9	8	8	5.2	0	0	1.6	CON	LAB
-332	236	Wimbledon	Stephen Hammond	68240	77.7	26.8	39.2	22	4.6	6.8	0	0	0.7	CON	LAB
-333	235	Plymouth Moor View	Johnny Mercer	69430	63.7	32.9	44.8	8.6	6.9	5.3	0	0	1.5	CON	LAB
-333	234	Fife North East	Wendy Chamberlain	60905	75.3	5	16.9	39.3	2	2.6	31.8	0	2.4	LIB	LIB
-334	234	Thurrock	Jackie Doyle-Price	79659	59.6	33.4	45.2	6.2	7	7	0	0	1.2	CON	LAB
-335	233	Bournemouth East	Tobias Ellwood	74125	66.5	30.3	42.1	12.9	6.2	7.2	0	0	1.3	CON	LAB
-335	232	Ross Skye and Lochaber	Ian Blackford	54230	73.5	9.2	20.9	20.9	2.3	2.9	39.9	0	4	NAT	NAT
-335	232	Dundee East	Stewart Hosie	66210	68.4	15.2	26.8	5.1	2	2.7	45.4	0	2.9	NAT	NAT
-336	232	Bournemouth West	Conor Burns	74205	62	30.2	41.8	13.5	5.8	7.4	0	0	1.3	CON	LAB
-337	231	Halesowen and Rowley Regis	James Morris	68300	62	34.7	46.1	6.2	6.4	5.1	0	0	1.4	CON	LAB
-338	230	Lanark and Hamilton East	Angela Crawley	77659	68.3	22.3	33.6	3.7	1.9	2.7	33.5	0	2.4	NAT	LAB
-339	229	Kettering	Philip Hollobone	73164	67.5	32.6	43.9	7.5	8.2	5.5	0	0	2.2	CON	LAB
-340	228	Amber Valley	Nigel Mills	69976	65.1	33	44.2	7.4	8.4	5.1	0	0	1.9	CON	LAB
-341	227	Nuneaton	Marcus Jones	70226	64.3	34.3	45.5	7	6.3	5.4	0	0	1.5	CON	LAB
-342	226	Dudley North	Marco Longhi	61936	59.2	34.9	45.8	6.1	6.8	5.1	0	0	1.3	CON	LAB
-343	225	Shrewsbury and Atcham	Daniel Kawczynski	82238	71.8	31.7	42.4	13	6	5.6	0	0	1.3	CON	LAB
-344	224	Welwyn Hatfield	Grant Shapps	74892	69.5	31.9	42.5	12.4	5.4	6.8	0	0	1.1	CON	LAB
-345	223	Swindon North	Justin Tomlinson	82441	66.9	33.5	43.8	9.6	6.1	5.5	0	0	1.4	CON	LAB
-346	222	Rochford and Southend East	James Duddridge	75624	61	33.9	44.1	8.2	6.9	5.4	0	0	1.5	CON	LAB
-347	221	Clwyd West	David Jones	57714	69.7	31.8	41.9	4.1	5.7	2	13.6	0	0.8	CON	LAB
-348	220	Wellingborough	Peter Bone	80765	64.3	32.7	42.8	8.2	8.4	6.1	0	0	1.8	CON	LAB
-349	219	Hexham	Guy Opperman	61324	75.3	32.3	42.1	11	7.6	5.7	0	0	1.3	CON	LAB
-350	218	Carmarthen West and Pembrokeshire South	Simon Hart	59158	71.2	32.5	42.3	4	6	2.3	12.2	0	0.8	CON	LAB
-351	217	Croydon South	Chris Philp	83982	70.7	33.7	42.7	10.1	5.7	6.7	0	0	1	CON	LAB
-352	216	Dover	Natalie Elphicke	76355	66.4	34.2	43.2	9.1	6.6	5.3	0	0	1.6	CON	LAB
-353	215	Basingstoke	Maria Miller	82928	66	32.3	41.2	13.2	5.8	6.3	0	0	1.3	CON	LAB
-354	214	Elmet and Rothwell	Alec Shelbrooke	80957	71.9	34.1	42.9	8.7	7.4	5.3	0	0	1.7	CON	LAB
-355	213	Rugby	Mark Pawsey	72292	70.3	34.3	43	10	6	5.4	0	0	1.4	CON	LAB
-356	212	Derbyshire South	Heather Wheeler	79331	67.3	34	42.6	8.4	7.7	5.6	0	0	1.8	CON	LAB
-357	211	Burton	Kate Griffiths	75036	65	35.8	44.2	7	6.4	5.3	0	0	1.3	CON	LAB
-358	210	Harlow	Robert Halfon	68078	63.7	36.3	44.4	7	6.3	4.6	0	0	1.4	CON	LAB
-358	209	Falkirk	Johnny McNally	84472	66.1	16.9	24.7	4.6	2.3	5.1	44.1	0	2.4	NAT	NAT
-359	209	Hemel Hempstead	Mike Penning	74035	69.3	33.9	41.4	11.1	6.2	6.3	0	0	1.1	CON	LAB
-360	208	Derbyshire Mid	Pauline Latham	67442	73.2	33.8	41.4	9.8	7.5	5.9	0	0	1.6	CON	LAB
-361	207	Stourbridge	Suzanne Webb	69891	65.4	36	43.5	7.5	6.6	5.2	0	0	1.3	CON	LAB
-362	206	Stafford	Theo Clarke	72572	70.5	35.1	42.6	9	6.2	5.7	0	0	1.4	CON	LAB
-363	205	Thanet South	Craig Mackinlay	73223	65.9	34.2	41.6	9.6	6.6	6.7	0	0	1.2	CON	LAB
-363	204	Ceredigion	Ben Lake	56386	71.1	14.9	22	8.1	6.7	1.9	45.8	0	0.7	NAT	NAT
-364	204	Banbury	Victoria Prentis	90116	69.8	33	39.8	13.5	6.1	6.6	0	0	1.1	CON	LAB
-365	203	Chelsea and Fulham	Greg Hands	67110	69.8	33.5	40.3	13.2	4.7	7.4	0	0	0.8	CON	LAB
-366	202	Leicestershire North West	Andrew Bridgen	78935	68.2	34.4	41.1	8.4	8.1	6.1	0	0	1.8	CON	LAB
-367	201	Wyre and Preston North	Ben Wallace	74775	70.8	35.4	41.9	8.1	7.7	5.5	0	0	1.4	CON	LAB
-368	200	Rochester and Strood	Kelly Tolhurst	82056	63.3	34.8	41.3	9.3	7	6.1	0	0	1.6	CON	LAB
-369	199	Monmouth	David Davies	67098	74.8	34.6	41	7.8	5.9	4.1	6	0	0.6	CON	LAB
-370	198	Bromley and Chislehurst	Bob Neill	66697	68.3	33.3	39.6	12.9	6	7.1	0	0	1.1	CON	LAB
-371	197	Portsmouth North	Penny Mordaunt	71299	64.4	34.8	41.1	10	6.8	5.8	0	0	1.5	CON	LAB
-372	196	Harborough	Neil O'Brien	80151	71.5	32.7	38.8	12.9	7.6	6.7	0	0	1.2	CON	LAB
-372	195	Ayrshire North and Arran	Patricia Gibson	73534	65.5	21.3	27.1	2.8	2.1	4.3	40.1	0	2.3	NAT	NAT
-373	195	Gillingham and Rainham	Rehman Chishti	73549	62.5	36.2	41.9	8.5	6.4	5.4	0	0	1.6	CON	LAB
-374	194	Somerset North East	Jacob Rees-Mogg	73692	76.4	31.3	36.9	19.2	5.7	5.7	0	0	1.2	CON	LAB
-374	193	Carmarthen East and Dinefwr	Jonathan Edwards	57419	71.4	18.6	24.2	1	6.8	0.8	47.4	0	1.2	NAT	NAT
-375	193	Selby and Ainsty	Nigel Adams	78398	72	36.3	41.5	6.3	6.7	4.7	0	2.1	2.4	CON	LAB
-376	192	Uxbridge and South Ruislip	Boris Johnson	70365	68.5	40	44.8	3.6	3.7	4.6	0	1.2	2.1	CON	LAB
-377	191	Bexleyheath and Crayford	David Evennett	65466	66.1	36.6	41.3	7.8	6.6	6.3	0	0	1.3	CON	LAB
-378	190	Congleton	Fiona Bruce	80930	70.7	34.4	38.9	12.1	7.6	5.4	0	0	1.5	CON	LAB
-379	189	Isle of Wight	Bob Seely	113021	65.9	29.1	33.6	9.6	11.4	14.3	0	0	1.9	CON	LAB
-380	188	Ribble Valley	Nigel Evans	79247	69.8	35.5	39.9	9.7	7.9	5.4	0	0	1.6	CON	LAB
-381	187	Waveney	Peter Aldous	82791	61.8	35.3	39.6	9.8	7.3	6.4	0	0	1.6	CON	LAB
-382	186	Gravesham	Adam Holloway	73242	64.9	37	41.3	8.1	6.5	5.7	0	0	1.4	CON	LAB
-383	185	Eddisbury	Edward Timpson	73700	71.9	34	38.2	14.1	7.2	5.1	0	0	1.5	CON	LAB
-384	184	Redditch	Rachel Maclean	65391	67.4	37.2	41.2	8.3	6.6	5.4	0	0	1.3	CON	LAB
-385	183	Fylde	Mark Menzies	66847	69.8	35.7	39.3	8.9	8.9	5.5	0	0	1.7	CON	LAB
-385	182	Inverness Nairn Badenoch and Strathspey	Drew Hendry	78059	70.2	19.8	23.2	7.1	2.4	5.3	39.4	0	2.8	NAT	NAT
-386	182	Forest of Dean	Mark Harper	71438	72.1	35.4	38.6	8.4	7.6	8.3	0	0	1.7	CON	LAB
-387	181	Bedfordshire South West	Andrew Selous	79926	66.7	35.8	39	11.3	6.5	6.1	0	0	1.3	CON	LAB
-388	180	Beverley and Holderness	Graham Stuart	79696	67.2	35.5	38.7	10.1	8.9	5	0	0	1.8	CON	LAB
-389	179	Warwickshire North	Craig Tracey	70271	65.3	37.9	41.1	7.8	6.7	4.9	0	0	1.6	CON	LAB
-389	178	Ayrshire Central	Philippa Whitford	69742	66.7	24.7	27.5	3.2	1.9	2.7	37.7	0	2.4	NAT	NAT
-390	178	Dartford	Gareth Johnson	82209	65.7	37.6	40.2	8.6	6.4	5.9	0	0	1.3	CON	LAB
-391	177	Cannock Chase	Amanda Milling	74813	61.9	37.6	40.2	7	7.2	6.1	0	0	1.7	CON	LAB
-391	176	Bath	Wera Hobhouse	67805	76.9	19	21.5	49.5	3.8	5.6	0	0	0.5	LIB	LIB
-392	176	Aylesbury	Rob Butler	86665	69.9	34.3	36.6	14	6.6	7.7	0	0	0.9	CON	LAB
-393	175	Worthing West	Peter Bottomley	78585	69.5	34.6	36.8	13.9	7	6.5	0	0	1.2	CON	LAB
-394	174	Derbyshire Dales	Sarah Dines	65080	76.9	35.1	37.1	12.2	8.1	6.1	0	0	1.4	CON	LAB
-395	173	Weston-Super-Mare	John Penrose	82526	67.4	33.7	35.7	17.3	6.5	5.6	0	0	1.1	CON	LAB
-396	172	Chatham and Aylesford	Tracey Crouch	71642	60.5	37.5	39.4	9.4	6.7	5.5	0	0	1.5	CON	LAB
-397	171	Aldershot	Leo Docherty	72617	66	33.9	35.7	16.3	6.4	6.6	0	0	1.2	CON	LAB
-398	170	Dorset South	Richard Drax	73809	69.2	35.2	36.9	13.2	7.2	5.9	0	0	1.4	CON	LAB
-399	169	Charnwood	Edward Argar	79534	69.6	36.4	38	9.7	7.9	6.5	0	0	1.6	CON	LAB
-400	168	Tatton	Esther McVey	69018	70.9	35.3	36.9	12.6	7.4	6.5	0	0	1.2	CON	LAB
-401	167	Hartlepool	Mike Hill	70855	57.9	37	38.5	4.2	8	3.5	0	4.9	4	LAB	LAB
-402	166	Beckenham	Bob Stewart	68662	73.6	35.3	36.6	14.1	5.8	7.1	0	0	1	CON	LAB
-402	165	Renfrewshire East	Kirsten Oswald	72232	76.6	25.1	26.4	4.8	1.9	2.8	36.5	0	2.5	NAT	NAT
-403	165	Huntingdon	Jonathan Djanogly	84657	69.9	33.7	35	16.9	6.5	6.6	0	0	1.3	CON	LAB
-404	164	St Austell and Newquay	Steve Double	79930	69.8	33.7	34.9	17.2	7.6	5.3	0	0	1.3	CON	LAB
-405	163	Leicestershire South	Alberto Costa	80520	71.4	36.4	37.5	10.5	7.8	6.2	0	0	1.5	CON	LAB
-406	162	Cleethorpes	Martin Vickers	73689	62.9	37.9	38.7	8.1	8.7	4.9	0	0	1.8	CON	LAB
-407	161	Ruislip, Northwood and Pinner	David Simmonds	72816	72.7	37.3	38	10.1	6.2	7.3	0	0	1	CON	LAB
-408	160	Hertford and Stortford	Julie Marson	81765	73.5	34.9	35.6	15	6.2	7.1	0	0	1.2	CON	LAB
-409	159	Wyre Forest	Mark Garnier	78077	64.8	38	38.6	8.3	8.3	5.6	0	0	1.1	CON	LAB
-410	158	Great Yarmouth	Brandon Lewis	71957	60.4	38.4	38.8	8.6	7.5	4.9	0	0	1.8	CON	LAB
-411	157	Newark	Robert Jenrick	75850	72.2	37.3	37.7	10.4	7.6	5.4	0	0	1.6	CON	LAB
-412	156	Haltemprice and Howden	David Davis	71083	70	36.7	36.9	10.9	8.4	5.5	0	0	1.6	CON	LAB
-413	155	Penrith and The Border	Neil Hudson	67555	70.8	35.5	35.7	12.7	8.8	5.6	0	0	1.7	CON	LAB
-414	154	Yorkshire East	Greg Knight	80923	65.2	36.5	36.7	9.7	10	5.3	0	0	1.9	CON	LAB
-415	153	Wrekin, The	Mark Pritchard	70693	69.2	38.3	38.5	10.4	6.1	5.4	0	0	1.3	CON	LAB
-416	152	Dudley South	Mike Wood	60731	60.2	39.4	39.5	8.1	6.7	4.9	0	0	1.4	CON	LAB
-417	151	Hertfordshire North East	Oliver Heald	76123	72.7	34.7	34.8	16.1	6.3	6.9	0	0	1.1	CON	LAB
-418	150	Bracknell	James Sunderland	78978	68.8	35.7	35.7	14.7	6.2	6.5	0	0	1.2	CON	LAB
-419	149	Berwick-upon-Tweed	Anne-Marie Trevelyan	59939	70.3	32.5	32.5	20.1	8.7	5	0	0	1.1	CON	CON
-419	148	Dwyfor Meirionnydd	Liz Saville Roberts	44362	67.5	15.9	15.8	0.7	6.5	0.5	59.7	0	1	NAT	NAT
-420	148	Norfolk South	Richard Bacon	86214	72.5	35.1	34.9	16.3	6.5	6	0	0	1.2	CON	CON
-421	147	Bury St Edmunds	Jo Churchill	89644	69.1	33.7	33.5	9.9	8.1	13	0	0	1.8	CON	CON
-422	146	Northamptonshire South	Andrea Leadsom	90842	73.7	36.5	36.1	11.5	7.8	6.6	0	0	1.6	CON	CON
-423	145	Somerset North	Liam Fox	80194	77.4	33.6	33.1	19.4	6.3	6.7	0	0	0.9	CON	CON
-424	144	Romford	Andrew Rosindell	72350	65.3	39.6	39.1	6.6	7	6.6	0	0	1.1	CON	CON
-424	143	Kingston and Surbiton	Ed Davey	81975	74.2	23.7	23.1	41.1	5	6.5	0	0	0.5	LIB	LIB
-425	143	Devon Central	Mel Stride	74926	77.5	33.6	33	18.8	7	6.6	0	0	1.1	CON	CON
-426	142	Tamworth	Christopher Pincher	71572	64.3	39.6	38.4	9.1	6.4	4.7	0	0	1.8	CON	CON
-426	141	Ayr Carrick and Cumnock	Allan Dorans	71970	64.7	28.1	26.9	3	1.9	2.7	35.1	0	2.4	NAT	NAT
-427	141	Hitchin and Harpenden	Bim Afolami	76323	77.1	31.8	30.6	26.4	5	5.3	0	0	0.8	CON	CON
-428	140	Thanet North	Roger Gale	72756	66.2	38	36.7	11.1	6.9	6.1	0	0	1.3	CON	CON
-429	139	Woking	Jonathan Lord	75454	71.5	32.8	31.4	22.4	5.8	6.9	0	0	0.7	CON	CON
-430	138	Staffordshire Moorlands	Karen Bradley	65485	66.7	39.5	38	9.8	6.6	4.6	0	0	1.4	CON	CON
-431	137	Skipton and Ripon	Julian Smith	78673	74.6	35.3	33.6	13.9	9.2	6.5	0	0	1.6	CON	CON
-432	136	Brigg and Goole	Andrew Percy	65939	65.8	39.5	37.8	7.4	8.8	4.5	0	0	1.9	CON	CON
-432	135	Hazel Grove	William Wragg	63346	69.9	28.7	27	32.2	6.9	4.4	0	0	0.8	CON	LIB
-433	135	Basildon South and East Thurrock	Stephen Metcalfe	74441	60.8	39.8	37.8	8.1	7.5	4.8	0	0	1.9	CON	CON
-434	134	Bedfordshire North East	Richard Fuller	90678	71.7	37.2	35.2	14	6.3	5.7	0	0	1.5	CON	CON
-435	133	Cambridgeshire North West	Shailesh Vara	94909	68	37.3	35.3	12.9	6.6	6.7	0	0	1.2	CON	CON
-435	132	Stirling	Alyn Smith	68473	76.8	23.7	21.7	3.5	2.1	4	42.7	0	2.4	NAT	NAT
-436	132	Cheadle	Mary Robinson	74577	75	30.6	28.3	29.1	6.4	5.1	0	0	0.6	CON	CON
-436	131	St Albans	Daisy Cooper	73727	78.1	27.2	24.9	36.1	4.9	6.4	0	0	0.5	LIB	LIB
-437	131	Runnymede and Weybridge	Ben Spencer	77196	69	36	33.6	16	6	7.2	0	0	1.2	CON	CON
-438	130	Sutton Coldfield	Andrew Mitchell	75638	69.2	38.9	36.4	11.5	6	6.2	0	0	1	CON	CON
-439	129	Bedfordshire Mid	Nadine Dorries	87795	73.7	37.1	34.5	14.3	6.3	6.5	0	0	1.3	CON	CON
-440	128	Gainsborough	Edward Leigh	76343	66.9	38.7	36.1	11.2	8.5	3.8	0	0	1.7	CON	CON
-441	127	Chelmsford	Vicky Ford	80394	71.1	34.7	32	21.5	5.8	5.1	0	0	1	CON	CON
-442	126	Grantham and Stamford	Gareth Davies	81502	68.7	37.8	35	11.1	8.8	5.8	0	0	1.5	CON	CON
-443	125	Wantage	David Johnston	90867	73.9	31.5	28.7	28.1	5.8	5	0	0	1	CON	CON
-443	124	Aberdeen South	Stephen Flynn	65719	69.4	25.9	23	7.4	2	2.9	36.2	0	2.6	NAT	NAT
-444	124	Folkestone and Hythe	Damian Collins	88272	66.8	36.5	33.6	14	7.7	6.8	0	0	1.3	CON	CON
-445	123	Richmond	Rishi Sunak	82569	69.9	37	33.9	12	9.3	5.8	0	0	1.9	CON	CON
-446	122	Reigate	Crispin Blunt	74242	71.6	34.4	31.3	18	6.5	8.6	0	0	1	CON	CON
-447	121	Ashford	Damian Green	89553	67.1	37.7	34.5	12.9	6.9	6.6	0	0	1.4	CON	CON
-448	120	Cambridgeshire South East	Lucy Frazer	86769	74.2	31.6	28.3	29.1	5.5	4.5	0	0	0.9	CON	CON
-449	119	Suffolk Coastal	Therese Coffey	81910	71.2	35.3	31.9	17.4	7.4	6.7	0	0	1.3	CON	CON
-450	118	Poole	Robert Syms	73989	68.2	36.3	32.9	16.6	6.9	6	0	0	1.2	CON	CON
-451	117	Sittingbourne and Sheppey	Gordon Henderson	83917	61.2	39.8	36.3	9.8	7.2	5.2	0	0	1.7	CON	CON
-451	116	Carshalton and Wallington	Elliot Colburn	72941	67.3	27.6	24.2	35.4	6.4	5.9	0	0	0.6	CON	LIB
-452	116	Harwich and North Essex	Bernard Jenkin	74153	70.1	37.6	34.1	14.3	6.6	6.1	0	0	1.3	CON	CON
-453	115	Daventry	Chris Heaton-Harris	77423	74.1	37.7	34.1	12	8.3	6.4	0	0	1.5	CON	CON
-454	114	Norfolk Mid	George Freeman	82203	68.4	37.9	34.2	15.1	6.8	4.5	0	0	1.4	CON	CON
-454	113	Cambridgeshire South	Anthony Browne	87288	76.7	29.7	25.8	33.7	5	5.1	0	0	0.7	CON	LIB
-455	113	Thirsk and Malton	Kevin Hollinrake	80991	69.9	37.2	33.3	12.6	9.5	5.9	0	0	1.6	CON	CON
-455	112	Argyll and Bute	Brendan O'Hara	66525	72.2	25.3	21.3	10.5	2.1	2.9	35.3	0	2.6	NAT	NAT
-456	112	Meriden	Saqib Bhatti	85368	63.4	39	35.1	11.6	6.6	6.5	0	0	1.2	CON	CON
-457	111	Spelthorne	Kwasi Kwarteng	70929	69.8	37.2	33.1	14.6	6.8	7.3	0	0	1	CON	CON
-458	110	Sussex Mid	Mims Davies	85146	73.7	34.2	29.9	22.5	6.1	6.3	0	0	1	CON	CON
-459	109	Hereford and South Herefordshire	Jesse Norman	72085	68.9	36.7	32.4	15.8	7.6	6.3	0	0	1.1	CON	CON
-460	108	Suffolk West	Matt Hancock	80193	64.1	38.5	34.2	12.5	6.9	6.5	0	0	1.3	CON	CON
-461	107	Sleaford and North Hykeham	Caroline Johnson	94761	70.2	39.7	35.2	9.1	9.2	4.9	0	0	1.8	CON	CON
-462	106	Suffolk Central and Ipswich North	Dan Poulter	80037	70.3	37.9	33.3	14.2	6.8	6.5	0	0	1.3	CON	CON
-463	105	Wokingham	John Redwood	83953	73.8	32.8	28.1	26.9	5.3	6.2	0	0	0.8	CON	CON
-464	104	Broxbourne	Charles Walker	73182	63.8	40.9	36	9.2	6.6	6	0	0	1.2	CON	CON
-465	103	Devon South West	Gary Streeter	72535	73.6	38.2	33.2	15.2	6.5	5.7	0	0	1.2	CON	CON
-466	102	Bosworth	Luke Evans	81542	69.2	36.7	31.8	16.7	8.3	5.2	0	0	1.2	CON	CON
-467	101	Salisbury	John Glen	74556	72.1	35.4	30.4	20.4	6.5	6.2	0	0	1.1	CON	CON
-467	100	Oxford West and Abingdon	Layla Moran	76951	76.4	24.9	19.7	45.3	4.7	4.9	0	0	0.5	LIB	LIB
-468	100	Wiltshire South West	Andrew Murrison	77969	70.4	36.6	31.4	17.9	6.9	6	0	0	1.1	CON	CON
-469	99	Broadland	Jerome Mayhew	78151	72.9	36.8	31.5	18.6	6.6	5.3	0	0	1.1	CON	CON
-470	98	Hertsmere	Oliver Dowden	73971	70.6	40	34.7	12	5.6	6.5	0	0	1.1	CON	CON
-471	97	Rutland and Melton	Alicia Kearns	82705	70.5	37.2	31.6	14.1	8.7	6.8	0	0	1.6	CON	CON
-472	96	Bridgwater and West Somerset	Ian Liddell-Grainger	85327	67.6	37.1	31.5	17.3	7.5	5.3	0	0	1.3	CON	CON
-473	95	Norfolk North West	James Wild	72080	64.7	40.2	34.6	11.4	7.3	5.3	0	0	1.4	CON	CON
-474	94	Epsom and Ewell	Chris Grayling	81138	73.3	36.4	30.8	19.1	6	6.7	0	0	1	CON	CON
-475	93	Basildon and Billericay	John Baron	69906	63.1	41	35.3	10.3	6.4	5.7	0	0	1.3	CON	CON
-476	92	Totnes	Anthony Mangnall	69863	74.7	33.3	27.5	26.4	7	4.8	0	0	1	CON	CON
-476	91	Ochil and South Perthshire	John Nicolson	78776	73.4	28.3	22.4	3.6	2	2.8	38.1	0	3	NAT	NAT
-476	91	Twickenham	Munira Wilson	84906	76	23.2	17.2	50.1	4.5	4.7	0	0	0.3	LIB	LIB
-477	91	Sutton and Cheam	Paul Scully	71779	70.3	33	26.8	27.5	6	6.1	0	0	0.6	CON	CON
-478	90	Witney	Robert Courts	83845	73.1	35	28.7	25	5.7	4.6	0	0	1	CON	CON
-479	89	Devon East	Simon Jupp	87168	73.5	37.8	31.5	8.9	13.7	5.3	0	0	2.8	CON	CON
-480	88	Bromsgrove	Sajid Javid	75078	72.3	40.1	33.6	13.3	6.3	5.6	0	0	1.1	CON	CON
-481	87	Stone	Bill Cash	69378	71.8	40.5	34.1	12.4	6.5	5.3	0	0	1.2	CON	CON
-482	86	Tunbridge Wells	Greg Clark	74823	73	35.8	29.3	23	5.8	5.1	0	0	1	CON	CON
-483	85	Faversham and Kent Mid	Helen Whately	73403	68.7	39	32.4	14.1	7	6.3	0	0	1.3	CON	CON
-484	84	Hertfordshire South West	Gagan Mohindra	80449	76.1	37.3	30.6	14.6	8.2	6.7	0	0	2.5	CON	CON
-485	83	Hornchurch and Upminster	Julia Lopez	80765	66.8	41.3	34.6	8.8	7.3	6.8	0	0	1.2	CON	CON
-486	82	Cornwall South East	Sheryll Murray	71825	74.7	36.1	29.2	21.1	7.5	5	0	0	1.1	CON	CON
-487	81	Southend West	David Amess	69043	67.4	41.2	34.3	11.7	6	4.7	0	0	2.2	CON	CON
-487	80	Guildford	Angela Richardson	77729	75.5	31.6	24.6	32.2	5.2	5.3	0	0	1.1	CON	LIB
-488	80	Kenilworth and Southam	Jeremy Wright	68154	77.2	37.3	30.3	19.2	5.8	6.2	0	0	1.1	CON	CON
-488	79	Perth and North Perthshire	Pete Wishart	72600	74.5	26.5	19.3	4.5	2	3	42.2	0	2.7	NAT	NAT
-489	79	Newton Abbot	Anne Marie Morris	72529	72.5	34.2	27	25.7	6.9	5.1	0	0	1	CON	CON
-490	78	Gosport	Caroline Dinenage	73541	65.9	39.8	32.6	13.8	7	5.6	0	0	1.3	CON	CON
-491	77	Suffolk South	James Cartlidge	76201	70.2	38.1	30.8	16.3	6.9	6.8	0	0	1.1	CON	CON
-492	76	Lichfield	Michael Fabricant	76616	70.5	40.6	33.2	13.2	6.5	5.2	0	0	1.4	CON	CON
-493	75	Maidstone and The Weald	Helen Grant	76109	67.9	37	29.5	19.8	6.6	6.2	0	0	1	CON	CON
-494	74	Solihull	Julian Knight	78760	70.3	38.5	31	17.1	6.3	6.4	0	0	0.7	CON	CON
-495	73	Havant	Alan Mak	72103	63.7	39	31.3	15.1	7.4	5.9	0	0	1.3	CON	CON
-496	72	Bognor Regis and Littlehampton	Nick Gibb	77446	66.1	39.6	31.7	13.9	7.7	5.8	0	0	1.4	CON	CON
-497	71	Buckingham	Greg Smith	83146	76.3	35.7	27.8	17.9	9.3	8.3	0	0	1	CON	CON
-498	70	Harrogate and Knaresborough	Andrew Jones	77941	73.1	32.9	24.9	29.8	7	4.4	0	0	1	CON	CON
-499	69	Epping Forest	Eleanor Laing	74304	67.7	40.5	32.5	11.7	6.9	7.3	0	0	1.1	CON	CON
-500	68	Braintree	James Cleverly	75208	67.1	41.4	33.2	12.1	7	4.6	0	0	1.7	CON	CON
-501	67	Tewkesbury	Laurence Robertson	83958	72.8	36.2	27.9	22.7	6.4	5.9	0	0	1	CON	CON
-502	66	Horsham	Jeremy Quin	86730	72.9	36	27.5	22.8	6.3	6.6	0	0	1	CON	CON
-503	65	Witham	Priti Patel	70402	70.1	40.1	31.4	12.9	7.1	7	0	0	1.4	CON	CON
-504	64	Eastleigh	Paul Holmes	83880	70.3	32.9	24	31	6.1	5.2	0	0	0.8	CON	CON
-505	63	Devizes	Danny Kruger	73372	69.4	37.8	28.8	18.4	7	6.8	0	0	1.2	CON	CON
-506	62	Aldridge-Brownhills	Wendy Morton	60138	65.4	43.6	34.3	9.5	6.8	4.3	0	0	1.5	CON	CON
-507	61	Hampshire North West	Kit Malthouse	83083	70.9	38.6	29.2	18.6	6.4	6.1	0	0	1.1	CON	CON
-508	60	Fareham	Suella Braverman	78337	73.1	39.7	30.2	16.3	6.6	6	0	0	1.1	CON	CON
-509	59	Norfolk South West	Liz Truss	78455	65.6	41.4	31.8	12.3	7.7	5.4	0	0	1.5	CON	CON
-510	58	Dumfries and Galloway	Alister Jack	74580	69	33.2	23.4	3.9	1.9	2.8	32.1	0	2.6	CON	CON
-511	57	Windsor	Adam Afriyie	75038	71.6	38.8	29.1	18.9	5.9	6.3	0	0	1	CON	CON
-512	56	Louth and Horncastle	Victoria Atkins	79634	65.7	42.6	32.4	9.7	9.9	3.7	0	0	1.7	CON	CON
-512	55	Richmond Park	Sarah Olney	82699	78.7	28.9	18.7	41.8	4.6	5.5	0	0	0.4	LIB	LIB
-513	55	Devon West and Torridge	Geoffrey Cox	80403	74.3	36.9	26.6	22.3	7.6	5.5	0	0	1	CON	CON
-514	54	Bexhill and Battle	Huw Merriman	81963	72.1	40.3	30.1	15.3	7.3	5.9	0	0	1.1	CON	CON
-515	53	Maidenhead	Theresa May	76668	73.7	39	28.6	19.1	5.9	6.6	0	0	0.8	CON	CON
-515	52	Gordon	Richard Thomson	79629	70.2	30.7	20.4	7	2	3	34.3	0	2.7	NAT	NAT
-516	52	Montgomeryshire	Craig Williams	48997	69.8	37.7	27.4	18	7.2	2.6	6.6	0	0.5	CON	CON
-517	51	Chichester	Gillian Keegan	85499	71.6	37.2	26.8	22.1	6.5	6.5	0	0	1	CON	CON
-518	50	Tonbridge and Malling	Tom Tugendhat	79278	71.9	39	28.3	16.4	6.9	8.2	0	0	1.1	CON	CON
-519	49	Romsey and Southampton North	Caroline Nokes	68228	75.3	35.3	24.5	29.9	5.2	4.3	0	0	0.8	CON	CON
-519	48	Chippenham	Michelle Donelan	77221	73.9	33.1	22.1	34.6	5.6	3.9	0	0	0.7	CON	LIB
-519	48	Angus	Dave Doogan	63952	67.5	29.8	18.7	3.7	1.9	2.8	40.7	0	2.5	NAT	NAT
-520	48	Orpington	Gareth Bacon	68877	70.7	41	29.8	15.3	6.4	6.5	0	0	1	CON	CON
-521	47	Worcestershire West	Harriett Baldwin	76241	75.5	38.9	27.5	19.9	6.7	6	0	0	1	CON	CON
-522	46	Boston and Skegness	Matt Warman	69381	60.1	43.2	31.6	8.1	10.9	4.3	0	0	2	CON	CON
-523	45	Surrey South West	Jeremy Hunt	79096	76.3	36.6	24.9	27.1	5.7	5.1	0	0	0.6	CON	CON
-524	44	Arundel and South Downs	Andrew Griffith	81726	75.1	38.3	26.6	21.1	6.5	6.5	0	0	1	CON	CON
-524	43	Westmorland and Lonsdale	Tim Farron	67789	77.8	26.9	15.1	47.1	7	3.3	0	0	0.6	LIB	LIB
-525	43	Torbay	Kevin Foster	75054	67.2	35.2	23.4	28.8	7.2	4.5	0	0	0.9	CON	CON
-526	42	Cambridgeshire North East	Steve Barclay	83699	63.3	42.7	30.9	12.1	7.6	5.3	0	0	1.5	CON	CON
-527	41	Henley	John Howell	76646	76.7	35.8	23.9	26.7	6.1	6.6	0	0	0.8	CON	CON
-528	40	Dumfriesshire, Clydesdale and Tweeddale	David Mundell	68330	71.9	34.9	23.1	4.6	2	2.9	29.9	0	2.6	CON	CON
-528	39	St Ives	Derek Thomas	68795	74.7	29.5	17.6	41.3	6.6	4.3	0	0	0.7	CON	LIB
-529	39	Wealden	Nus Ghani	82992	73.4	38.7	26.7	20.1	6.8	6.7	0	0	1	CON	CON
-529	38	Cheltenham	Alex Chalk	81044	73.2	28.8	16.8	45.3	4.8	3.7	0	0	0.6	CON	LIB
-530	38	Surrey East	Claire Coutinho	83148	71.8	39.2	27.2	19	6.8	6.7	0	0	1.1	CON	CON
-531	37	Sevenoaks	Laura Trott	71757	71	39.5	27.2	18.9	6.8	6.6	0	0	1.1	CON	CON
-532	36	Worcestershire Mid	Nigel Huddleston	78220	71.8	41.9	29.5	14.7	7	5.7	0	0	1.3	CON	CON
-532	35	Aberdeenshire West and Kincardine	Andrew Bowie	72640	73.4	32	19.6	8.1	2.1	3	32.6	0	2.7	CON	NAT
-533	35	Brecon and Radnorshire	Fay Jones	55490	74.5	35.3	22.8	27.8	6.6	2.6	4.5	0	0.4	CON	CON
-533	34	Taunton Deane	Rebecca Pow	88676	71.9	33.2	20.5	35.3	6.4	3.7	0	0	0.9	CON	LIB
-534	34	Wiltshire North	James Gray	73280	74.7	36.9	23.9	26.8	6.1	5.4	0	0	0.9	CON	CON
-535	33	Herefordshire North	Bill Wiggin	70252	72.6	38.3	25.3	18.6	8.3	8.3	0	0	1.2	CON	CON
-536	32	South Holland and The Deepings	John Hayes	75975	64.7	43.4	30	9.3	10.1	5.3	0	0	1.9	CON	CON
-536	31	Eastbourne	Caroline Ansell	79307	69.5	30.8	17.4	41.3	6.4	3.5	0	0	0.6	CON	LIB
-537	31	New Forest East	Julian Lewis	73549	69.1	40.3	26.8	18	7.4	6.3	0	0	1.2	CON	CON
-538	30	Surrey Heath	Michael Gove	81349	72.1	38.3	24.8	23.1	6.3	6.4	0	0	1	CON	CON
-539	29	Esher and Walton	Dominic Raab	81184	77.7	34.9	21.4	32.7	5.2	5.1	0	0	0.7	CON	CON
-540	28	Cotswolds, The	Geoffrey Clifton-Brown	81939	74.7	37.3	23.7	25.4	6.5	6.3	0	0	0.9	CON	CON
-541	27	Saffron Walden	Kemi Badenoch	87017	72.5	39.9	26.2	20.1	6.3	6.6	0	0	0.9	CON	CON
-542	26	Hampshire East	Damian Hinds	76478	74.4	38.3	24.5	23.6	6.4	6.2	0	0	1	CON	CON
-542	25	Winchester	Steve Brine	75582	77.9	31.9	17.8	40.8	4.6	4.3	0	0	0.6	CON	LIB
-543	25	Hampshire North East	Ranil Jayawardena	78954	75.1	39	24.9	23.5	5.9	5.6	0	0	1.1	CON	CON
-544	24	Newbury	Laura Farris	83414	71.9	36.1	22	29.3	6	5.7	0	0	0.9	CON	CON
-545	23	Dorset West	Chris Loder	81897	74.4	34.9	20.5	32.2	6.6	5	0	0	0.8	CON	CON
-546	22	Ludlow	Philip Dunne	69444	72.3	40.6	26.2	20	7.1	5.1	0	0	1	CON	CON
-546	21	Wells	James Heappey	84124	73.3	33.7	19.3	36.6	6.1	3.5	0	0	0.8	CON	LIB
-546	21	Lewes	Maria Caulfield	71503	76.7	29.9	15.3	44	5.8	4.5	0	0	0.5	CON	LIB
-546	21	Devon North	Selaine Saxby	75859	73.3	33.3	18.7	35.1	7.2	4.9	0	0	0.7	CON	LIB
-547	21	Stratford-on-Avon	Nadhim Zahawi	74037	74.4	39.4	24.7	22.8	6.5	5.7	0	0	0.9	CON	CON
-548	20	Shropshire North	Owen Paterson	83258	67.9	36.2	21.1	29.9	6.3	4.4	0	0	2.1	CON	CON
-549	19	Old Bexley and Sidcup	James Brokenshire	66104	69.8	47.3	32.2	6.1	7.4	4.6	0	0	2.4	CON	CON
-550	18	Yeovil	Marcus Fysh	82468	71.9	34.6	19.4	33.8	6.9	4.4	0	0	0.8	CON	CON
-551	17	Staffordshire South	Gavin Williamson	73668	67.9	45.6	30.4	10.6	7	5	0	0	1.4	CON	CON
-551	16	Moray	Douglas Ross	71035	68.7	34.3	19	3	2	2.8	35.8	0	3.1	CON	NAT
-552	16	Clacton	Giles Watling	70930	61.3	44.2	28.8	10.7	9.2	5.7	0	0	1.5	CON	CON
-553	15	Rayleigh and Wickford	Mark Francois	78930	69.6	45.1	29.4	11	7.2	6.1	0	0	1.2	CON	CON
-554	14	New Forest West	Desmond Swayne	70866	71	40.9	25.2	17.6	7.7	7.4	0	0	1.1	CON	CON
-555	13	Castle Point	Rebecca Harris	69608	63.6	46.8	30.9	8.9	7.8	4.5	0	0	1.1	CON	CON
-556	12	Dorset North	Simon Hoare	76765	73.1	39.9	23.5	23	7.1	5.5	0	0	1	CON	CON
-556	11	Thornbury and Yate	Luke Hall	69492	75.2	35	18.5	36.8	5.6	3.5	0	0	0.6	CON	LIB
-557	11	Meon Valley	Flick Drummond	75737	72.4	40.8	23.7	22.5	6.4	5.6	0	0	1	CON	CON
-558	10	Berwickshire, Roxburgh and Selkirk	John Lamont	74518	71.3	37.2	19.6	5.2	2	3	30.3	0	2.7	CON	CON
-559	9	Cornwall North	Scott Mann	69935	73.9	36.2	18.4	34.4	6.9	3.3	0	0	0.7	CON	CON
-560	8	Brentwood and Ongar	Alex Burghart	75255	70.4	44.6	26.4	15	6.7	6.1	0	0	1.1	CON	CON
-561	7	Maldon	John Whittingdale	72438	69.6	45.5	26.9	13.9	6.9	5.7	0	0	1.2	CON	CON
-562	6	Mole Valley	Paul Beresford	74665	76.5	37.5	18.9	30.7	6.1	6	0	0	0.8	CON	CON
-563	5	Dorset Mid and Poole North	Michael Tomlinson	65427	74.8	38.1	18.5	31.9	6.2	4.5	0	0	0.7	CON	CON
-564	4	Christchurch	Christopher Chope	71520	72.6	43.5	23.4	19.2	7.1	5.8	0	0	1	CON	CON
-565	3	Banff and Buchan	David Duguid	66655	63.4	38.6	18.5	3.5	1.9	2.9	31.9	0	2.6	CON	CON
-566	2	Beaconsfield	Joy Morrissey	77720	74.5	41.2	20.7	25.8	6.1	4.4	0	0	1.8	CON	CON
-566	1	Somerton and Frome	David Warburton	85866	75.6	32.1	11.4	41.7	6.3	6.9	0	0	1.7	CON	LIB
-566	1	Norfolk North	Duncan Baker	70729	71.9	35.5	14.7	38.2	7.8	3.2	0	0	0.6	CON	LIB
-567	1	Tiverton and Honiton	Neil Parish	82953	71.9	39	15.7	35.3	5	3.9	0	0	1.2	CON	CON
-567	0	Chesham and Amersham	Cheryl Gillan	72542	76.8	37.8	12	39.4	4.5	5.4	0	0	0.9	CON	LIB
+1	571	Liverpool Walton	Dan Carden	70861	66.3	4.8	79.8	2	6.8	5.3	0	0	1.3	LAB	LAB
+2	570	Bootle	Peter Dowd	74832	65.7	4.6	79.3	2.2	7.4	5.4	0	0	1.2	LAB	LAB
+3	569	Knowsley	George Howarth	70836	65.3	4.2	78.6	2.3	7.2	6.2	0	0	1.4	LAB	LAB
+4	568	Liverpool Riverside	Kim Johnson	70301	65.6	3.2	77.5	2.9	5.6	9.3	0	0	1.5	LAB	LAB
+5	567	Liverpool West Derby	Ian Byrne	70379	66.9	4.7	77.6	2.5	8.2	5.4	0	0	1.6	LAB	LAB
+6	566	Peckham	Harriet Harman	71491	63.4	5.1	75.3	3.4	5	9.7	0	0	1.6	LAB	LAB
+7	565	Lewisham North	Vicky Foxcroft	75020	68.3	5.6	75.8	3.3	4.5	9.5	0	0	1.4	LAB	LAB
+8	564	Hackney South and Shoreditch	Meg Hillier	80391	61	4.8	74.4	3.1	4.2	11.9	0	0	1.6	LAB	LAB
+9	563	Tottenham	David Lammy	75561	61.8	4.8	73.8	2.9	5.2	11.5	0	0	1.8	LAB	LAB
+10	562	Liverpool Wavertree	Paula Barker	71135	67.3	4.9	70.8	5.5	6	11	0	0	1.8	LAB	LAB
+11	561	Islington North	Jeremy Corbyn	75162	71.6	5.1	71.1	4.3	4.3	13.6	0	0	1.6	LAB	LAB
+12	560	Lewisham West and East Dulwich	Ellie Reeves	70348	68.4	7.6	73.4	3.2	5.3	9.2	0	0	1.4	LAB	LAB
+13	559	Chorley	Lindsay Hoyle	74743	51	4.8	70.6	2.2	9.6	9	0	0	3.8	LAB	LAB
+14	558	Walthamstow	Stella Creasy	70267	68.8	6.4	71.8	3.2	5.8	10.8	0	0	1.9	LAB	LAB
+15	557	Liverpool Garston	Maria Eagle	70128	69.8	6	71.3	6.4	8.4	5.8	0	0	2.1	LAB	LAB
+16	556	Hackney North and Stoke Newington	Diane Abbott	80736	61.4	5.3	70.3	3.5	4.8	14.1	0	0	2	LAB	LAB
+17	555	Dulwich and West Norwood	Helen Hayes	74932	68.9	7.4	71.4	1.8	4.4	13.5	0	0	1.4	LAB	LAB
+18	554	Vauxhall and Camberwell Green	Florence Eshalomi	72629	63.4	7	70.8	5.2	5.5	9.9	0	0	1.7	LAB	LAB
+19	553	Widnes and Halewood	Derek Twigg	70355	65.6	8.7	71.9	2.2	10.3	5.5	0	0	1.5	LAB	LAB
+20	552	Lewisham East	Janet Daby	69956	66.6	8.7	71.2	3.1	7.2	8.2	0	0	1.6	LAB	LAB
+21	551	Clapham and Brixton Hill	Bell Ribeiro-Addy	79342	65.2	8	69.8	5.5	5	10	0	0	1.6	LAB	LAB
+22	550	Holborn and St Pancras	Keir Starmer	72190	66	7.3	68.8	4.1	5.7	12.2	0	0	1.9	LAB	LAB
+23	549	Manchester Withington	Jeff Smith	71167	68.7	6.8	68.1	7.4	5.9	10	0	0	1.7	LAB	LAB
+24	548	Islington South and Finsbury	Emily Thornberry	77383	67.2	7.9	68.8	5.2	6.2	10.1	0	0	1.9	LAB	LAB
+25	547	West Ham and Beckton	Lyn Brown	70621	61.6	7.7	68	3	7.7	11.2	0	0	2.4	LAB	LAB
+26	546	Manchester Rusholme	Unknown (new seat)	69299	57.5	5	63.9	5.1	6	17.9	0	0	2.2	LAB	LAB
+27	545	Wallasey	Angela Eagle	72516	70.7	10	68.4	3.1	10.5	6.5	0	0	1.5	LAB	LAB
+28	544	Rhondda and Ogmore	Chris Bryant	73521	60.2	6.8	64.3	2.3	12.2	6.2	6.2	0	2.1	LAB	LAB
+29	543	Greenwich and Woolwich	Matthew Pennycook	69900	66.4	10.4	67.4	4	6.8	9.7	0	0	1.7	LAB	LAB
+30	542	Newcastle upon Tyne East and Wallsend	Nick Brown	76871	66.2	9.2	65.8	4.7	11	7.7	0	0	1.7	LAB	LAB
+31	541	Croydon West	Steve Reed	70732	64.4	9.8	65.9	3.1	6.8	12.6	0	0	1.8	LAB	LAB
+32	540	St Helens South and Whiston	Marie Rimmer	70538	63.6	8.6	64.7	3.9	11.1	9.9	0	0	1.8	LAB	LAB
+33	539	Queen's Park and Maida Vale	Karen Buck	77359	64.6	9.1	64.9	4.8	6.8	12.1	0	0	2.3	LAB	LAB
+34	538	Salford	Rebecca Long-Bailey	71672	60.6	9.1	64.8	3.7	11.7	9.1	0	0	1.8	LAB	LAB
+35	537	Streatham and Croydon North	Unknown (new seat)	78082	64.9	9.5	65.1	5.7	6.4	11.5	0	0	1.8	LAB	LAB
+36	536	Birkenhead	Mick Whitley	75675	67.9	7	62.6	3.5	7.7	16.4	0	0	2.7	LAB	LAB
+37	535	Manchester Central	Lucy Powell	73790	56	8.3	63.6	4.8	11.1	10.2	0	0	2.1	LAB	LAB
+38	534	Nottingham East	Nadia Whittome	75287	60.4	9.1	64.3	4	8.8	11.7	0	0	2.2	LAB	LAB
+39	533	Stratford and Bow	Unknown (new seat)	73601	64.1	7.5	62.3	4.5	6	17.4	0	0	2.4	LAB	LAB
+40	532	Edinburgh South	Ian Murray	71688	74.7	8.3	63	5.9	3.5	4.9	12.1	0	2.4	LAB	LAB
+41	531	Blaenau Gwent and Rhymney	Nick Smith	70687	59.6	7.3	61.2	2.9	16.3	6	4.1	0	2.3	LAB	LAB
+42	530	Leeds Central and Headingley	Alex Sobel	75218	63.6	8.8	62.3	5.7	8.4	13.1	0	0	1.8	LAB	LAB
+43	529	Aberafan Maesteg	Stephen Kinnock	69525	62.8	9.1	61.9	2.8	13	6.3	4.7	0	2.2	LAB	LAB
+44	528	Birmingham Ladywood	Shabana Mahmood	78301	57.4	6.1	58.7	5.6	7	19.6	0	0	3	LAB	LAB
+45	527	Leyton and Wanstead	John Cryer	71085	68.8	11.5	64.1	4.2	7.1	11.1	0	0	2.1	LAB	LAB
+46	526	Oxford East	Anneliese Dodds	71602	63	9.6	61.8	5.8	6.9	13.8	0	0	2	LAB	LAB
+47	525	Gorton and Denton	Afzal Khan	73749	59.6	9.5	61.7	4.3	11.1	11.3	0	0	2.1	LAB	LAB
+48	524	East Ham	Stephen Timms	70899	61.8	8.7	60.8	3.3	7	17.1	0	0	3.1	LAB	LAB
+49	523	Bethnal Green and Stepney	Rushanara Ali	76294	68.4	6.4	58.3	7.6	6.9	17.1	0	0	3.7	LAB	LAB
+50	522	Merthyr Tydfil and Aberdare	Gerald Jones	74598	58	8.5	60	3.2	14.3	5.6	5.8	0	2.6	LAB	LAB
+51	521	Hove and Portslade	Peter Kyle	74313	75.9	14.5	65.4	3.5	8.4	7.2	0	0	0.9	LAB	LAB
+52	520	Stretford and Urmston	Kate Green	72371	69.2	16.1	66.6	3	7.1	5.1	0	0	2.1	LAB	LAB
+53	519	York Central	Rachael Maskell	76303	66.3	14	64.5	4	9.4	7.1	0	0	1	LAB	LAB
+54	518	Hornsey and Friern Barnet	Catherine West	69277	72.7	9	59.3	17	5.5	7.9	0	0	1.3	LAB	LAB
+55	517	Ellesmere Port and Bromborough	Justin Madders	71097	71.5	14.3	63.8	4	9.8	7.2	0	0	0.9	LAB	LAB
+56	516	Glasgow North East	Anne McLaughlin	76435	56.2	3.7	53	2.6	3.1	2.6	32.9	0	2.1	NAT	LAB
+57	515	Leeds South	Hilary Benn	74574	54.7	12.2	61.1	3.7	12.7	9	0	0	1.3	LAB	LAB
+58	514	Leeds North East	Fabian Hamilton	70545	71.5	12.8	61.2	5.4	8.8	9.6	0	0	2.1	LAB	LAB
+59	513	Mitcham and Morden	Siobhain McDonagh	76805	66.4	15.4	63.7	4.1	8.7	6.9	0	0	1.3	LAB	LAB
+60	512	Rutherglen	Margaret Ferrier	70291	66.8	7.5	55.9	3.8	3.8	2.1	24.7	0	2.3	NAT	LAB
+61	511	Cardiff East	Jo Stevens	75658	64.9	10.5	58.8	8.6	9.7	8.7	1.2	0	2.4	LAB	LAB
+62	510	Erith and Thamesmead	Abena Oppong-Asare	73353	64.3	15.5	63.5	2.6	10.1	7	0	0	1.2	LAB	LAB
+63	509	Ealing Southall	Virendra Sharma	75523	66.3	12.6	60.2	3.2	7.4	14.1	0	0	2.4	LAB	LAB
+64	508	Brent East	Dawn Butler	74720	59.9	12.3	59.6	4.5	8	13.2	0	0	2.3	LAB	LAB
+65	507	Tooting	Rosena Allin-Khan	76953	76	16.4	63.5	4.9	6.2	8.1	0	0	1.1	LAB	LAB
+66	506	Coatbridge and Bellshill	Steven Bonnar	71594	65.9	4.5	51.5	2.3	3.2	3.5	32.8	0	2.2	NAT	LAB
+67	505	Sheffield Brightside and Hillsborough	Gill Furniss	70294	57.1	10.1	57.1	3.3	13.1	14.1	0	0	2.3	LAB	LAB
+68	504	St Helens North	Conor McGinn	75594	62.9	14	61	3.8	14	6.1	0	0	1.1	LAB	LAB
+69	503	Jarrow and Gateshead East	Kate Osborne	71050	62	13.2	60.1	4.2	16.1	4.8	0	0	1.6	LAB	LAB
+70	502	Barnsley North	Dan Jarvis	76552	56.1	10.3	56.8	2.7	21.3	6.1	0	0	2.8	LAB	LAB
+71	501	Poplar and Limehouse	Apsana Begum	74951	66.7	9.5	55.8	8.1	8	15.3	0	0	3.4	LAB	LAB
+72	500	Glasgow North	Patrick Grady	75508	60.7	3.1	49.2	4	3.3	4.7	33.6	0	2.1	NAT	LAB
+73	499	Sheffield Heeley	Louise Haigh	74095	62.5	12.5	58.6	6.2	12	9.3	0	0	1.4	LAB	LAB
+74	498	Newcastle upon Tyne Central and West	Chi Onwurah	75872	66.3	13.4	59	4.9	14.4	7	0	0	1.2	LAB	LAB
+75	497	South Shields	Emma Lewell-Buck	69711	60.5	10.7	56.3	3.5	14.9	11.6	0	0	2.9	LAB	LAB
+76	496	Glasgow South West	Chris Stephens	70821	57.9	4.6	50.1	3.1	3.3	3.4	33.1	0	2.3	NAT	LAB
+77	495	Blackley and Middleton South	Graham Stringer	70878	54.7	14.1	59.5	3.7	14.6	6.8	0	0	1.2	LAB	LAB
+78	494	Southgate and Wood Green	Bambos Charalambous	75799	71.7	16.2	61.5	5.2	7.9	7.9	0	0	1.4	LAB	LAB
+79	493	Norwich South	Clive Lewis	77605	66.4	13.3	58.6	5.3	7.5	14.3	0	0	1	LAB	LAB
+80	492	Swansea West	Geraint Davies	73780	60.2	12.7	57.8	5.8	12.5	6	3.8	0	1.4	LAB	LAB
+81	491	Bristol East	Kerry McCarthy	75476	71.4	12.8	57.6	5.8	9.3	13.5	0	0	1.1	LAB	LAB
+82	490	Easington	Grahame Morris	69856	57.6	13.4	58.2	3.5	19.4	4.1	0	0	1.4	LAB	LAB
+83	489	Barking	Margaret Hodge	71151	57.1	15.1	59.7	3.1	11.9	8.6	0	0	1.6	LAB	LAB
+84	488	Stockport	Navendu Mishra	75659	62.3	15.2	59.5	5	11.2	8	0	0	1	LAB	LAB
+85	487	Glasgow East	David Linden	70653	57.7	4.9	49.1	3	3.2	3.5	34.1	0	2.2	NAT	LAB
+86	486	Brighton Kemptown and Peacehaven	Lloyd Russell-Moyle	70996	69.6	18.1	62.2	2.6	9.3	6.9	0	0	0.9	LAB	LAB
+87	485	Nottingham South	Lilian Greenwood	75840	59.4	14.8	58.8	4.7	11.7	8.7	0	0	1.2	LAB	LAB
+88	484	Exeter	Ben Bradshaw	72928	68.5	15.2	59.1	2.8	8.8	13.1	0	0	1	LAB	LAB
+89	483	Sefton Central	Bill Esterson	74418	72.3	18.2	62.1	4.1	10.6	4.2	0	0	0.9	LAB	LAB
+90	482	Wythenshawe and Sale East	Mike Kane	76314	58.6	16.2	59.9	3.7	11.2	8	0	0	1	LAB	LAB
+91	481	Hammersmith and Chiswick	Andy Slaughter	75119	69	17	60.4	5.6	7.5	8.1	0	0	1.3	LAB	LAB
+92	480	Sheffield Central	Paul Blomfield	70914	56.7	4.8	48.2	4.2	4	37.5	0	0	1.4	LAB	LAB
+93	479	Ealing Central and Acton	Rupa Huq	76249	72.2	15.1	58.3	8.5	7.6	8.9	0	0	1.6	LAB	LAB
+94	478	Pontypridd	Alex Davies-Jones	73664	62.7	14.5	57.4	2.7	12.4	4.6	6.8	0	1.5	LAB	LAB
+95	477	Gateshead Central and Whickham	Ian Mearns	71243	61.4	16.8	59.6	6	11.3	5.1	0	0	1.3	LAB	LAB
+96	476	Leicester South	Jonathan Ashworth	71620	64.5	11.1	53.7	4.7	7.1	21	0	0	2.3	LAB	LAB
+97	475	Bristol South	Karin Smyth	74269	65.6	14.2	56.6	5.5	9.6	13.1	0	0	1.1	LAB	LAB
+98	474	Neath and Swansea East	Christina Rees	74090	63.1	12.5	54.8	3.9	13.2	4.7	9.4	0	1.4	LAB	LAB
+99	473	Blyth and Ashington	Ian Lavery	75298	63.8	17.4	59.3	3.6	14.2	4.3	0	0	1.1	LAB	LAB
+100	472	Birmingham Selly Oak	Steve McCabe	81511	59.9	16.3	57.3	4.3	10.1	10.8	0	0	1.2	LAB	LAB
+101	471	Cambridge	Daniel Zeichner	73882	67.2	9.1	50	23.9	5.8	9.9	0	0	1.2	LAB	LAB
+102	470	Battersea	Marsha De Cordova	71971	75.6	20.3	61	5	5.9	6.6	0	0	1.2	LAB	LAB
+103	469	Birmingham Perry Barr	Khalid Mahmood	75301	58.1	10.7	51.4	7.5	10	16.9	0	0	3.6	LAB	LAB
+104	468	Glasgow South	Stewart McDonald	72763	65.9	5.4	46.1	4.4	3.4	4.6	33.7	0	2.3	NAT	LAB
+105	467	Cardiff West	Kevin Brennan	74561	67.2	16.6	57.3	4	9.5	6.1	5.2	0	1.3	LAB	LAB
+106	466	Wigan	Lisa Nandy	75680	59.5	17	57.6	3.3	16.2	4.8	0	0	1.1	LAB	LAB
+107	465	Hull East	Karl Turner	73112	49.7	12.8	53.4	6.2	19.6	5.9	0	0	2	LAB	LAB
+108	464	Middlesbrough and Thornaby East	Andy McDonald	70890	58.9	14.9	55.5	4.1	17.1	6.5	0	0	1.9	LAB	LAB
+109	463	Ilford South	Sam Tarry	74166	62.8	13.3	53.8	3	9.2	16.4	0	0	4.3	LAB	LAB
+110	462	Barnsley South	Stephanie Peacock	75635	55.2	13.7	54.1	2.9	22.8	4.9	0	0	1.6	LAB	LAB
+111	461	Plymouth Sutton and Devonport	Luke Pollard	73824	68.3	18.8	59.1	3	11.9	6.3	0	0	1	LAB	LAB
+112	460	Southampton Test	Alan Whitehead	70117	64.2	18.6	59	3.6	10.3	7.4	0	0	1.2	LAB	LAB
+113	459	Washington and Gateshead South	Sharon Hodgson	71731	58.6	16.5	56.6	3.6	16.9	5.1	0	0	1.2	LAB	LAB
+114	458	Edmonton and Winchmore Hill	Kate Osamor	75656	64.3	17.9	57.9	4.4	9.5	8.7	0	0	1.6	LAB	LAB
+115	457	Ealing North	James Murray	73069	66.6	18.8	58.6	3.7	8.8	8.9	0	0	1.3	LAB	LAB
+116	456	Newcastle upon Tyne North	Catherine McKinnell	76162	66.8	15.3	55.1	10.6	11.1	6.4	0	0	1.4	LAB	LAB
+117	455	Houghton and Sunderland South	Bridget Phillipson	76748	57.7	15.2	54.8	5	18.1	5.2	0	0	1.6	LAB	LAB
+118	454	Bermondsey and Old Southwark	Neil Coyle	71073	62.9	9	48.6	27.2	6.6	7.1	0	0	1.6	LAB	LAB
+119	453	Runcorn and Helsby	Mike Amesbury	70451	69.1	20.7	60	3.2	10.2	4.9	0	0	1	LAB	LAB
+120	452	Preston	Mark Hendrick	73810	59.3	17	56.3	5.2	12.4	7.7	0	0	1.3	LAB	LAB
+121	451	Coventry East	Colleen Fletcher	74310	59.3	19.1	58.3	2.9	12.3	6.2	0	0	1.2	LAB	LAB
+122	450	Enfield North	Feryal Clark	77308	65.5	19.8	59	3.5	9	7.1	0	0	1.5	LAB	LAB
+123	449	Leicester West	Liz Kendall	73309	54.8	17.9	57	4.4	11.7	7.4	0	0	1.6	LAB	LAB
+124	448	Durham North	Kevan Jones	72859	63.4	16.2	55.3	5.2	17.2	4.7	0	0	1.4	LAB	LAB
+125	447	Kingston upon Hull North and Cottingham	Diana Johnson	76620	55.3	17.2	56.3	5.4	14	5.5	0	0	1.7	LAB	LAB
+126	446	Chester North and Neston	Chris Matheson	73078	71.2	22.2	61.2	4.4	6.7	3.8	0	0	1.7	LAB	LAB
+127	445	Lancashire West	Rosie Cooper	73347	71.8	23.1	61.9	2.8	7.8	3.4	0	0	1	LAB	LAB
+128	444	Cardiff South and Penarth	Stephen Doughty	73492	65	17.3	56.1	5	9	8.1	3.3	0	1.3	LAB	LAB
+129	443	Blaydon and Consett	Unknown (changed seat)	70058	66.7	18.7	57.5	4	14.4	4.1	0	0	1.3	LAB	LAB
+130	442	Caerphilly	Wayne David	70954	63.2	14.9	53.4	1.7	10.7	3.7	14.3	0	1.3	LAB	LAB
+131	441	Dunbartonshire West	Martin Docherty	69016	67.7	6.5	44.9	3.1	3.5	3.9	35.1	0	2.9	NAT	LAB
+132	440	Makerfield	Yvonne Fovargue	76308	59.7	19.4	57.8	2.6	15.3	3.8	0	0	1.1	LAB	LAB
+133	439	Smethwick	John Spellar	70903	60	17.2	55.6	3.4	13.8	8.5	0	0	1.4	LAB	LAB
+134	438	Durham, City of	Mary Foy	72653	68.2	14.8	53.1	12.7	11.8	6.2	0	0	1.4	LAB	LAB
+135	437	Sheffield South East	Clive Betts	75260	62.1	18.1	56.4	3.8	15.4	4.7	0	0	1.7	LAB	LAB
+136	436	Tynemouth	Alan Campbell	72908	71.9	21.2	59.2	3.8	10.6	4.2	0	0	1	LAB	LAB
+137	435	Leeds West and Pudsey	Unknown (new seat)	69837	67.1	20.5	58.4	3.4	10.9	5.4	0	0	1.4	LAB	LAB
+138	434	Hampstead and Highgate	Tulip Siddiq	77786	67.2	12.8	50.5	18.6	6.6	10	0	0	1.5	LAB	LAB
+139	433	Bolton South and Walkden	Yasmin Qureshi	76112	59	16.5	54.2	4.1	15.7	8.1	0	0	1.4	LAB	LAB
+140	432	Sunderland Central	Julie Elliott	72679	59.8	17.2	54.9	6.3	14.5	5.3	0	0	1.8	LAB	LAB
+141	431	Birmingham Hall Green and Moseley	Tahir Ali	77165	65.5	11.4	48.9	8.2	9	17.7	0	0	4.7	LAB	LAB
+142	430	Glenrothes and Mid Fife	Peter Grant	68703	63.5	7.4	44.8	4.1	3.4	3.4	34.3	0	2.6	NAT	LAB
+143	429	Ashton under Lyne	Angela Rayner	71709	57.2	19.7	57.1	2.5	13.9	5.6	0	0	1.1	LAB	LAB
+144	428	Glasgow West	Carol Monaghan	72836	62.8	7.2	44.6	5.5	3.3	3.3	33.8	0	2.4	NAT	LAB
+145	427	Rawmarsh and Conisbrough	John Healey	69958	57.4	18.6	55.9	2.7	17.5	3.8	0	0	1.6	LAB	LAB
+146	426	Pontefract, Castleford and Knottingley	Yvette Cooper	72666	57.1	18.5	55.7	3.3	17	3.7	0	0	1.7	LAB	LAB
+147	425	Edinburgh East and Musselburgh	Tommy Sheppard	75152	69.3	6.6	43.8	5	3.5	5.3	33.4	0	2.4	NAT	LAB
+148	424	Cardiff North	Anna McMorrin	71374	76.5	20.9	58.1	4.5	8.6	5.1	1.5	0	1.3	LAB	LAB
+149	423	Bradford West	Naz Shah	70695	62.6	11.6	48.7	5	9.9	21.6	0	0	3.1	LAB	LAB
+150	422	Whitehaven and Workington	Trudy Harrison	73374	68.5	22	59	2	13	3.1	0	0	0.8	CON	LAB
+151	421	Chesterfield	Toby Perkins	71033	63.6	19.5	56.5	4.6	13.9	4.2	0	0	1.3	LAB	LAB
+152	420	Cowdenbeath and Kirkcaldy	Neale Hanvey	70191	65.2	12.3	49.2	4.8	3.6	5.7	21.7	0	2.7	NAT	LAB
+153	419	Dundee Central	Chris Law	74801	65.3	4.7	41.5	4.4	3.4	2.9	40.5	0	2.7	NAT	LAB
+154	418	Blackpool South	Scott Benton	77039	57.8	19.6	56.4	2.4	15.9	4.7	0	0	1	CON	LAB
+155	417	Bristol North West	Darren Jones	76243	73.6	20	56.7	5.6	7.7	8.9	0	0	1.1	LAB	LAB
+156	416	Portsmouth South	Stephen Morgan	74186	63.9	17.4	54	9.6	11.1	6.2	0	0	1.7	LAB	LAB
+157	415	Normanton and Hemsworth	Jon Trickett	75392	59.2	17.2	53.8	2.9	19.6	4.8	0	0	1.7	LAB	LAB
+157	414	Bristol Central	Thangam Debbonaire	69801	76.1	4.3	40.5	2.2	2	50.2	0	0	0.7	LAB	Green
+158	414	Birmingham Edgbaston	Preet Gill	73255	61	20.1	56.3	4.8	9.9	7.4	0	0	1.5	LAB	LAB
+159	413	Southampton Itchen	Royston Smith	72298	65.6	21.4	57.2	2.7	12.5	5.2	0	0	1.1	CON	LAB
+160	412	Nottingham North and Kimberley	Alex Norris	73973	57.7	20.7	56.6	2.8	12.7	5.9	0	0	1.3	LAB	LAB
+161	411	Inverclyde and Renfrewshire West	Ronnie Cowan	69793	66.2	8.9	44.7	4.8	3.2	2.8	33.2	0	2.4	NAT	LAB
+162	410	Torfaen	Nick Thomas-Symonds	70218	61.3	17	52.7	3.8	17	5.3	3	0	1.2	LAB	LAB
+163	409	Putney	Fleur Anderson	72934	76.8	21.9	57.5	6.1	6.5	6.7	0	0	1.3	LAB	LAB
+164	408	Hayes and Harlington	John McDonnell	72327	60.8	21.5	57	2	9.5	8.4	0	0	1.6	LAB	LAB
+165	407	Worsley and Eccles	Barbara Keeley	77299	60.1	21.4	56.8	3.3	12.7	4.7	0	0	1.1	LAB	LAB
+166	406	Cumbernauld and Kirkintilloch	Stuart McDonald	69904	68.6	7.2	42.6	4.3	3.2	2.9	37.4	0	2.3	NAT	LAB
+167	405	Cramlington and Killingworth	Unknown (changed seat)	73124	65	20.9	56.1	4.2	13.5	4.1	0	0	1.2	LAB	LAB
+168	404	Stalybridge and Hyde	Jonathan Reynolds	73063	58	20.8	55.9	3	13.6	5.4	0	0	1.3	LAB	LAB
+169	403	Stockton North	Alex Cunningham	69643	62.6	20.6	55.7	3.2	14.9	4.2	0	0	1.3	LAB	LAB
+170	402	Blackburn	Kate Hollern	69792	62.8	14.6	49.6	5	12.8	14.9	0	0	3.1	LAB	LAB
+171	401	Midlothian	Owen Thompson	70544	68.4	12.1	47	5.2	3.3	2.9	27	0	2.5	NAT	LAB
+172	400	Newport East	Jessica Morden	75617	63.3	19.9	54.7	4	12.7	5.8	1.7	0	1.3	LAB	LAB
+173	399	Reading Central	Matt Rodda	71434	71.3	21.6	56.5	3.7	6.7	10.5	0	0	1	LAB	LAB
+174	398	Doncaster North	Ed Miliband	71752	56.3	16.6	51.4	3.6	22.2	4.4	0	0	1.8	LAB	LAB
+175	397	Brentford and Isleworth	Ruth Cadbury	75746	68	20	54.6	5.4	9.2	9.2	0	0	1.5	LAB	LAB
+176	396	Newton Aycliffe and Spennymoor	Paul Howell	71018	65.4	20.5	54.9	4.6	14.7	3.7	0	0	1.6	CON	LAB
+177	395	Northampton North	Michael Ellis	75272	66.9	21.6	56.1	3.5	12.3	5.4	0	0	1.1	CON	LAB
+178	394	Ipswich	Tom Hunt	75526	65.6	22	56.3	2.7	12.8	5.1	0	0	1.1	CON	LAB
+179	393	Derby South	Margaret Beckett	73061	58.1	20	54.3	4.1	14.2	5.8	0	0	1.5	LAB	LAB
+180	392	Bradford East	Imran Hussain	71646	60.4	12.4	46.6	9	13.2	15.3	0	0	3.4	LAB	LAB
+181	391	Newport West and Islwyn	Chris Evans	75266	63.5	21	55.1	3.1	13	4.7	1.8	0	1.3	LAB	LAB
+182	390	Tipton and Wednesbury	Shaun Bailey	73716	54.5	20.4	54.4	2	16.7	5.1	0	0	1.3	CON	LAB
+183	389	Warrington North	Charlotte Nichols	72097	64.6	22.5	56.5	3.1	12.5	4.4	0	0	1	LAB	LAB
+184	388	Motherwell, Wishaw and Carluke	Marion Fellows	71444	65.4	11.5	45.5	3.1	3.4	2.8	30.8	0	2.8	NAT	LAB
+185	387	Wolverhampton South East	Pat McFadden	76072	55.7	22	55.9	1.8	13.3	5.8	0	0	1.3	LAB	LAB
+186	386	Rotherham	Sarah Champion	74645	57.9	16.8	50.6	4.4	21.1	5.3	0	0	1.8	LAB	LAB
+187	385	Airdrie and Shotts	Neil Gray	69843	62.4	11.8	45.4	1.8	2.9	1.9	34.8	0	1.4	NAT	LAB
+188	384	Calder Valley	Craig Whittaker	76434	72.9	23	56.4	3.7	12	3.6	0	0	1.2	CON	LAB
+189	383	Llanelli	Nia Griffith	69600	64.2	14	47.3	1.8	11.7	3.1	21	0	1.1	LAB	LAB
+190	382	Bristol North East	Unknown (new seat)	69495	71.5	22.8	56	3.2	9.4	7.7	0	0	0.9	LAB	LAB
+191	381	Paisley and Renfrewshire South	Mhairi Black	68828	67.2	9.2	42.2	4.9	3.2	2.8	35.3	0	2.4	NAT	LAB
+192	380	Darlington	Peter Gibson	70099	65.5	22.3	55.2	3.3	12.3	5.7	0	0	1	CON	LAB
+193	379	Na h-Eileanan An Iar (Western Isles)	Angus MacNeil	21106	68.6	12.4	45.2	3.3	3.2	2.8	30.6	0	2.4	NAT	LAB
+194	378	Norwich North	Chloe Smith	72378	69.1	23.1	55.8	3.3	11.3	5.5	0	0	1.1	CON	LAB
+195	377	Warwick and Leamington	Matt Western	75602	71.3	22.7	55.4	4.5	7.4	8.7	0	0	1.2	LAB	LAB
+196	376	Harrow West	Gareth Thomas	74387	66.3	22	54.4	3.6	8.9	9.6	0	0	1.5	LAB	LAB
+197	375	Croydon East	Sarah Jones	75259	66.8	23.3	55.8	3.9	9.4	6	0	0	1.5	LAB	LAB
+198	374	Leeds South West and Morley	Andrea Jenkyns	70921	64.3	21.9	54.3	2.7	14.8	5	0	0	1.2	CON	LAB
+199	373	Gower	Tonia Antoniazzi	76005	69.6	22.5	54.7	4.2	10.8	4.1	2.5	0	1.2	LAB	LAB
+200	372	Loughborough	Jane Hunt	73617	68.5	23.7	55.9	3.5	10.6	5.2	0	0	1	CON	LAB
+201	371	Alyn and Deeside	Mark Tami	75403	68.8	21.4	53.5	3.6	14	3.7	2.6	0	1.2	LAB	LAB
+202	370	Oldham West, Chadderton and Royton	Jim McMahon	72998	60.9	18.4	50.4	5	16	8.4	0	0	1.9	LAB	LAB
+203	369	Canterbury	Rosie Duffield	75633	75	24.5	56.5	3.7	8.2	5.9	0	0	1.3	LAB	LAB
+204	368	Leeds East	Richard Burgon	74719	61.1	22.3	54.3	3.1	13.8	5.3	0	0	1.2	LAB	LAB
+205	367	Vale of Glamorgan	Alun Cairns	70148	71.6	24.3	56.3	2	10.3	5.5	0.6	0	1	CON	LAB
+206	366	Barrow and Furness	Simon Fell	78041	66	23.3	55.1	3.1	13.7	3.8	0	0	1	CON	LAB
+207	365	Feltham and Heston	Seema Malhotra	74250	59.1	23	54.8	2.5	9.8	8.5	0	0	1.5	LAB	LAB
+208	364	Brent West	Barry Gardiner	79036	61.2	21.2	53	4.2	8.8	11	0	0	1.8	LAB	LAB
+209	363	Bishop Auckland	Dehenna Davison	70578	65.8	21.4	53.2	3.9	16.7	3.4	0	0	1.4	CON	LAB
+210	362	Paisley and Renfrewshire North	Gavin Newlands	69791	66.9	10.6	42.2	5.3	3.3	2.9	33.2	0	2.5	NAT	LAB
+210	361	Brighton Pavilion	Caroline Lucas	77893	73.4	6.9	38.5	2.6	3.7	47.1	0	0	1.2	Green	Green
+211	361	Lothian East	Kenny MacAskill	70354	71.7	16.7	48.2	4.9	3.5	3.1	20.7	0	3	NAT	LAB
+212	360	Gedling	Tom Randall	76299	69.9	24.9	56.3	2.8	10.6	4.3	0	0	1.1	CON	LAB
+213	359	Birmingham Northfield	Gary Sambrook	74909	58.5	22.6	53.9	3.3	11.9	6.6	0	0	1.6	CON	LAB
+214	358	Edinburgh North and Leith	Deidre Brock	78178	73.1	9.1	40.3	9.7	3.6	5.4	29.3	0	2.7	NAT	LAB
+215	357	High Peak	Robert Largan	74264	72.9	25.6	56.8	3	9.3	4.3	0	0	1	CON	LAB
+216	356	Huddersfield	Barry Sheerman	75495	65.4	21.2	52.3	4.2	10.2	10.7	0	0	1.4	LAB	LAB
+217	355	Leigh and Atherton	James Grundy	76369	61.6	24.1	55	2.4	13.9	3.3	0	0	1.3	CON	LAB
+218	354	Lincoln	Karl McCartney	74943	67.6	23.6	54.4	3.6	11.4	5.4	0	0	1.6	CON	LAB
+219	353	Colne Valley	Jason McCartney	71047	72.3	23.8	53.9	4.2	12.6	4.2	0	0	1.3	CON	LAB
+220	352	Beckenham and Penge	Bob Stewart	76436	72	24.1	54.3	6	8.4	5.7	0	0	1.3	CON	LAB
+221	351	Coventry North West	Taiwo Owatemi	75247	63.5	23.4	53.4	4	11	6.7	0	0	1.5	LAB	LAB
+222	350	Stevenage	Stephen McPartland	71562	66.6	24	54	3.8	11.9	5.1	0	0	1.2	CON	LAB
+223	349	Swindon South	Robert Buckland	72559	69	24.8	54.7	3.3	11.5	4.6	0	0	1.1	CON	LAB
+224	348	Worcester	Robin Walker	73485	69.3	23.3	53.2	3.8	10.1	8.5	0	0	1.1	CON	LAB
+225	347	Doncaster Central	Rosie Winterton	75156	58.4	21.6	51.5	3.1	17.3	5	0	0	1.6	LAB	LAB
+226	346	Shrewsbury	Daniel Kawczynski	74764	71.8	23.1	52.9	5.8	11.9	5.1	0	0	1.2	CON	LAB
+227	345	Newcastle-under-Lyme	Aaron Bell	71555	65.9	23.2	52.9	3.6	14.8	4.3	0	0	1.2	CON	LAB
+228	344	Bridgend	Jamie Wallis	70710	65.4	22.4	52.1	3.5	12.3	4	4.3	0	1.4	CON	LAB
+229	343	Crewe and Nantwich	Kieran Mullan	76322	67.3	24.5	54.2	2.7	13.5	4.1	0	0	1	CON	LAB
+230	342	Warrington South	Andy Carter	76256	71.9	25.7	55.2	4.2	10.1	3.5	0	0	1.3	CON	LAB
+231	341	Bolsover	Mark Fletcher	74427	61.9	23.8	53.3	2.4	15.2	3.8	0	0	1.5	CON	LAB
+232	340	Bury South	Christian Wakeford	75131	65.2	23.9	53.4	3.2	12.7	5.1	0	0	1.7	CON	LAB
+233	339	Thanet East	Craig Mackinlay	74214	66	23.7	53	2.7	13.2	6.6	0	0	0.9	CON	LAB
+234	338	Birmingham Hodge Hill and Solihull North	Liam Byrne	77784	58.8	17.6	46.8	5.9	11.9	16.2	0	0	1.6	LAB	LAB
+235	337	Hamilton and Clyde Valley	Angela Crawley	74123	67.9	14.9	44.1	3.5	3.4	3.1	28.3	0	2.8	NAT	LAB
+236	336	Milton Keynes North	Ben Everitt	70484	68	24.1	53.2	4.5	11.3	5.5	0	0	1.4	CON	LAB
+237	335	Bedford	Mohammad Yasin	71098	66.2	24	53.2	5	9.1	7.2	0	0	1.5	LAB	LAB
+238	334	Coventry South	Zarah Sultana	72674	62.5	24.4	53.5	4.1	10.3	6.1	0	0	1.7	LAB	LAB
+239	333	Filton and Bradley Stoke	Jack Lopresti	73358	72.5	23.7	52.7	5.4	11.6	5.2	0	0	1.4	CON	LAB
+240	332	Dunfermline and Dollar	Douglas Chapman	70060	69.9	12.2	41.2	6	3.5	4.6	30	0	2.6	NAT	LAB
+241	331	Wirral West	Unknown (changed seat)	71641	76.9	26.3	55.2	4.1	9.3	3.9	0	0	1.2	CON	LAB
+242	330	Eltham and Chislehurst	Unknown (changed seat)	74030	68.2	26.3	55.1	2.8	9.3	5	0	0	1.4	CON	LAB
+243	329	Corby and East Northamptonshire	Tom Pursglove	76933	70.2	25.4	54.3	4.2	12	3.4	0	0	0.7	CON	LAB
+244	328	Luton North	Sarah Owen	73355	62.3	22.4	51.1	5.1	11	8.2	0	0	2.2	LAB	LAB
+245	327	Stroud	Siobhan Baillie	76249	77.8	24.3	53	3.4	9	9	0	0	1.3	CON	LAB
+246	326	Kingston upon Hull West and Haltemprice	Unknown (changed seat)	74518	56.7	21.3	49.9	6.6	15.6	4.3	0	0	2.3	CON	LAB
+247	325	Pembrokeshire Mid and South	Stephen Crabb	76780	71.2	22.5	51	3.6	14.6	3.5	3.4	0	1.2	CON	LAB
+248	324	Stoke-on-Trent North	Jonathan Gullis	70840	59	22.7	51.1	2.9	17.7	4.3	0	0	1.3	CON	LAB
+249	323	Camborne and Redruth	George Eustice	73101	72.3	21.9	50.2	6.6	14.8	4.9	0	0	1.5	CON	LAB
+250	322	Hastings and Rye	Sally-Ann Hart	76846	67.5	25.2	53.6	3.9	10.1	5.9	0	0	1.3	CON	LAB
+251	321	Worthing East and Shoreham	Tim Loughton	75196	70.7	24.4	52.7	3.9	12	5.9	0	0	1.1	CON	LAB
+252	320	Dagenham and Rainham	Jon Cruddas	73233	61.3	24.8	53	2.1	13.2	5.3	0	0	1.8	LAB	LAB
+253	319	Slough	Tan Dhesi	77608	58.8	19.4	47.6	6.7	11.3	12.7	0	0	2.3	LAB	LAB
+254	318	Derby North	Amanda Solloway	73198	64.2	24.3	52.5	4.8	11.3	5.3	0	0	1.8	CON	LAB
+255	317	Stoke-on-Trent Central	Jo Gideon	71444	58.7	24.6	52.7	2.6	13.7	5.2	0	0	1.2	CON	LAB
+256	316	Southport	Damien Moore	73910	68.6	22.8	50.8	8	13.6	3.6	0	0	1.2	CON	LAB
+257	315	Shipley	Philip Davies	74018	72.9	25.6	53.4	3.6	10.1	6.2	0	0	1.2	CON	LAB
+258	314	Heywood and Middleton North	Unknown (changed seat)	72636	59.3	23.4	51.3	3.6	15	5.4	0	0	1.3	LAB	LAB
+259	313	Leeds North West	Stuart Andrew	71302	73.4	25	52.7	7.4	9.3	4.1	0	0	1.5	CON	LAB
+260	312	Walsall and Bloxwich	Eddie Hughes	74080	58.3	22.4	50.1	3.7	15	7.2	0	0	1.7	CON	LAB
+261	311	East Kilbride and Strathaven	Lisa Cameron	74435	69.3	12.2	39.7	5	3.6	4.4	32.2	0	2.9	NAT	LAB
+262	310	Kensington and Bayswater	Felicity Buchan	79095	67.5	23.5	50.9	8.8	7.9	7.1	0	0	1.8	CON	LAB
+263	309	Halifax	Holly Lynch	74742	64.9	24	51.4	3.7	12.4	7.2	0	0	1.3	LAB	LAB
+264	308	Ribble South	Katherine Fletcher	71551	70.3	25.6	52.8	3.8	12.7	4	0	0	1.1	CON	LAB
+265	307	York Outer	Julian Sturdy	73271	74	21.8	49	12.8	11.3	3.5	0	0	1.6	CON	LAB
+266	306	Gloucester	Richard Graham	76123	66.5	22.7	49.9	6.3	14.1	5.4	0	0	1.6	CON	LAB
+267	305	Livingston	Hannah Bardell	74224	66.3	12.6	39.5	4.7	3.5	4.8	32.5	0	2.5	NAT	LAB
+268	304	Broxtowe	Darren Henry	71567	73.6	26.1	52.9	2.5	11.3	5	0	0	2.3	CON	LAB
+269	303	Birmingham Erdington	Jack Dromey	78252	54.1	28.6	55.3	2.1	7.5	3.9	0	1.1	1.7	LAB	LAB
+270	302	Bradford South	Judith Cummins	70607	57.6	23	49.5	3.1	13.7	9.4	0	0	1.3	LAB	LAB
+271	301	Birmingham Yardley	Jess Phillips	73100	57.2	15.3	41.6	16.7	13.6	10.3	0	0	2.6	LAB	LAB
+272	300	Bournemouth West	Conor Burns	73342	62.2	21.5	47.9	7.2	13.7	8.3	0	0	1.4	CON	LAB
+273	299	Colchester	Will Quince	75677	64.6	23.9	50.2	6.9	11.4	6.3	0	0	1.3	CON	LAB
+274	298	Penistone and Stocksbridge	Miriam Cates	70927	69.8	23.5	49.7	6.7	14.6	3.4	0	0	2.1	CON	LAB
+275	297	Redcar	Jacob Young	70725	62.3	23.8	50	4.9	15.6	3.9	0	0	1.8	CON	LAB
+276	296	Cheshire Mid	Unknown (new seat)	69411	71.6	26.3	52.5	4.2	11.3	4.3	0	0	1.2	CON	LAB
+277	295	Welwyn Hatfield	Grant Shapps	74505	69.5	24.4	50.4	6.3	11.7	5.8	0	0	1.5	CON	LAB
+278	294	Wakefield and Rothwell	Unknown (new seat)	73602	66.5	26.2	52.2	2.9	10.3	3.9	0	1.5	3	CON	LAB
+279	293	Bournemouth East	Tobias Ellwood	74219	66.5	23.6	49.5	5.5	12.3	7.8	0	0	1.2	CON	LAB
+280	292	Blackpool North and Fleetwood	Paul Maynard	75797	63.4	25.2	51	3.6	15.5	4	0	0	0.7	CON	LAB
+281	291	Great Grimsby and Cleethorpes	Lia Nici	77565	56.8	22.9	48.5	4.7	18.4	4.6	0	0	1	CON	LAB
+282	290	Erewash	Maggie Throup	72525	67.3	26.7	52.1	3.1	12.9	4.5	0	0	0.7	CON	LAB
+283	289	Luton South and South Bedfordshire	Rachel Hopkins	69998	61.2	21.2	46.4	4.9	13.8	10.6	0	0	3.1	LAB	LAB
+284	288	Bassetlaw	Brendan Clarke-Smith	76595	63.5	25.6	50.9	3	17.1	2.7	0	0	0.7	CON	LAB
+285	287	Ilford North	Wes Streeting	74670	67.3	26.5	51.5	2.6	8.7	8.8	0	0	1.8	LAB	LAB
+286	286	Oldham East and Saddleworth	Debbie Abrahams	72120	64	23	47.9	6.2	14.8	6.2	0	0	2.1	LAB	LAB
+287	285	Lancaster and Wyre	Unknown (changed seat)	75065	66.4	25.4	50	3.6	8.1	11.7	0	0	1.2	CON	LAB
+288	284	Middlesbrough South and Cleveland East	Simon Clarke	69287	65.6	25.4	49.7	4.4	16	3.8	0	0	0.8	CON	LAB
+289	283	Rossendale and Darwen	Jake Berry	74211	67	27.1	51.3	3.3	13.2	4.4	0	0	0.6	CON	LAB
+290	282	Crawley	Henry Smith	74206	67.2	26.5	50.6	3.1	12.3	6.2	0	0	1.3	CON	LAB
+291	281	Chingford and Woodford Green	Iain Duncan Smith	75340	73.2	28.1	52.2	3.7	9.1	5.2	0	0	1.8	CON	LAB
+292	280	Derbyshire North East	Lee Rowley	72212	68	27	50.9	4.4	13.2	3.9	0	0	0.7	CON	LAB
+293	279	Bolton West	Chris Green	72183	66.2	25.5	49.3	5.9	14	4.3	0	0	1	CON	LAB
+294	278	Milton Keynes Central	Iain Stewart	76559	67.3	27	50.7	5	8.8	6.6	0	0	1.9	CON	LAB
+295	277	Wolverhampton North East	Jane Stevenson	71096	55.3	25.7	49.5	3	16.2	4.8	0	0	0.8	CON	LAB
+296	276	Clwyd North	David Jones	76558	67.8	25.4	49.1	3.5	11.3	4.2	5.2	0	1.4	CON	LAB
+297	275	Bury North	James Daly	77499	67.9	27.6	51.2	3.2	11.4	5	0	0	1.5	CON	LAB
+298	274	Bathgate and Linlithgow	Martyn Day	70467	66.4	14.8	38.4	5.6	3.7	4.8	29.5	0	3.2	NAT	LAB
+299	273	Carlisle	John Stevenson	76811	67	26.5	50.1	4.5	13.7	4.4	0	0	0.8	CON	LAB
+300	272	Rother Valley	Alexander Stafford	69565	65	24.1	47.6	4.4	17.3	4.3	0	0	2.3	CON	LAB
+301	271	Macclesfield	David Rutley	76216	70.7	27.4	50.7	4.5	11.7	4.7	0	0	1	CON	LAB
+302	270	Leicester East	Claudia Webbe	76155	63	23.8	46.8	5.6	10.6	10.7	0	0	2.5	LAB	LAB
+303	269	Clwyd East	Rob Roberts	76518	68.8	26.1	48.8	4.1	12.4	3.6	3.6	0	1.4	CON	LAB
+304	268	Scarborough and Whitby	Robert Goodwill	74404	66.8	26.8	49.4	4.5	15.1	3.3	0	0	0.9	CON	LAB
+305	267	Bangor Aberconwy	Robin Millar	70127	70.5	20.5	42.8	2.5	7.3	2.6	23.3	0	1	CON	LAB
+306	266	Kilmarnock and Loudoun	Alan Brown	74517	63.9	14.1	36.5	3.8	3.4	2.9	36.3	0	2.9	NAT	LAB
+307	265	Wolverhampton West	Stuart Anderson	77127	65	28.5	50.8	3	10.8	5.3	0	0	1.5	CON	LAB
+308	264	Basingstoke	Maria Miller	77260	66.4	26	48.2	5.6	12.4	6.3	0	0	1.5	CON	LAB
+309	263	Bolton North East	Mark Logan	77252	63.7	26.7	49	3.9	13.1	5.5	0	0	1.7	CON	LAB
+310	262	Watford	Dean Russell	70110	69.7	24.9	47.1	11	9.1	5.7	0	0	2.2	CON	LAB
+310	261	Orkney and Shetland	Alistair Carmichael	34210	67.7	3.2	25.4	42.2	3.5	3.2	19.5	0	3	LIB	LIB
+311	261	Hitchin	Bim Afolami	71857	75.1	25.7	47.8	9.3	11.3	4.5	0	0	1.4	CON	LAB
+312	260	Scunthorpe	Holly Mumby-Croft	73696	61.7	27.1	49.1	3	15.9	4.1	0	0	0.8	CON	LAB
+313	259	Truro and Falmouth	Cherilyn Mackrory	72935	76.8	26.1	48.1	7.5	10.9	6	0	0	1.4	CON	LAB
+314	258	Rushcliffe	Ruth Edwards	75883	78.5	27.9	49.9	7.5	8.9	4.2	0	0	1.6	CON	LAB
+315	257	Hexham	Guy Opperman	72603	74.2	26.7	48.6	6.4	12.3	4.8	0	0	1.2	CON	LAB
+316	256	Monmouthshire	David Davies	72681	72.5	27.2	49.2	4.7	12.1	4.8	0.8	0	1.2	CON	LAB
+317	255	Morecambe and Lunesdale	David Morris	76057	69.2	25.6	47.5	8.2	13.3	4.4	0	0	1.1	CON	LAB
+318	254	Wrexham	Sarah Atherton	70870	67.4	26.5	48.4	3.2	10.9	3.5	5.9	0	1.5	CON	LAB
+319	253	Doncaster East and the Isle of Axholme	Nick Fletcher	70027	61.5	25.8	47.6	3	18	4.1	0	0	1.5	CON	LAB
+320	252	Hendon	Matthew Offord	72939	66.6	28.2	50	3.7	8.5	7.8	0	0	1.9	CON	LAB
+321	251	Hyndburn	Sara Britcliffe	70839	59.9	26.7	48.4	3.5	13.9	5.9	0	0	1.6	CON	LAB
+322	250	Dover and Deal	Natalie Elphicke	76985	66.4	28	49.6	3.5	13.7	4.5	0	0	0.8	CON	LAB
+323	249	Chipping Barnet	Theresa Villiers	77717	71.3	30.4	51.5	3.2	7.6	5.8	0	0	1.4	CON	LAB
+324	248	West Bromwich	Nicola Richards	71963	57.4	27.6	48.6	2.6	13.2	6.2	0	0	1.7	CON	LAB
+325	247	Telford	Lucy Allan	70351	62.3	27	47.9	3.3	16.4	4.5	0	0	0.9	CON	LAB
+326	246	Cities of London and Westminster	Nickie Aiken	74448	66.8	24.4	45.2	12.7	8.2	7.6	0	0	1.9	CON	LAB
+327	245	Ossett and Denby Dale	Imran Ahmad-Khan	71264	65.2	28.3	49	2.3	8.7	2.9	0	3.8	5.1	CON	LAB
+328	244	Burnley	Antony Higginbotham	74722	61.6	24.5	45.1	6.1	15.2	7.5	0	0	1.6	CON	LAB
+329	243	Peterborough	Paul Bristow	71663	65.9	26.4	46.8	4.7	13.3	6.6	0	0	2.2	CON	LAB
+330	242	Penrith and Solway	Mark Jenkinson	77207	68.9	27.4	47.7	5.6	14.1	4.3	0	0	0.9	CON	LAB
+331	241	Stockton West	Matt Vickers	69969	70.1	27.3	47.6	5.6	15.2	3.3	0	0	1	CON	LAB
+332	240	Keighley and Ilkley	Robbie Moore	72788	72.3	28.8	49.1	4	10.5	6	0	0	1.6	CON	LAB
+333	239	Dewsbury and Batley	Unknown (changed seat)	69626	68.3	24.5	44.7	4.2	10.9	8.6	0	4.4	2.8	LAB	LAB
+334	238	Chelsea and Fulham	Greg Hands	78943	69.7	28	48.2	8.3	7.6	6	0	0	1.9	CON	LAB
+335	237	Banbury	Victoria Prentis	69699	70.5	27.5	47.5	7.1	11.5	5.2	0	0	1.2	CON	LAB
+336	236	Hemel Hempstead	Mike Penning	70036	69.9	25.7	45.6	8.9	13	5.4	0	0	1.4	CON	LAB
+336	235	Mid Dunbartonshire	Amy Callaghan	73389	79.1	7.2	27	31.9	3.5	4	23.5	0	2.9	NAT	LIB
+337	235	Plymouth Moor View	Johnny Mercer	73457	64	25.4	45.1	4.8	18.4	5.2	0	0	1.1	CON	LAB
+337	234	Sheffield Hallam	Olivia Blake	76154	77.1	13.6	33.2	40.9	7.7	3.7	0	0	0.9	LAB	LIB
+338	234	Rugby	Mark Pawsey	72566	70.3	27.9	47.3	6	13.2	4.7	0	0	0.9	CON	LAB
+339	233	Edinburgh South West	Joanna Cherry	73516	70.9	14.6	33.7	7	3.6	5	33.1	0	2.9	NAT	LAB
+340	232	Croydon South	Chris Philp	71305	70.4	28.3	47.2	6.4	10.8	5.4	0	0	1.9	CON	LAB
+341	231	Buckingham and Bletchley	Unknown (new seat)	73799	70.8	27.9	46.6	6.5	12.6	4.9	0	0	1.5	CON	LAB
+342	230	Sherwood Forest	Mark Spencer	76676	67.9	26.2	44.6	5.4	17.9	4.6	0	0	1.3	CON	LAB
+343	229	Stafford	Theo Clarke	69680	70.8	29.8	48	4	11.4	6.2	0	0	0.6	CON	LAB
+344	228	Ynys Mon (Anglesey)	Virginia Crosbie	51927	70.4	17.7	35.6	1.2	7.3	1.8	35.5	0	1	CON	LAB
+345	227	Thurrock	Jackie Doyle-Price	72679	59.6	26.2	44.1	4.2	18.3	5.7	0	0	1.6	CON	LAB
+346	226	Altrincham and Sale West	Graham Brady	73107	74.9	29.6	47.2	6.2	7.8	7.7	0	0	1.6	CON	LAB
+347	225	Wellingborough and Rushden	Peter Bone	77190	64.7	25.8	43.2	5.9	15.6	4.5	0	1.8	3.2	CON	LAB
+348	224	Weston-super-Mare	John Penrose	69967	67.4	27	44.4	8	14.9	4.9	0	0	0.8	CON	LAB
+348	223	Edinburgh West	Christine Jardine	75666	75	9.4	26.4	35	3.4	4.4	18.8	0	2.5	LIB	LIB
+349	223	Montgomeryshire and Glyndwr	Craig Williams	74118	69	25.7	42.6	9.7	15.1	3.7	1.8	0	1.5	CON	LAB
+350	222	Northampton South	Andrew Lewer	71109	68.6	28.4	45.2	6.9	13.4	5.1	0	0	1.1	CON	LAB
+350	221	Alloa and Grangemouth	John Nicolson	70834	69.8	16.1	32.9	4	3.6	4.1	36.4	0	2.9	NAT	NAT
+351	221	Somerset North	Liam Fox	73346	77.4	27.7	44.5	8.2	11.8	6.7	0	0	1.1	CON	LAB
+352	220	Lowestoft	Peter Aldous	75537	61.8	27	43.7	4.6	15.8	7.8	0	0	1.1	CON	LAB
+353	219	Pendle and Clitheroe	Andrew Stephenson	76246	68.6	27.2	43.8	7.5	14.8	5.7	0	0	1.1	CON	LAB
+354	218	Aylesbury	Rob Butler	76209	71.4	24.6	41.2	14.1	12.5	5.8	0	0	1.9	CON	LAB
+354	217	Fife North East	Unknown (changed seat)	70255	73.7	6	22.4	36.6	3.2	2.8	26.6	0	2.4	NAT	LIB
+355	217	Bromley and Biggin Hill	Bob Neill	70212	70.5	29.1	45.4	7.8	11.6	5.1	0	0	1.1	CON	LAB
+356	216	Southend East and Rochford	James Duddridge	70283	61.3	26.6	42.7	5.6	18.3	5.2	0	0	1.6	CON	LAB
+357	215	Isle of Wight West	Unknown (new seat)	55555	65.9	26.4	42.5	4.4	15	10.8	0	0	1	CON	LAB
+357	214	Aberdeen North	Kirsty Blackman	76515	63.5	15.2	31.3	6.1	3.5	4.2	36.8	0	2.8	NAT	NAT
+358	214	Harrow East	Bob Blackman	77127	67.7	29.7	45.5	4.5	11	7	0	0	2.4	CON	LAB
+359	213	Selby	Nigel Adams	74457	72	31.9	47.6	3.2	8.9	4.3	0	2.1	2.1	CON	LAB
+360	212	Worthing West	Peter Bottomley	76124	70.2	29.7	45.4	5.9	12.9	5.3	0	0	0.8	CON	LAB
+361	211	Ashfield	Lee Anderson	69549	62.7	15.3	30.9	2.9	17.6	3.1	0	27.6	2.7	CON	LAB
+362	210	Isle of Wight East	Bob Seely	57470	65.9	26.7	42.2	4.5	17.8	7.8	0	0	1.1	CON	LAB
+362	209	Falkirk	Johnny McNally	73900	66.2	15.4	30.8	5.3	3.6	5.3	36.8	0	2.7	NAT	NAT
+363	209	Portsmouth North	Penny Mordaunt	71298	64.4	25.6	40.8	7.8	18.5	5.7	0	0	1.7	CON	LAB
+364	208	Somerset North East and Hanham	Jacob Rees-Mogg	72940	74.2	30.4	45.6	6.3	12	4.8	0	0	0.8	CON	LAB
+364	207	Caithness Sutherland and Easter Ross	Unknown (changed seat)	74896	69.3	9.7	24.9	29.6	3.6	3.4	25.6	0	3.1	NAT	LIB
+365	207	Norfolk South	Richard Bacon	69725	71.7	28.8	43.9	9.6	12.1	4.7	0	0	0.9	CON	LAB
+366	206	Nuneaton	Marcus Jones	70225	64.3	28.1	42.9	5	16	6.7	0	0	1.3	CON	LAB
+367	205	Devon Central	Mel Stride	73137	77.5	26.7	41.4	12.3	12	6.7	0	0	0.9	CON	LAB
+368	204	Hertfordshire North East	Oliver Heald	76123	72.7	29.9	44.5	7.6	11.1	6	0	0	0.8	CON	LAB
+369	203	Hertford and Stortford	Julie Marson	74993	73.5	29.1	43.7	6.5	8.8	11.1	0	0	0.8	CON	LAB
+369	202	Inverness, Skye and West Ross-shire	Drew Hendry	77420	71.3	13.3	27.9	13	3.7	4.6	34.3	0	3.1	NAT	NAT
+370	202	Halesowen	James Morris	70183	63	27.8	42.3	5.1	18	5.4	0	0	1.4	CON	LAB
+371	201	Suffolk Coastal	Therese Coffey	73982	71.2	27.8	42.3	9.4	11.6	8	0	0	1	CON	LAB
+372	200	Wycombe	Steve Baker	71214	70.1	29.1	43.6	7.6	10.2	7.1	0	0	2.4	CON	LAB
+373	199	Dunstable and Leighton Buzzard	Andrew Selous	74095	66.7	26.4	40.7	9.5	16.1	5.9	0	0	1.5	CON	LAB
+374	198	St Austell and Newquay	Steve Double	74107	69.8	26.8	40.3	9.8	17.3	4.7	0	0	1.2	CON	LAB
+375	197	Derbyshire Mid	Pauline Latham	70483	73.3	28.5	42	8.2	13.6	6.4	0	0	1.2	CON	LAB
+376	196	Bexleyheath and Crayford	David Evennett	68825	65.6	29	42.4	5.1	16.4	5.5	0	0	1.7	CON	LAB
+377	195	Kettering	Philip Hollobone	76557	67.6	27.5	40.8	7.3	15.8	6.9	0	0	1.7	CON	LAB
+378	194	Harborough, Oadby and Wigston	Neil O'Brien	74366	71.5	26.9	40.1	14.4	11.5	5.9	0	0	1.2	CON	LAB
+378	193	Ayrshire North and Arran	Patricia Gibson	73534	65.5	19.3	32.4	3.2	3.5	4.8	34	0	2.7	NAT	NAT
+379	193	Swindon North	Justin Tomlinson	72058	66.9	29.6	42.7	5.3	15.3	5.9	0	0	1.1	CON	LAB
+380	192	Folkestone and Hythe	Damian Collins	69793	66.8	29.8	42.8	4.9	12.2	9.6	0	0	0.7	CON	LAB
+381	191	Earley and Woodley	Unknown (new seat)	70472	72.6	29.7	42.7	10.4	8.9	6.4	0	0	1.9	CON	LAB
+382	190	Bracknell	James Sunderland	69872	69.1	31.7	44.7	5.1	11.9	5.6	0	0	0.8	CON	LAB
+383	189	Dorset South	Richard Drax	77420	69.5	25.8	38.2	10.8	16.8	7	0	0	1.4	CON	LAB
+384	188	Rochester and Strood	Kelly Tolhurst	71774	63.3	28.9	41.4	4.5	18.1	5.7	0	0	1.4	CON	LAB
+385	187	Reading West and Mid Berkshire	Alok Sharma	69675	69.6	30.4	42.8	9.1	11.3	5.4	0	0	1	CON	LAB
+386	186	Hertfordshire South West	Gagan Mohindra	71163	74.1	28.2	40.5	8.6	13.1	5.7	0	0	4	CON	LAB
+387	185	Leicestershire North West	Andrew Bridgen	74791	68.2	29.4	41.5	5.8	16.5	5.6	0	0	1.2	CON	LAB
+388	184	Derbyshire South	Heather Wheeler	70152	67.3	30.9	42.9	4.7	15.5	5	0	0	1	CON	LAB
+389	183	Forest of Dean	Mark Harper	71437	72.1	27.9	39.8	3.9	14	13.2	0	0	1.2	CON	LAB
+390	182	Derbyshire Dales	Sarah Dines	71145	75.6	28.2	40.1	10.8	13.8	5.8	0	0	1.2	CON	LAB
+391	181	Stourbridge	Suzanne Webb	70361	63.9	28.8	40.6	5.8	17.6	5.7	0	0	1.5	CON	LAB
+392	180	Northumberland North	Anne-Marie Trevelyan	72484	68.9	28.2	39.8	12.8	13.9	4.4	0	0	0.8	CON	LAB
+393	179	Huntingdon	Jonathan Djanogly	75121	69.3	29.3	40.9	10.2	13.6	4.9	0	0	1.1	CON	LAB
+394	178	Dartford	Gareth Johnson	71324	65.7	29.6	41.1	6	15.9	6	0	0	1.4	CON	LAB
+395	177	Rochdale	Tony Lloyd	70809	60.1	16.4	27.8	5.8	11.5	4.9	0	19.8	13.8	LAB	LAB
+396	176	Beverley and Holderness	Graham Stuart	71221	67.2	27	38.3	11.3	16.9	4.7	0	0	1.8	CON	LAB
+397	175	Chichester	Gillian Keegan	76286	70.8	27	38	14.9	13.3	5.7	0	0	1	CON	LAB
+398	174	Harwich and North Essex	Bernard Jenkin	75459	69.5	28.5	39.5	9	16.1	5.6	0	0	1.4	CON	LAB
+399	173	Ayrshire Central	Philippa Whitford	69742	66.7	22.2	33	3.6	3.4	3.2	31.6	0	2.8	NAT	LAB
+400	172	Tatton	Esther McVey	75992	71.1	30.1	40.9	10.4	13.2	4.5	0	0	0.9	CON	LAB
+401	171	Windsor	Adam Afriyie	73998	69.6	29.7	40.3	9.2	12.9	6.2	0	0	1.9	CON	LAB
+402	170	Mansfield	Ben Bradley	74411	63.9	32.6	43.1	2.5	16.7	4.2	0	0	0.9	CON	LAB
+402	169	Ceredigion Preseli	Ben Lake	74308	71.1	14	24.4	5.8	8.3	2.3	44.4	0	0.8	NAT	NAT
+403	169	Aldershot	Leo Docherty	77531	66.6	30.9	41.2	8.1	13.1	5.8	0	0	1	CON	LAB
+404	168	Spen Valley	Unknown (changed seat)	71601	67	30.6	40.9	3.7	7.3	2.5	0	11	4	CON	LAB
+405	167	Gillingham and Rainham	Rehman Chishti	73549	62.5	30.7	40.9	4.6	16.5	5.8	0	0	1.4	CON	LAB
+405	166	Carmarthen	Unknown (changed seat)	72404	71.3	20.3	30.5	1.1	5.8	1.6	39.9	0	0.8	CON	NAT
+406	166	Uxbridge and South Ruislip	Boris Johnson	74828	69.1	36.3	46.2	2.8	6.1	4.5	0	1.2	2.9	CON	LAB
+407	165	Burton and Uttoxeter	Kate Griffiths	75038	64.9	30.9	40.8	4.8	16.8	5.6	0	0	1.1	CON	LAB
+408	164	Cambridgeshire North West	Shailesh Vara	72889	68	28.3	37.8	9.3	15.7	7.4	0	0	1.5	CON	LAB
+408	163	Arbroath and Broughty Ferry	Stewart Hosie	75106	68.1	19.2	28.6	5.7	3.5	3.2	36.8	0	3	NAT	NAT
+409	163	Renfrewshire East	Kirsten Oswald	72232	76.6	22.6	31.8	5.6	3.5	3.3	30.4	0	2.9	NAT	LAB
+410	162	Kenilworth and Southam	Jeremy Wright	70364	76.6	30.1	39.3	12.4	10.9	6.3	0	0	1	CON	LAB
+411	161	Broadland and Fakenham	Jerome Mayhew	72907	72.9	27.1	36.1	14.6	14.8	5.9	0	0	1.5	CON	LAB
+412	160	Ruislip, Northwood and Pinner	David Simmonds	72003	71.9	32.6	41.5	7.9	10.7	5.9	0	0	1.5	CON	LAB
+413	159	Poole	Robert Syms	71928	68.1	26.6	35.2	13.5	18	5.3	0	0	1.5	CON	LAB
+413	158	Dwyfor Meirionnydd	Liz Saville Roberts	72047	68	9.3	17.9	0.9	5.1	1	65.3	0	0.5	NAT	NAT
+414	158	Congleton	Fiona Bruce	69884	70.7	29.9	38.5	9.8	15.8	4.7	0	0	1.3	CON	LAB
+415	157	Gravesham	Adam Holloway	73240	64.9	31.7	40.2	4.2	16.4	6.2	0	0	1.2	CON	LAB
+416	156	Salisbury	John Glen	69961	71.9	29.8	38.2	13.2	12.9	5	0	0	1	CON	LAB
+417	155	Bridgwater	Ian Liddell-Grainger	71290	69.1	29.4	37.4	12.5	15.6	4.2	0	0	0.9	CON	LAB
+418	154	Dudley	Marco Longhi	71755	59.4	32.6	40.4	3	16.8	6.1	0	0	1.1	CON	LAB
+419	153	Ribble Valley	Nigel Evans	75219	70	31.8	39.5	7.1	15.5	4.7	0	0	1.3	CON	LAB
+420	152	Ayr Carrick and Cumnock	Allan Dorans	71971	64.7	25.2	32.8	3.4	3.5	3.3	29	0	2.9	NAT	LAB
+421	151	Bedfordshire North	Richard Fuller	76467	71.7	29	36.5	10.6	17	5.1	0	0	1.8	CON	LAB
+422	150	Chester South and Eddisbury	Edward Timpson	71875	71.6	30	37.6	11.7	14.8	4.5	0	0	1.4	CON	LAB
+423	149	Ashford	Damian Green	73390	67	30.5	37.9	6.1	14.1	10.3	0	0	1.2	CON	LAB
+423	148	Aberdeen South	Stephen Flynn	76047	67.9	21.5	28.8	7.9	3.5	3.8	31.4	0	3	NAT	NAT
+424	148	St Neots and Mid Cambridgeshire	Unknown (new seat)	74372	73.2	26.3	33.6	23.9	11.1	4	0	0	1.1	CON	LAB
+425	147	Didcot and Wantage	David Johnston	73642	74	25.2	32.4	27.5	9.9	4	0	0	1	CON	LAB
+426	146	Reigate	Crispin Blunt	75944	71.9	31.4	38.6	10.1	10.4	8.5	0	0	1	CON	LAB
+427	145	Tewkesbury	Laurence Robertson	72556	72.4	28.8	35.8	15.9	12.9	5.7	0	0	0.9	CON	LAB
+428	144	Hereford and South Herefordshire	Jesse Norman	71233	68.9	27.7	34.7	12.6	16.8	6.9	0	0	1.3	CON	LAB
+429	143	Devon South West	Gary Streeter	75337	73.6	29	35.9	11.9	16.1	5.8	0	0	1.3	CON	LAB
+430	142	Finchley and Golders Green	Mike Freer	77742	71	31.3	38.1	16.6	7.5	5.4	0	0	1.1	CON	LAB
+431	141	Leicestershire Mid	Edward Argar	75557	69.8	31.5	38.1	7.6	15	6.4	0	0	1.3	CON	LAB
+432	140	Wiltshire South West	Andrew Murrison	71331	70.6	26.9	33.3	15.4	17.2	5.7	0	0	1.5	CON	LAB
+433	139	Spelthorne	Kwasi Kwarteng	70929	69.8	29.6	35.8	10.3	15.7	7.1	0	0	1.5	CON	LAB
+433	138	Wimbledon	Stephen Hammond	74718	77.1	24.7	30.7	33.2	6.7	3.6	0	0	1.1	CON	LIB
+434	138	Amber Valley	Nigel Mills	70045	65.1	35.2	41.2	2.9	13.6	6.2	0	0	0.7	CON	LAB
+435	137	Maidstone and Malling	Helen Grant	72955	68	28	34	15	15.2	6.3	0	0	1.6	CON	LAB
+436	136	Suffolk Central and Ipswich North	Dan Poulter	72161	70.2	31.2	37.1	7.3	12.6	10.7	0	0	1.2	CON	LAB
+437	135	Melton and Syston	Unknown (new seat)	72307	70	31.1	36.8	7	15.4	8.4	0	0	1.3	CON	LAB
+438	134	Bedfordshire Mid	Nadine Dorries	70946	73.7	30.7	36.4	15.1	10.3	3.6	0	2.3	1.6	CON	LAB
+439	133	Sutton Coldfield	Andrew Mitchell	75638	69.2	31.8	37.4	9.4	14.5	5.5	0	0	1.4	CON	LAB
+440	132	Bury St Edmunds and Stowmarket	Jo Churchill	76811	68.6	30.7	36.2	4.2	12.6	15.1	0	0	1.3	CON	LAB
+441	131	Hartlepool	Mike Hill	70854	57.9	33.8	39.2	2.7	12.6	2.8	0	4.9	4	LAB	LAB
+442	130	Harlow	Robert Halfon	73339	64.3	34.5	39.7	4	15	5.6	0	0	1.2	CON	LAB
+443	129	Suffolk South	James Cartlidge	72700	70.2	30.1	35.2	9.6	14	10	0	0	1.1	CON	LAB
+443	128	Argyll, Bute and South Lochaber	Brendan O'Hara	70737	72.3	21.7	26.7	12	3.5	3.4	29.7	0	3	NAT	NAT
+444	128	Skipton and Ripon	Julian Smith	76159	74.6	29.4	34.2	13	15.6	6.4	0	0	1.4	CON	LAB
+445	127	Hampshire North West	Kit Malthouse	75968	70.8	28.9	33.6	14.9	15.2	5.8	0	0	1.6	CON	LAB
+446	126	Orpington	Gareth Bacon	71351	70.3	32.2	36.9	9.2	14.5	5.6	0	0	1.6	CON	LAB
+446	125	Stirling and Strathallan	Alyn Smith	75296	76.5	22.4	26.9	4.2	3.6	4.5	35.7	0	2.8	NAT	NAT
+447	125	Surrey East	Claire Coutinho	72655	71.8	31.5	35.8	11.8	14.6	5	0	0	1.2	CON	LAB
+448	124	Cornwall South East	Sheryll Murray	71359	74.7	28.6	32.8	14.6	17.7	4.9	0	0	1.4	CON	LAB
+449	123	Warwickshire North and Bedworth	Craig Tracey	70270	65.3	34.4	38.6	3.8	16.3	5.8	0	0	1.1	CON	LAB
+450	122	Waveney Valley	Unknown (new seat)	71189	70.2	30.4	34.5	7.4	12.3	14.3	0	0	1.1	CON	LAB
+451	121	Stoke-on-Trent South	Jack Brereton	69994	64.6	34.3	38.2	5.3	15.8	5.2	0	0	1.2	CON	LAB
+452	120	Fareham and Waterlooville	Suella Braverman	76845	72.8	29	32.4	15.6	16	5.6	0	0	1.5	CON	LAB
+453	119	Bicester and Woodstock	Unknown (new seat)	70137	72.3	27.9	31.3	24.3	11	4.6	0	0	0.9	CON	LAB
+454	118	Southend West and Leigh	David Amess	77112	66.7	34.1	37.1	7.2	14.4	4.6	0	0	2.7	CON	LAB
+454	117	Chelmsford	Vicky Ford	76077	71	26.3	29.2	29.9	10.8	3	0	0	0.7	CON	LIB
+455	117	Meriden and Solihull East	Saqib Bhatti	74917	65.2	31.1	33.9	11.4	13.8	8.4	0	0	1.4	CON	LAB
+456	116	Cotswolds North	Unknown (new seat)	70809	74.8	29.1	31.9	16.8	14.3	6.5	0	0	1.3	CON	LAB
+456	115	Bath	Wera Hobhouse	73515	76.9	15.5	18.1	54.9	7.4	3.5	0	0	0.7	LIB	LIB
+457	115	Great Yarmouth	Brandon Lewis	71956	60.4	35	37.7	3.1	17.1	6	0	0	1.1	CON	LAB
+458	114	Tamworth	Christopher Pincher	73523	64.5	38.6	41.1	2.5	11.2	3.5	0	1.1	2	CON	LAB
+459	113	Staffordshire Moorlands	Karen Bradley	72269	67.4	36.4	38.8	3.7	15.1	5.2	0	0	0.8	CON	LAB
+460	112	Cannock Chase	Amanda Milling	74815	61.9	35.5	37.6	2.3	15	8.6	0	0	0.9	CON	LAB
+461	111	Harpenden and Berkhamsted	Unknown (new seat)	71327	76	28.2	30.1	25.7	10.5	3.5	0	0	2	CON	LAB
+462	110	Torridge and Tavistock	Geoffrey Cox	74621	74.3	29	30.9	14.7	18.4	5.7	0	0	1.2	CON	LAB
+463	109	Newark	Robert Jenrick	76720	71.8	35.1	37	6.3	15.1	5.4	0	0	1.1	CON	LAB
+464	108	Worcestershire West	Harriett Baldwin	76241	75.5	30.4	32.2	14.1	15.3	6.8	0	0	1.1	CON	LAB
+465	107	Devon South	Anthony Mangnall	72090	74.6	27.2	29	27.2	12.3	3.5	0	0	0.8	CON	LAB
+466	106	Torbay	Kevin Foster	76019	67.3	24.8	26.6	24.2	18.3	4.7	0	0	1.5	CON	LAB
+467	105	Chatham and Aylesford	Tracey Crouch	74212	60.9	35.8	37.4	3.9	14.9	6.8	0	0	1.2	CON	LAB
+468	104	Ely and East Cambridgeshire	Lucy Frazer	76033	72.5	27.2	28.7	28.4	11.4	3.2	0	0	1	CON	LAB
+469	103	Sussex Weald	Nus Ghani	69515	73.2	30.8	32.3	13.2	13.7	8.7	0	0	1.3	CON	LAB
+470	102	Hamble Valley	Unknown (new seat)	76428	71.7	29.7	30.8	18.5	14.4	5	0	0	1.6	CON	LAB
+470	101	Oxford West and Abingdon	Layla Moran	71526	75.1	22.1	23.1	43.3	6.9	3.8	0	0	0.8	LIB	LIB
+471	101	Wrekin, The	Mark Pritchard	75745	69	35.9	36.8	5.1	15	6.1	0	0	1.1	CON	LAB
+472	100	Sevenoaks	Laura Trott	73255	70.6	30.7	31.5	14.9	15.4	5.7	0	0	1.8	CON	LAB
+473	99	Epsom and Ewell	Chris Grayling	77463	73.6	31.1	31.7	19	13.1	4.2	0	0	1	CON	LAB
+474	98	Fylde	Mark Menzies	74016	70	35.4	36	5.8	16.2	5.4	0	0	1.2	CON	LAB
+475	97	Gainsborough	Edward Leigh	74306	66.9	34.5	35	8.7	15.7	4.5	0	0	1.5	CON	LAB
+476	96	Dumfries and Galloway	Alister Jack	76172	69.1	29.4	29.8	4.5	3.5	3.6	26.1	0	3.1	CON	LAB
+477	95	Herne Bay and Sandwich	Roger Gale	75704	66.7	35.7	35.9	4.8	15.2	7.2	0	0	1.1	CON	LAB
+478	94	Stratford-on-Avon	Nadhim Zahawi	72318	74.3	28.7	28.8	21.6	14	5.7	0	0	1.4	CON	LAB
+479	93	Essex North West	Kemi Badenoch	76643	72.5	31.2	31.2	14.4	16.5	5.4	0	0	1.3	CON	LAB
+479	92	Perth and Kinross-shire	Pete Wishart	75339	74	25.4	25.2	5.7	3.6	3.6	33.3	0	3.2	NAT	NAT
+480	92	Basildon South and East Thurrock	Stephen Metcalfe	73037	60.7	35	34.8	3.7	19.4	5.3	0	0	1.8	CON	CON
+481	91	Bridlington and the Wolds	Greg Knight	72681	65.4	34	33.8	6.1	19.1	5.5	0	0	1.4	CON	CON
+482	90	Redditch	Rachel Maclean	69775	67.7	37	36.8	4.2	14.7	6.2	0	0	1.1	CON	CON
+482	89	Kingston and Surbiton	Ed Davey	75437	74.6	17.9	17.7	51.7	7.9	3.7	0	0	1	LIB	LIB
+483	89	Horsham	Jeremy Quin	76767	73	28.6	28.2	28	10.7	3.8	0	0	0.7	CON	CON
+484	88	Newton Abbot	Anne Marie Morris	72392	72.5	27.5	27	27.2	14.3	3.3	0	0	0.6	CON	CON
+485	87	Arundel and South Downs	Andrew Griffith	76681	74.2	32	31.5	12.8	11.3	11.2	0	0	1.2	CON	CON
+486	86	Romford	Andrew Rosindell	73812	65.3	36.5	36	4.3	15	6.7	0	0	1.5	CON	CON
+486	85	Cambridgeshire South	Anthony Browne	75311	75.4	26.8	26.2	35.6	7.6	2.8	0	0	1	CON	LIB
+487	85	Sussex Mid	Mims Davies	72208	74	29.7	29.1	26.7	8.3	5.1	0	0	1.1	CON	CON
+487	84	Twickenham	Munira Wilson	77386	76	21	20.4	48.7	6.2	2.8	0	0	0.9	LIB	LIB
+488	84	Frome and East Somerset	Unknown (new seat)	70040	75.8	28	27.2	27.2	10.2	6.2	0	0	1.2	CON	CON
+489	83	Bromsgrove	Sajid Javid	75078	72.3	37.1	36.1	6.3	14.2	5.3	0	0	1	CON	CON
+490	82	Gosport	Caroline Dinenage	73541	65.9	34.6	33.6	8.1	15.4	6.9	0	0	1.4	CON	CON
+491	81	Wyre Forest	Mark Garnier	78076	64.8	36	34.8	5.6	16	6.4	0	0	1.1	CON	CON
+492	80	Norfolk Mid	George Freeman	71200	68.2	36.1	34.8	6.7	15.8	5.2	0	0	1.3	CON	CON
+493	79	Bognor Regis and Littlehampton	Nick Gibb	76860	66.6	35.1	33.8	7	16.4	6.4	0	0	1.3	CON	CON
+493	78	Eastleigh	Paul Holmes	69813	72.5	26	24.6	33.7	11.5	3.2	0	0	0.9	CON	LIB
+494	78	Hinckley and Bosworth	Luke Evans	75165	69.1	33.4	31.9	13.4	14.5	5.5	0	0	1.4	CON	CON
+494	77	Hazel Grove	William Wragg	73970	69	28.1	26.6	32	9.8	2.7	0	0	0.8	CON	LIB
+495	77	Stone, Great Wyrley and Penkridge	Unknown (new seat)	70181	69.6	36.8	35.3	4.9	16.4	5.4	0	0	1.1	CON	CON
+496	76	Suffolk West	Matt Hancock	77063	64.5	35.8	34	5	17.1	7	0	0	1.1	CON	CON
+497	75	Dumfriesshire, Clydesdale and Tweeddale	David Mundell	70255	71.7	31.2	29.3	5.3	3.6	3.7	23.7	0	3.2	CON	CON
+498	74	Broxbourne	Charles Walker	75559	64.7	36.4	34.3	5.8	14.8	7.3	0	0	1.4	CON	CON
+499	73	Leicestershire South	Alberto Costa	75166	71.4	36.6	34.4	7.4	14.2	6.1	0	0	1.3	CON	CON
+500	72	Runnymede and Weybridge	Ben Spencer	74090	70.6	32.5	30.3	20.3	11.9	4.3	0	0	0.8	CON	CON
+501	71	Tunbridge Wells	Greg Clark	74822	73	31.7	29.4	24	11.2	3	0	0	0.6	CON	CON
+502	70	Hampshire East	Damian Hinds	69715	73.9	31.7	29.3	17.9	13.3	6.2	0	0	1.5	CON	CON
+502	69	Moray West, Nairn and Strathspey	Unknown (changed seat)	75420	69.2	28.6	26.1	4.3	3.8	4.5	29.4	0	3.4	NAT	NAT
+503	69	Solihull West and Shirley	Julian Knight	71171	69.2	33.1	30.7	13.5	13	8.3	0	0	1.3	CON	CON
+504	68	Faversham and Kent Mid	Helen Whately	71738	67.9	36.6	34.1	6.2	13.6	8.3	0	0	1.2	CON	CON
+505	67	Basildon and Billericay	John Baron	76681	62.9	37.8	35.2	4.3	15.1	6.4	0	0	1.2	CON	CON
+505	66	St Albans	Daisy Cooper	70565	78.1	22.9	20.3	45.4	6.9	3.6	0	0	0.9	LIB	LIB
+506	66	Lichfield	Michael Fabricant	74665	70.4	38.2	35.6	5.4	14	5.7	0	0	1.1	CON	CON
+507	65	Henley and Thame	John Howell	70107	76.7	30.1	27.4	26.1	9.2	6.4	0	0	0.8	CON	CON
+507	64	Sutton and Cheam	Paul Scully	71645	70.3	28.5	25.7	30.5	10.4	3.8	0	0	1.1	CON	LIB
+508	64	Hornchurch and Upminster	Julia Lopez	76844	66.8	37.9	35.2	3.1	17.2	5.7	0	0	1	CON	CON
+509	63	Bexhill and Battle	Huw Merriman	70305	71.8	36.5	33.6	6.9	15	7	0	0	1	CON	CON
+510	62	Sittingbourne and Sheppey	Gordon Henderson	76885	61.2	37.2	34.3	3.5	17.5	6.3	0	0	1.3	CON	CON
+511	61	Norfolk North West	James Wild	75586	64.7	37.4	34.5	4.5	16.3	6.3	0	0	1	CON	CON
+512	60	Hampshire North East	Ranil Jayawardena	75361	74.3	33	30	15.4	15	5	0	0	1.7	CON	CON
+513	59	Aberdeenshire West and Kincardine	Andrew Bowie	72640	73.4	28.5	25.5	9.1	3.6	3.7	26.5	0	3.2	CON	CON
+514	58	Goole and Pocklington	David Davis	76519	67.8	36.8	33.7	6.2	16.1	5.7	0	0	1.4	CON	CON
+515	57	Grantham and Bourne	Gareth Davies	72168	69.1	36.7	33.6	6	15.8	6.7	0	0	1.1	CON	CON
+515	56	Dorking and Horley	Paul Beresford	70013	75.1	28.7	25.6	29.2	11.1	4.4	0	0	1	CON	LIB
+516	56	Daventry	Chris Heaton-Harris	76041	73.6	36.6	33.4	8.2	14.2	6.3	0	0	1.3	CON	CON
+516	55	Angus and Perthshire Glens	Dave Doogan	75151	70.1	27.4	24	4	3.5	3.5	34.4	0	3.1	NAT	NAT
+517	55	East Grinstead and Uckfield	Unknown (new seat)	72092	73.8	34	30.6	12.1	12.8	9.2	0	0	1.2	CON	CON
+518	54	Northamptonshire South	Andrea Leadsom	76174	73.1	37.2	33.8	7.7	14	6	0	0	1.3	CON	CON
+519	53	Havant	Alan Mak	72102	63.7	36.4	32.9	6.9	15.5	7	0	0	1.3	CON	CON
+519	52	Harrogate and Knaresborough	Andrew Jones	75382	73	27.2	23.5	34.8	11.1	2.5	0	0	1	CON	LIB
+520	52	Wokingham	John Redwood	70557	72.8	31.1	27.2	27.2	9.8	3.8	0	0	1	CON	CON
+521	51	Tiverton and Minehead	Unknown (new seat)	71003	70.2	29	25	25.4	13.7	5.2	0	0	1.6	CON	CON
+522	50	Buckinghamshire Mid	Greg Smith	72601	73.9	34.1	30.1	14.5	14.4	5.3	0	0	1.7	CON	CON
+522	49	St Ives	Derek Thomas	71343	74.6	25.7	21.6	33.7	15.5	2.7	0	0	0.7	CON	LIB
+522	49	Taunton and Wellington	Rebecca Pow	77219	71.9	26	21.7	36.1	12.7	2.5	0	0	1	CON	LIB
+523	49	Epping Forest	Eleanor Laing	74303	67.7	36.8	32.4	6.4	15.5	7.4	0	0	1.4	CON	CON
+524	48	Sleaford and North Hykeham	Caroline Johnson	74547	70.2	37.5	32.8	5.9	17.2	5.1	0	0	1.4	CON	CON
+524	47	Carshalton and Wallington	Elliot Colburn	73133	67.3	28.1	23.3	34.1	9.8	3.5	0	0	1.2	CON	LIB
+525	47	Witney	Robert Courts	70019	73.3	33.9	29.1	22.7	9.9	3.8	0	0	0.5	CON	CON
+526	46	Thirsk and Malton	Kevin Hollinrake	76632	69.9	36.3	31.5	8.1	16.2	6.6	0	0	1.4	CON	CON
+526	45	Chippenham	Michelle Donelan	71341	74.3	28.2	23.2	33.4	11.5	3.1	0	0	0.6	CON	LIB
+527	45	Hertsmere	Oliver Dowden	73133	70.2	39.2	34.1	5.5	12.5	7.4	0	0	1.2	CON	CON
+528	44	Brecon, Radnor and Cwm Tawe	Fay Jones	72621	72.3	32.5	27.3	23.4	10.7	2.6	2.5	0	0.9	CON	CON
+529	43	Aldridge-Brownhills	Wendy Morton	72512	64.9	38.1	32.4	5.1	17.1	5.8	0	0	1.5	CON	CON
+530	42	Richmond and Northallerton	Rishi Sunak	73217	69.9	37.3	31.6	8.5	14.3	6.7	0	0	1.6	CON	CON
+531	41	Brigg and Immingham	Martin Vickers	71838	62.3	37.9	32.2	5.4	17.6	5.6	0	0	1.3	CON	CON
+531	40	Winchester	Steve Brine	77307	76.6	28.2	22.4	36	9.2	3.3	0	0	0.9	CON	LIB
+532	40	Braintree	James Cleverly	76023	67.6	38.9	32.9	5.2	16.6	5.1	0	0	1.4	CON	CON
+533	39	Gordon and Buchan	Unknown (changed seat)	69002	68.9	30.9	24.8	7.9	3.6	3.8	25.8	0	3.2	CON	CON
+534	38	Woking	Jonathan Lord	71024	71.5	31.5	25.3	28.8	8.6	4.6	0	0	1.2	CON	CON
+535	37	New Forest East	Julian Lewis	73549	69.1	36.6	30.3	9.9	14.6	7.1	0	0	1.5	CON	CON
+536	36	Witham	Priti Patel	74881	69.8	38.4	32.1	5.8	14	8.5	0	0	1.2	CON	CON
+537	35	Norfolk South West	Liz Truss	72980	65.7	38.2	31.8	4.9	17.6	6.4	0	0	1.2	CON	CON
+538	34	Aberdeenshire North and Moray East	David Duguid	71236	64.8	31.9	25.2	3.6	3.6	3.6	28.9	0	3.2	CON	CON
+539	33	Berwickshire, Roxburgh and Selkirk	John Lamont	74518	71.3	33	26.2	6	3.6	3.8	24.2	0	3.3	CON	CON
+540	32	Melksham and Devizes	Unknown (new seat)	71522	72.3	30.6	23.8	29.6	12.4	3.1	0	0	0.6	CON	CON
+540	31	Cotswolds South	Geoffrey Clifton-Brown	72683	74.7	30.2	23.3	31.2	11.2	3.5	0	0	0.6	CON	LIB
+540	31	Newbury	Laura Farris	71439	71.9	29.5	22.5	32.7	10.3	4.3	0	0	0.7	CON	LIB
+541	31	Droitwich and Evesham	Nigel Huddleston	73836	71.7	38.4	31.4	7.1	13.7	8.2	0	0	1.2	CON	CON
+542	30	Rutland and Stamford	Alicia Kearns	71730	69.8	37.6	30.6	10.6	13.9	6	0	0	1.3	CON	CON
+542	29	Richmond Park	Sarah Olney	75915	78.7	26	19	44.7	6.1	3.4	0	0	0.9	LIB	LIB
+543	29	Clacton	Giles Watling	76574	62	36.5	29.5	4.7	22.2	5.8	0	0	1.3	CON	CON
+544	28	Shropshire South	Philip Dunne	76915	72.3	37.2	29.8	11.2	15	5.7	0	0	1.2	CON	CON
+545	27	Tonbridge	Tom Tugendhat	72745	71.4	37.7	30.3	6.8	11	13.1	0	0	1.1	CON	CON
+546	26	Maidenhead	Theresa May	72602	73.2	34.3	26.7	23.7	10	4.7	0	0	0.7	CON	CON
+546	25	Dorset West	Chris Loder	76136	74.4	28.7	20.9	35.3	11.1	3.5	0	0	0.5	CON	LIB
+547	25	Wiltshire East	Danny Kruger	70844	69.9	37.8	29.8	9.8	14.8	6.5	0	0	1.3	CON	CON
+547	24	Wells and Mendip Hills	James Heappey	69509	72.2	30.3	22.2	32.7	10.6	3.7	0	0	0.5	CON	LIB
+547	24	Guildford	Angela Richardson	71286	75.7	30.9	22.8	32	9.1	3.6	0	0	1.7	CON	LIB
+547	24	Devon North	Selaine Saxby	75860	73.3	28.5	20.1	33.9	13.5	3.4	0	0	0.5	CON	LIB
+548	24	Romsey and Southampton North	Caroline Nokes	73616	74.7	32.3	23.9	29.4	10.8	3	0	0	0.6	CON	CON
+548	23	Thornbury and Yate	Luke Hall	74719	75	28.8	20.2	37	11.1	2.3	0	0	0.6	CON	LIB
+548	23	Cheadle	Mary Robinson	74578	75	29.1	20.1	39	8.4	2.4	0	0	0.8	CON	LIB
+549	23	Louth and Horncastle	Victoria Atkins	76035	65.7	39.6	30.6	5.3	18.9	4.4	0	0	1.1	CON	CON
+550	22	New Forest West	Desmond Swayne	70868	71	38.2	29.2	9.4	13.8	8.3	0	0	1.1	CON	CON
+551	21	Cambridgeshire North East	Steve Barclay	70565	63.3	38.5	29.3	5.6	18.7	6.5	0	0	1.3	CON	CON
+552	20	Herefordshire North	Bill Wiggin	71099	72.6	37.6	28.3	8.5	13.5	11	0	0	1	CON	CON
+553	19	Boston and Skegness	Matt Warman	75021	60.5	37.8	28.2	4.2	24.1	4.4	0	0	1.3	CON	CON
+554	18	Godalming and Ash	Unknown (new seat)	71232	75.2	32.6	23	30.2	10.4	3.1	0	0	0.7	CON	CON
+555	17	Wetherby and Easingwold	Alec Shelbrooke	71150	71.7	41.3	31.6	6.2	12.4	7.2	0	0	1.3	CON	CON
+556	16	Surrey Heath	Michael Gove	70526	72.1	33.8	24.1	26	11.5	4	0	0	0.7	CON	CON
+556	15	Eastbourne	Caroline Ansell	73000	69.5	27.1	17.4	40.9	11	2.6	0	0	1	CON	LIB
+556	15	Westmorland and Lonsdale	Unknown (changed seat)	73247	75.8	27	17.1	43.1	9.7	2.2	0	0	0.9	CON	LIB
+556	15	Yeovil	Marcus Fysh	76056	71.9	28.1	18.1	37.5	12.9	2.8	0	0	0.6	CON	LIB
+556	15	Norfolk North	Duncan Baker	71794	71.9	28.4	18.3	36.5	14.3	1.9	0	0	0.6	CON	LIB
+557	15	Old Bexley and Sidcup	James Brokenshire	73965	69.4	44.3	34	3.5	10.4	4.8	0	0	2.9	CON	CON
+558	14	Farnham and Bordon	Jeremy Hunt	72663	75.6	33.6	23.3	28.1	11.6	2.8	0	0	0.5	CON	CON
+559	13	Rayleigh and Wickford	Mark Francois	76201	69.6	40.1	29.6	5.3	17.5	6.4	0	0	1.2	CON	CON
+560	12	Brentwood and Ongar	Alex Burghart	75078	70.4	39.9	29.3	8.7	14.7	6	0	0	1.5	CON	CON
+561	11	Dorset North	Simon Hoare	72596	73.1	37.5	26.4	14.2	14.7	6	0	0	1.2	CON	CON
+562	10	Christchurch	Christopher Chope	71673	72.6	38.2	27.1	10.7	17.3	5.7	0	0	1	CON	CON
+562	9	Esher and Walton	Dominic Raab	72783	77.1	32.5	21.1	33.7	8.8	2.8	0	0	1	CON	LIB
+563	9	Castle Point	Rebecca Harris	71217	63.5	40.2	28.6	4.2	21.6	4.4	0	0	1	CON	CON
+563	8	Cheltenham	Alex Chalk	76294	73.2	28.3	16.5	43.5	8.1	2.7	0	0	0.9	CON	LIB
+563	8	Lewes	Maria Caulfield	74728	75.8	31.4	19.7	34	7.9	6.3	0	0	0.7	CON	LIB
+563	8	Cornwall North	Scott Mann	74608	73.6	28.3	16.5	35.5	16.5	2.4	0	0	0.8	CON	LIB
+564	8	Exmouth and Exeter East	Simon Jupp	74902	72.9	39.4	27.6	17.1	11.8	3.5	0	0	0.7	CON	CON
+565	7	Shropshire North	Owen Paterson	76778	67.9	31.8	19.9	31.2	10.5	4.4	0	0	2.1	CON	CON
+565	6	Dorset Mid and Poole North	Michael Tomlinson	74424	74.1	28.6	16.2	37.5	13.8	3.1	0	0	0.8	CON	LIB
+566	6	Beaconsfield	Joy Morrissey	71573	74.5	35.9	23.2	22.3	11.7	5.4	0	0	1.5	CON	CON
+567	5	Maldon	John Whittingdale	76755	69.7	41.2	28.3	6.8	16.4	6	0	0	1.2	CON	CON
+568	4	South Holland and The Deepings	John Hayes	75977	64.7	40.9	26.7	5	20.7	5.6	0	0	1.2	CON	CON
+569	3	Kingswinford and South Staffordshire	Gavin Williamson	71981	64.6	42.7	28.3	5.5	15.8	6.4	0	0	1.2	CON	CON
+570	2	Weald of Kent	Unknown (new seat)	70125	67.6	42.7	28.1	6.3	14.5	7.1	0	0	1.3	CON	CON
+570	1	Glastonbury and Somerton	David Warburton	69925	74.7	27.8	12.4	43.9	8.2	5.8	0	0	1.8	CON	LIB
+571	1	Honiton and Sidmouth	Neil Parish	74523	72.4	36.4	16.1	33.7	9.7	2.8	0	0	1.3	CON	CON
+571	0	Chesham and Amersham	Cheryl Gillan	73642	75.9	36.1	14.6	38.1	6.3	3.9	0	0	1	CON	LIB

--- a/db/fixtures/electoral_calculus_constituencies_tsv.rb
+++ b/db/fixtures/electoral_calculus_constituencies_tsv.rb
@@ -30,12 +30,12 @@ class ElectoralCalculusConstituenciesTsv
       constituency_name = data[2]
 
       votes = {
-        "con" => { percent: data[6] },
-        "lab" => { percent: data[7] },
-        "libdem" => { percent: data[8] },
-        "reform" => { percent: data[9] },
-        "green" => { percent: data[10] },
-        "nat" => { percent: data[11] }
+        con:    { percent: data[6] },
+        lab:    { percent: data[7] },
+        libdem: { percent: data[8] },
+        reform: { percent: data[9] },
+        green:  { percent: data[10] },
+        nat:    { percent: data[11] }
       }
 
       data_transformed = {

--- a/db/fixtures/electoral_calculus_constituencies_tsv.rb
+++ b/db/fixtures/electoral_calculus_constituencies_tsv.rb
@@ -8,87 +8,42 @@ require_relative "constituencies_original_with_ons_csv"
 # into a spreadsheet, which must then be saved as tab-separated values.
 # This is straightforward in LibreOffice spreadsheets, and
 # presumably in other tools too.
-# This then takes care of mapping the 'nationalist vote' to the
-# appropriate party.
 
 class ElectoralCalculusConstituenciesTsv
+  attr_reader :file_name
+
   include Enumerable
 
   TSV_FILE_NAME = "./db/fixtures/electoral_calculus_constituencies.tsv"
 
   def initialize
-    @parties_by_party_code = {
-      "con"    => Party.find_by(name: "Conservatives"),
-      "green"  => Party.find_by(name: "Green"),
-      "lab"    => Party.find_by(name: "Labour"),
-      "libdem" => Party.find_by(name: "Liberal Democrats"),
-      "snp"    => Party.find_by(name: "SNP"),
-      "plaid"  => Party.find_by(name: "Plaid Cymru"),
-      "reform" => Party.find_by(name: "Reform")
-    }
-
-    missing_parties = @parties_by_party_code.select{ |_key, value| value.nil? }
-
-    raise "Can't find these parties: #{missing_parties.keys}" unless missing_parties.count.zero?
+    @file_name = TSV_FILE_NAME
   end
 
   # rubocop:disable Metrics/MethodLength
   def each
-    CSV.foreach(TSV_FILE_NAME, headers: false, col_sep: "\t") do |data|
+    CSV.foreach(file_name, headers: false, col_sep: "\t") do |data|
       unless data.length == 16
         raise ArgumentError, "Input fields #{data} do not have expected length 16"
       end
 
       constituency_name = data[2]
-      constituency_ons_id = ons_ids_by_constituency_name[constituency_name]
-      if constituency_ons_id.nil?
-        raise ArgumentError, "failed ons id lookup for #{constituency_name} "
-      end
-      country = constituency_ons_id[0]
 
       votes = {
         "con" => { percent: data[6] },
         "lab" => { percent: data[7] },
         "libdem" => { percent: data[8] },
         "reform" => { percent: data[9] },
-        "green" => { percent: data[10] }
+        "green" => { percent: data[10] },
+        "nat" => { percent: data[11] }
       }
 
-      if country == "S"
-        votes["snp"] = { percent: data[11], note: "(Assigning nationalist vote to SNP)" }
-      elsif country == "W"
-        votes["plaid"] = { percent: data[11], note: "(Assigning nationalist vote to Plaid Cymru)" }
-      elsif %w[S E W N].exclude?(country)
-        throw "Invalid country '#{country}' for #{constituency_name};"
-      end
+      data_transformed = {
+        votes: votes,
+        constituency_name: constituency_name,
+      }
 
-      votes.each_key do |party|
-        data_transformed = {
-          vote_percent: votes[party][:percent].to_f,
-          party_id: @parties_by_party_code[party].id,
-          party_name: @parties_by_party_code[party].name,
-          constituency_ons_id: constituency_ons_id,
-          constituency_name: constituency_name,
-          conversion_note: votes[party][:note]
-        }
-
-        yield data_transformed
-      end
+      yield data_transformed
     end
-  end
-
-  private def original_constituencies_with_ons_csv
-    OriginalConstituenciesWithOnsCsv
-      .new("db/fixtures/constituency_original_names_with_ons_ids.csv")
-  end
-
-  private def ons_ids_by_constituency_name
-    return @ons_ids_by_constituency_name if defined?(@ons_ids_by_constituency_name)
-
-    @ons_ids_by_constituency_name = original_constituencies_with_ons_csv.each_with_object({}) do |c, hash|
-      hash[c[:name]] = c[:ons_id]
-    end
-
-    return @ons_ids_by_constituency_name
   end
 end

--- a/db/fixtures/electoral_calculus_polls.rb
+++ b/db/fixtures/electoral_calculus_polls.rb
@@ -1,0 +1,29 @@
+# This loads the electoral calculus poll predictions into the polls table
+
+require_relative "electoral_calculus_constituencies_tsv"
+
+class ElectoralCalculusPolls
+  attr_reader :polls_data
+
+  def initialize
+    @polls_data = ElectoralCalculusConstituenciesTsv.new
+  end
+
+  def load
+    polls_data.each do |party_result|
+      vote_count = (party_result[:vote_percent] * 100).to_i
+      ons_id = party_result[:constituency_ons_id]
+      party_id = party_result[:party_id]
+      conversion_note = party_result[:conversion_note]
+
+      unless conversion_note.nil?
+        puts "\nConversion Note: #{party_result} "
+      end
+
+      poll = Poll.find_or_initialize_by constituency_ons_id: ons_id, party_id: party_id
+      poll.votes = vote_count
+      poll.save!
+      print "."
+    end
+  end
+end

--- a/db/fixtures/electoral_calculus_polls.rb
+++ b/db/fixtures/electoral_calculus_polls.rb
@@ -1,12 +1,12 @@
 # This loads the electoral calculus poll predictions into the polls table
 
-require_relative "electoral_calculus_constituencies_tsv"
+require_relative "electoral_calculus_polls_raw"
 
 class ElectoralCalculusPolls
   attr_reader :polls_data
 
   def initialize
-    @polls_data = ElectoralCalculusConstituenciesTsv.new
+    @polls_data = ElectoralCalculusConstituenciesPollsRaw.new
   end
 
   def load

--- a/db/fixtures/electoral_calculus_polls_raw.rb
+++ b/db/fixtures/electoral_calculus_polls_raw.rb
@@ -1,0 +1,80 @@
+require "csv"
+require_relative "constituencies_original_with_ons_csv"
+require_relative "electoral_calculus_constituencies_tsv"
+
+# This maps Electoral calculus polls data provided per constituency to from usable by SMV
+# - EC name is mapped to an ONS id
+# - party names mapped to SMV party IDs
+# - loop over each party/constituency combo, not over constituencies
+# - takes care of mapping the 'nationalist vote' to the appropriate party.
+
+class ElectoralCalculusConstituenciesPollsRaw
+  include Enumerable
+
+  def initialize
+    @parties_by_party_code = {
+      "con"    => Party.find_by(name: "Conservatives"),
+      "green"  => Party.find_by(name: "Green"),
+      "lab"    => Party.find_by(name: "Labour"),
+      "libdem" => Party.find_by(name: "Liberal Democrats"),
+      "snp"    => Party.find_by(name: "SNP"),
+      "plaid"  => Party.find_by(name: "Plaid Cymru"),
+      "reform" => Party.find_by(name: "Reform")
+    }
+
+    missing_parties = @parties_by_party_code.select{ |_key, value| value.nil? }
+
+    raise "Can't find these parties: #{missing_parties.keys}" unless missing_parties.count.zero?
+  end
+
+  # rubocop:disable Metrics/MethodLength
+  def each
+    ElectoralCalculusConstituenciesTsv.new.each do |data|
+      constituency_name = data[:constituency_name]
+      constituency_ons_id = ons_ids_by_constituency_name[constituency_name]
+      if constituency_ons_id.nil?
+        puts "failed ons id lookup for #{constituency_name} "
+        next
+      end
+      country = constituency_ons_id[0]
+
+      if country == "S"
+        data[:votes]["snp"] = { percent: data[:votes]["nat"][:percent], note: "(Assigning nationalist vote to SNP)" }
+      elsif country == "W"
+        # rubocop:disable Layout/LineLength
+        data[:votes]["plaid"] = { percent: data[:votes]["nat"][:percent], note: "(Assigning nationalist vote to Plaid Cymru)" }
+      elsif %w[S E W N].exclude?(country)
+        throw "Invalid country '#{country}' for #{constituency_name};"
+      end
+      data[:votes].delete("nat")
+
+      data[:votes].each_key do |party|
+        data_transformed = {
+          vote_percent: data[:votes][party][:percent].to_f,
+          party_id: @parties_by_party_code[party].id,
+          party_name: @parties_by_party_code[party].name,
+          constituency_ons_id: constituency_ons_id,
+          constituency_name: constituency_name,
+          conversion_note: data[:votes][party][:note]
+        }
+
+        yield data_transformed
+      end
+    end
+  end
+
+  private def original_constituencies_with_ons_csv
+    OriginalConstituenciesWithOnsCsv
+      .new("db/fixtures/constituency_original_names_with_ons_ids.csv")
+  end
+
+  private def ons_ids_by_constituency_name
+    return @ons_ids_by_constituency_name if defined?(@ons_ids_by_constituency_name)
+
+    @ons_ids_by_constituency_name = original_constituencies_with_ons_csv.each_with_object({}) do |c, hash|
+      hash[c[:name]] = c[:ons_id]
+    end
+
+    return @ons_ids_by_constituency_name
+  end
+end

--- a/db/fixtures/electoral_calculus_polls_raw.rb
+++ b/db/fixtures/electoral_calculus_polls_raw.rb
@@ -13,13 +13,13 @@ class ElectoralCalculusConstituenciesPollsRaw
 
   def initialize
     @parties_by_party_code = {
-      "con"    => Party.find_by(name: "Conservatives"),
-      "green"  => Party.find_by(name: "Green"),
-      "lab"    => Party.find_by(name: "Labour"),
-      "libdem" => Party.find_by(name: "Liberal Democrats"),
-      "snp"    => Party.find_by(name: "SNP"),
-      "plaid"  => Party.find_by(name: "Plaid Cymru"),
-      "reform" => Party.find_by(name: "Reform")
+      con:    Party.find_by(name: "Conservatives"),
+      green:  Party.find_by(name: "Green"),
+      lab:    Party.find_by(name: "Labour"),
+      libdem: Party.find_by(name: "Liberal Democrats"),
+      snp:    Party.find_by(name: "SNP"),
+      plaid:  Party.find_by(name: "Plaid Cymru"),
+      reform: Party.find_by(name: "Reform")
     }
 
     missing_parties = @parties_by_party_code.select{ |_key, value| value.nil? }
@@ -39,14 +39,13 @@ class ElectoralCalculusConstituenciesPollsRaw
       country = constituency_ons_id[0]
 
       if country == "S"
-        data[:votes]["snp"] = { percent: data[:votes]["nat"][:percent], note: "(Assigning nationalist vote to SNP)" }
+        data[:votes][:snp] = { percent: data[:votes][:nat][:percent], note: "(Assigning nationalist vote to SNP)" }
       elsif country == "W"
-        # rubocop:disable Layout/LineLength
-        data[:votes]["plaid"] = { percent: data[:votes]["nat"][:percent], note: "(Assigning nationalist vote to Plaid Cymru)" }
+        data[:votes][:plaid] = { percent: data[:votes][:nat][:percent], note: "(Assigning nationalist vote to Plaid" }
       elsif %w[S E W N].exclude?(country)
         throw "Invalid country '#{country}' for #{constituency_name};"
       end
-      data[:votes].delete("nat")
+      data[:votes].delete(:nat)
 
       data[:votes].each_key do |party|
         data_transformed = {

--- a/db/fixtures/electoral_calculus_polls_raw.rb
+++ b/db/fixtures/electoral_calculus_polls_raw.rb
@@ -29,11 +29,15 @@ class ElectoralCalculusConstituenciesPollsRaw
 
   # rubocop:disable Metrics/MethodLength
   def each
+    failed_ons_lookup = Set.new
+
     ElectoralCalculusConstituenciesTsv.new.each do |data|
       constituency_name = data[:constituency_name]
-      constituency_ons_id = ons_ids_by_constituency_name[constituency_name]
+      constituency_ons_id = constituency_ons_id_from_ec_constituency_name(constituency_name)
+
       if constituency_ons_id.nil?
-        puts "failed ons id lookup for #{constituency_name} "
+        # puts "failed ons id lookup for #{constituency_name} "
+        failed_ons_lookup.add(constituency_name)
         next
       end
       country = constituency_ons_id[0]
@@ -60,6 +64,15 @@ class ElectoralCalculusConstituenciesPollsRaw
         yield data_transformed
       end
     end
+
+    return unless failed_ons_lookup.size.positive?
+
+    puts "\n\nConstituencies where no ONS id found (count: #{failed_ons_lookup.size})"
+    pp failed_ons_lookup.to_a.sort
+  end
+
+  private def constituency_ons_id_from_ec_constituency_name(name)
+    ons_ids_by_constituency_name[name]
   end
 
   private def original_constituencies_with_ons_csv

--- a/db/fixtures/electoral_calculus_polls_raw.rb
+++ b/db/fixtures/electoral_calculus_polls_raw.rb
@@ -72,21 +72,20 @@ class ElectoralCalculusConstituenciesPollsRaw
   end
 
   private def constituency_ons_id_from_ec_constituency_name(name)
-    ons_ids_by_constituency_name[name]
+    # right now, this misses just 78 constituencies.
+    # expect to fix this by calling alternative lookups if the my_soc one returns a nil
+    # looks like we'll find a few in the pattern "Hampshire East" <=> "East Hampshire"
+    my_soc_constituency_ons_ids_by_name[name]
   end
 
-  private def original_constituencies_with_ons_csv
-    OriginalConstituenciesWithOnsCsv
-      .new("db/fixtures/constituency_original_names_with_ons_ids.csv")
-  end
+  private def my_soc_constituency_ons_ids_by_name
+    return @my_soc_constituency_ons_ids_by_name if defined?(@my_soc_constituency_ons_ids_by_name)
 
-  private def ons_ids_by_constituency_name
-    return @ons_ids_by_constituency_name if defined?(@ons_ids_by_constituency_name)
-
-    @ons_ids_by_constituency_name = original_constituencies_with_ons_csv.each_with_object({}) do |c, hash|
+    hash = {}
+    MysocietyConstituenciesCsv.new.each do |c|
       hash[c[:name]] = c[:ons_id]
     end
 
-    return @ons_ids_by_constituency_name
+    return @my_soc_constituency_ons_ids_by_name = hash
   end
 end

--- a/db/seeds_for_general_election.rb
+++ b/db/seeds_for_general_election.rb
@@ -9,7 +9,7 @@
 require "active_record/fixtures"
 require "csv"
 require_relative "fixtures/mysociety_constituencies_csv"
-require_relative "fixtures/electoral_calculus_constituencies_tsv"
+require_relative "fixtures/electoral_calculus_polls"
 require_relative("fixtures/tactical_vote_stt_recs")
 
 Party.find_or_create_by(name: "Conservatives", color: "#0087DC")
@@ -37,34 +37,9 @@ puts "#{OnsConstituency.count} ONS Constituencies loaded\n\n"
 
 # ---------------------------------------------------------------------------------
 
-# Possible backup first
-# Poll.all.map(&:as_json).map do |p| p.slice(
-#   "id", "old_constituency_id", "constituency_ons_id", "party_id", "votes"
-# )
-# end.to_yaml
-
 puts "\n\nPolls Data from Electoral calculus\n\n"
 
-# TODO: this code is currently duplicated in db/migrate/20191126122621_refresh_polls.rb
-
-polls_data = ElectoralCalculusConstituenciesTsv.new
-
-polls_data.each do |party_result|
-  vote_count = (party_result[:vote_percent] * 100).to_i
-  ons_id = party_result[:constituency_ons_id]
-  party_id = party_result[:party_id]
-  conversion_note = party_result[:conversion_note]
-
-  unless conversion_note.nil?
-    puts "\nConversion Note: #{party_result} "
-  end
-
-  poll = Poll.find_or_initialize_by constituency_ons_id: ons_id, party_id: party_id
-  poll.votes = vote_count
-  poll.save!
-  print "."
-end
-puts "\n\n"
+ElectoralCalculusPolls.new.load
 
 # ---------------------------------------------------------------------------------
 
@@ -72,7 +47,7 @@ puts "\n\n"
 
 # Recommendation.refresh_from_json(progress: true)
 
-puts "Loading Recommendations from STT"
+puts "\n\nLoading Recommendations from STT"
 
 TacticalVoteSttRecs.new.load
 

--- a/db/seeds_for_general_election.rb
+++ b/db/seeds_for_general_election.rb
@@ -43,29 +43,27 @@ puts "#{OnsConstituency.count} ONS Constituencies loaded\n\n"
 # )
 # end.to_yaml
 
-puts "\n\nNO POLLS DATA LOADED - this is emergency fix code \n\n"
+puts "\n\nPolls Data from Electoral calculus\n\n"
 
-# puts "\n\nPolls Data from Electoral calculus\n\n"
+# TODO: this code is currently duplicated in db/migrate/20191126122621_refresh_polls.rb
 
-# # TODO: this code is currently duplicated in db/migrate/20191126122621_refresh_polls.rb
+polls_data = ElectoralCalculusConstituenciesTsv.new
 
-# polls_data = ElectoralCalculusConstituenciesTsv.new
+polls_data.each do |party_result|
+  vote_count = (party_result[:vote_percent] * 100).to_i
+  ons_id = party_result[:constituency_ons_id]
+  party_id = party_result[:party_id]
+  conversion_note = party_result[:conversion_note]
 
-# polls_data.each do |party_result|
-#   vote_count = (party_result[:vote_percent] * 100).to_i
-#   ons_id = party_result[:constituency_ons_id]
-#   party_id = party_result[:party_id]
-#   conversion_note = party_result[:conversion_note]
+  unless conversion_note.nil?
+    puts "\nConversion Note: #{party_result} "
+  end
 
-#   unless conversion_note.nil?
-#     puts "\nConversion Note: #{party_result} "
-#   end
-
-#   poll = Poll.find_or_initialize_by constituency_ons_id: ons_id, party_id: party_id
-#   poll.votes = vote_count
-#   poll.save!
-#   print "."
-# end
+  poll = Poll.find_or_initialize_by constituency_ons_id: ons_id, party_id: party_id
+  poll.votes = vote_count
+  poll.save!
+  print "."
+end
 puts "\n\n"
 
 # ---------------------------------------------------------------------------------

--- a/spec/controllers/user/swaps_controller_spec.rb
+++ b/spec/controllers/user/swaps_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe User::SwapsController, type: :controller do
           allow(new_user).to receive(:willing_party).and_return(1)
           allow(new_user).to receive(:preferred_party).and_return(2)
           get :show
-          expect(assigns).not_to have_key(:hide_polls)
+          expect(assigns).to have_key(:hide_polls)
         end
       end
 
@@ -72,7 +72,7 @@ RSpec.describe User::SwapsController, type: :controller do
         it "assigns @hide_polls" do
           allow(controller).to receive(:swapping_open?).and_return(true)
           get :new, params: { user_id: swap_user.id }
-          expect(assigns).not_to have_key(:hide_polls)
+          expect(assigns).to have_key(:hide_polls)
         end
       end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe UsersController, type: :controller do
 
       it "assigns @hide_polls" do
         get :show
-        expect(assigns).not_to have_key(:hide_polls)
+        expect(assigns).to have_key(:hide_polls)
       end
     end
 


### PR DESCRIPTION
Update Electoral Calculus poll predictions to May 21st

78 constituencies missed (also, the NI ones are missing as usual).

However thats 80% covered and seems good enough to go public, to be improved later.

Main steps:

- ec ordered seats data, html timestamp 2024-05-21T00:00:00Z
- Revert "do not seed the polls data"
- EC: identify the lookup failures
- EC: now do direct lookup on new constituency names
- Revert "for now always hide polls"
