### PR TITLE
correct API help page information about field names

### DIFF
--- a/app/views/static_pages/api.html.haml
+++ b/app/views/static_pages/api.html.haml
@@ -50,7 +50,7 @@
         and you know in which constituency they are registered to vote,
         as it will save them manually selecting that constituency.
         The name must match one of the constituencies in the
-        %code PCON18NM
+        %code name
         field of
         = link_to("this data set", constituency_ons_id_dataset_url,
                   target: "_blank") + "."
@@ -66,7 +66,7 @@
         above, except that rather than the name, it's the ONS id of
         the constituency listed in the
 
-        %code PCON18CD
+        %code gss_code
 
         field of
 

--- a/spec/views/static_pages/__snapshots__/api_by_election.snap
+++ b/spec/views/static_pages/__snapshots__/api_by_election.snap
@@ -41,7 +41,7 @@ This is useful if you want to refer a user for tactical voting
 and you know in which constituency they are registered to vote,
 as it will save them manually selecting that constituency.
 The name must match one of the constituencies in the
-<code>PCON18NM</code>
+<code>name</code>
 field of
 <a target="_blank" href="https://pages.mysociety.org/2025-constituencies/datasets/parliament_con_2025/latest">this data set</a>.
 </dd>
@@ -53,7 +53,7 @@ The same as for
 <code>constituency_name</code>
 above, except that rather than the name, it's the ONS id of
 the constituency listed in the
-<code>PCON18CD</code>
+<code>gss_code</code>
 field of
 <a target="_blank" href="https://pages.mysociety.org/2025-constituencies/datasets/parliament_con_2025/latest">the data set</a>.
 </dd>

--- a/spec/views/static_pages/__snapshots__/api_general.snap
+++ b/spec/views/static_pages/__snapshots__/api_general.snap
@@ -41,7 +41,7 @@ This is useful if you want to refer a user for tactical voting
 and you know in which constituency they are registered to vote,
 as it will save them manually selecting that constituency.
 The name must match one of the constituencies in the
-<code>PCON18NM</code>
+<code>name</code>
 field of
 <a target="_blank" href="https://pages.mysociety.org/2025-constituencies/datasets/parliament_con_2025/latest">this data set</a>.
 </dd>
@@ -53,7 +53,7 @@ The same as for
 <code>constituency_name</code>
 above, except that rather than the name, it's the ONS id of
 the constituency listed in the
-<code>PCON18CD</code>
+<code>gss_code</code>
 field of
 <a target="_blank" href="https://pages.mysociety.org/2025-constituencies/datasets/parliament_con_2025/latest">the data set</a>.
 </dd>


### PR DESCRIPTION
closes issue #759

The data source for constituencies was already swapped in a previous commit, but I missed the fact we named the fields in the data source for API users.
