### PR TITLE
tell user they need to verify mobile number

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -51,7 +51,7 @@ class UsersController < ApplicationController
       return edit_user_path
     end
 
-    return edit_user_path if !@user.valid?
+    return edit_user_path unless @user.valid?
 
     # Otherwise, return to the user path - user will see a verification prompt if needed
     user_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,7 +46,13 @@ class UsersController < ApplicationController
 
   def redirect_path
     # If the user came from the edit path, and the mobile still needs verification, return there
-    return edit_user_path if params[:user] && mobile_set_but_not_verified? || !@user.valid?
+    if params[:user] && mobile_set_but_not_verified?
+      flash[:errors] = ["Please verify the mobile phone number you provided."]
+      return edit_user_path
+    end
+
+    return edit_user_path if !@user.valid?
+
     # Otherwise, return to the user path - user will see a verification prompt if needed
     user_path
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,10 @@
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = :debug
 
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development


### PR DESCRIPTION
Scenario: user has entered mobile phone number on /user/edit but hasn't yet verified.

Might happen
- right after registration (esp. if browser autofills email and phone number)
- when about to make the 1st swap, in which case the rules are we need a mobile phone number

Once on the /user/edit page with mobile phone filled in, the only way save will work is after verifying the mobile phone number. Alternatively they can navigate away to the home page.

This commit does not change that behaviour, it just lets the user know why save is not working with an error message.

This mitigates issue #766 and might be considered a fix.

It also directly addresses the problem raised in #166 though the solution is different.