### PR TITLE
remove erroneous `source:` options in `has_many`

### DIFF
--- a/app/models/ons_constituency.rb
+++ b/app/models/ons_constituency.rb
@@ -12,7 +12,6 @@ class OnsConstituency < ApplicationRecord
 
   has_many :recommended_parties,
            inverse_of: :constituency,
-           source: :recommended_party,
            primary_key: "ons_id",
            foreign_key: "constituency_ons_id",
            dependent: :destroy

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -2,7 +2,6 @@ class Party < ApplicationRecord
   has_many :polls, dependent: :destroy
   has_many :recommended_parties,
            inverse_of: :party,
-           source: :recommended_party,
            dependent: :destroy
 
   REFERENCE_DATA = {


### PR DESCRIPTION
The `source` option is documented as follows:

> Specifies the source association name used by `#has_many :through`
> queries. Only use it if the name cannot be inferred from the
> association. `has_many :subscribers, through: :subscriptions` will
> look for either `:subscribers` or `:subscriber` on `Subscription`,
> unless a `:source` is given.

Therefore it's not needed here, and it actually breaks `rake db:setup`:

```
Parties selected for GE
rake aborted!
ArgumentError: Unknown key: :source. Valid keys are: :class_name, :anonymous_class, :primary_key, :foreign_key, :dependent, :validate, :inverse_of, :strict_loading, :autosave, :before_add, :after_add, :before_remove, :after_remove, :extend, :counter_cache, :join_table, :index_errors, :ensuring_owner_was
```