### PR TITLE
issue 773 show aligned tv sites

### DIFF
--- a/app/helpers/recommendations_helper.rb
+++ b/app/helpers/recommendations_helper.rb
@@ -48,9 +48,18 @@ module RecommendationsHelper
 
   def recommendations_sites
     {
-      "stop-the-tories" => { order: 1 },
-      "sprint-for-pr" => { order: 2 },
-      "tactical-vote" => { order: 3 }
+      "stop-the-tories" => {
+        order: 1 ,
+        link: "https://stopthetories.vote/"
+      },
+      "sprint-for-pr" => {
+        order: 2,
+        link: "https://sprintforpr.uk/plan"
+     },
+      "tactical-vote" => {
+        order: 3,
+        link: "https://tactical.vote/all/"
+     }
     }
   end
 end

--- a/app/helpers/recommendations_helper.rb
+++ b/app/helpers/recommendations_helper.rb
@@ -39,14 +39,7 @@ module RecommendationsHelper
     {
       "stop-the-tories" => { order: 1 },
       "sprint-for-pr" => { order: 2 },
-      "get-voting" => { order: 91 },
-      "peoples-vote" => { order: 92 },
-      "remain-united" => { order: 93 },
-      "tacticalvote-co-uk" => { order: 94 },
-      "tactical-vote" => { order: 95 },
-      "avaaz-votesmart" => { order: 96 },
-      "one-uk" => { order: 97 },
-      "unite-2-leave" => { order: 98 }
+      "tactical-vote" => { order: 3 }
     }
   end
 end

--- a/app/helpers/recommendations_helper.rb
+++ b/app/helpers/recommendations_helper.rb
@@ -10,6 +10,14 @@ module RecommendationsHelper
     return data
   end
 
+  def party_recommendations_for(constituency, party)
+    data = []
+    RecommendedParty.where(party_id: party.id, constituency_ons_id: constituency.ons_id).each do |recommendation|
+      data.push recommendation
+    end
+    return data
+  end
+
   def recommendations_sites
     {
       "stop-the-tories" => { order: 1 },

--- a/app/helpers/recommendations_helper.rb
+++ b/app/helpers/recommendations_helper.rb
@@ -29,10 +29,10 @@ module RecommendationsHelper
       rec_party = rec_party_lookup[site.id]
       rec = rec_lookup[site.id]
 
-      if rec_party
-        array.push([:good, rec_party]) # we know the site recommended exactly this party
+      if rec_party && rec
+        array.push([:good, site, rec, rec_party]) # we know the site recommended exactly this party
       elsif rec
-        array.push([:bad, rec]) # we know the site make a recommendation, but not this party
+        array.push([:bad, site, rec]) # we know the site make a recommendation, but not this party
       else
         array.push([:unknown, site]) # site did not offer a recommendation
       end

--- a/app/helpers/recommendations_helper.rb
+++ b/app/helpers/recommendations_helper.rb
@@ -18,6 +18,23 @@ module RecommendationsHelper
     return data
   end
 
+  def full_party_recommendations_for(constituency, party)
+    rec_party_results = party_recommendations_for(constituency, party)
+
+    rec_party_lookup = rec_party_results.each_with_object({}) do |rec, hash|
+      hash[rec.site] = rec
+    end
+
+    recommendations_for(constituency).each_with_object([]) do |rec, array|
+      rec_party = rec_party_lookup[rec.site]
+      if rec_party
+        array.push([:good, rec_party])
+      else
+        array.push([:bad, rec])
+      end
+    end
+  end
+
   def recommendations_sites
     {
       "stop-the-tories" => { order: 1 },

--- a/app/helpers/recommendations_helper.rb
+++ b/app/helpers/recommendations_helper.rb
@@ -18,6 +18,7 @@ module RecommendationsHelper
     return data
   end
 
+  # rubocop:disable Metrics/MethodLength
   def fullest_recommendations_for(constituency, party)
     rec_party_results = party_recommendations_for(constituency, party)
     rec_party_lookup = rec_party_results.each_with_object({}) { |rec, hash| hash[rec.site] = rec }
@@ -30,11 +31,26 @@ module RecommendationsHelper
       rec = rec_lookup[site.id]
 
       if rec_party && rec
-        array.push([:good, site, rec, rec_party]) # we know the site recommended exactly this party
+        # we know the site recommended exactly this party
+        array.push(OpenStruct.new({
+          match: :good,
+          site: site,
+          recommendation: rec,
+          recommendation_party: rec_party
+        }))
       elsif rec
-        array.push([:bad, site, rec]) # we know the site make a recommendation, but not this party
+        # we know the site make a recommendation, but not this party
+        array.push(OpenStruct.new({
+          match: :bad,
+          site: site,
+          recommendation: rec
+        }))
       else
-        array.push([:unknown, site]) # site did not offer a recommendation
+        # site did not offer a recommendation
+        array.push(OpenStruct.new({
+          match: :unknown,
+          site: site
+        }))
       end
     end
   end

--- a/app/models/recommendation.rb
+++ b/app/models/recommendation.rb
@@ -49,8 +49,6 @@ class Recommendation < ApplicationRecord
 
     party_ids.each do |party_id|
       rec_party = RecommendedParty.find_or_initialize_by(rec_key.merge({ party_id: party_id }))
-      rec_party.link = link
-      rec_party.text = text
       rec_party.save!
       print "!" # to signify update with heart/any
     end

--- a/app/views/recommendations/_party_recommendation.html.haml
+++ b/app/views/recommendations/_party_recommendation.html.haml
@@ -1,5 +1,9 @@
-%p{ class: "party-recommendation #{party_recommendation.site}" }
-  &#x2705 Good Swap -
-  = link_to URI.parse(party_recommendation.link).host, party_recommendation.link
+%p{ class: "party-recommendation #{party_recommendation.last.site}" }
+  - if party_recommendation.first == :good
+    &#x2705 Good Swap -
+  - else
+    &#x274C Bad Swap -
+  = link_to URI.parse(party_recommendation.last.link).host, party_recommendation.last.link
   recommend
-  = party_recommendation.text
+  = party_recommendation.last.text
+

--- a/app/views/recommendations/_party_recommendation.html.haml
+++ b/app/views/recommendations/_party_recommendation.html.haml
@@ -1,4 +1,4 @@
 %p{ class: "party-recommendation #{party_recommendation.site}" }
   &#x2705 Good Swap (according to
-  = party_recommendation.site
+  = link_to URI.parse(party_recommendation.link).host, party_recommendation.link
   )

--- a/app/views/recommendations/_party_recommendation.html.haml
+++ b/app/views/recommendations/_party_recommendation.html.haml
@@ -12,7 +12,7 @@
       = party_recommendation.last.text
   - else
     &#x1F937
-    = party_recommendation.last.site
+    = party_recommendation.last.id
     has no recommendation
 
 

--- a/app/views/recommendations/_party_recommendation.html.haml
+++ b/app/views/recommendations/_party_recommendation.html.haml
@@ -1,18 +1,15 @@
-%p{ class: "party-recommendation #{party_recommendation.last.site}" }
+%p{ class: "party-recommendation #{party_recommendation[1]}" }
   - if party_recommendation.first != :unknown
     - if party_recommendation.first == :good
       &#x2705
-      = link_to URI.parse(party_recommendation.last.link).host, party_recommendation.last.link
-      recommend
-      = party_recommendation.last.party.name
     - else
       &#x274C
-      = link_to URI.parse(party_recommendation.last.link).host, party_recommendation.last.link
-      recommend
-      = party_recommendation.last.text
+    = link_to URI.parse(party_recommendation[1].link).host, party_recommendation[1].link
+    recommend
+    = party_recommendation[2].text
   - else
     &#x1F937
-    = party_recommendation.last.id
+    = link_to URI.parse(party_recommendation[1].link).host, party_recommendation[1].link
     has no recommendation
 
 

--- a/app/views/recommendations/_party_recommendation.html.haml
+++ b/app/views/recommendations/_party_recommendation.html.haml
@@ -1,9 +1,15 @@
 %p{ class: "party-recommendation #{party_recommendation.last.site}" }
-  - if party_recommendation.first == :good
-    &#x2705 Good Swap -
+  - if party_recommendation.first != :unknown
+    - if party_recommendation.first == :good
+      &#x2705 Good Swap -
+    - else
+      &#x274C Bad Swap -
+    = link_to URI.parse(party_recommendation.last.link).host, party_recommendation.last.link
+    recommend
+    = party_recommendation.last.text
   - else
-    &#x274C Bad Swap -
-  = link_to URI.parse(party_recommendation.last.link).host, party_recommendation.last.link
-  recommend
-  = party_recommendation.last.text
+    &#x1F937 unknown -
+    = party_recommendation.last.site
+    has no recommendation
+
 

--- a/app/views/recommendations/_party_recommendation.html.haml
+++ b/app/views/recommendations/_party_recommendation.html.haml
@@ -2,13 +2,10 @@
   - if rec.match != :unknown
     - if rec.match == :good
       &#x2705
-    - else
-      &#x274C
     = link_to URI.parse(rec.site.link).host, rec.site.link
     recommend
     = rec.recommendation.text
   - else
-    &#x1F937
     = link_to URI.parse(rec.site.link).host, rec.site.link
     has no recommendation
 

--- a/app/views/recommendations/_party_recommendation.html.haml
+++ b/app/views/recommendations/_party_recommendation.html.haml
@@ -1,4 +1,5 @@
 %p{ class: "party-recommendation #{party_recommendation.site}" }
-  &#x2705 Good Swap (according to
+  &#x2705 Good Swap -
   = link_to URI.parse(party_recommendation.link).host, party_recommendation.link
-  )
+  recommend
+  = party_recommendation.text

--- a/app/views/recommendations/_party_recommendation.html.haml
+++ b/app/views/recommendations/_party_recommendation.html.haml
@@ -1,15 +1,15 @@
-%p{ class: "party-recommendation #{party_recommendation[1]}" }
-  - if party_recommendation.first != :unknown
-    - if party_recommendation.first == :good
+%p{ class: "party-recommendation #{rec.site.id}" }
+  - if rec.match != :unknown
+    - if rec.match == :good
       &#x2705
     - else
       &#x274C
-    = link_to URI.parse(party_recommendation[1].link).host, party_recommendation[1].link
+    = link_to URI.parse(rec.site.link).host, rec.site.link
     recommend
-    = party_recommendation[2].text
+    = rec.recommendation.text
   - else
     &#x1F937
-    = link_to URI.parse(party_recommendation[1].link).host, party_recommendation[1].link
+    = link_to URI.parse(rec.site.link).host, rec.site.link
     has no recommendation
 
 

--- a/app/views/recommendations/_party_recommendation.html.haml
+++ b/app/views/recommendations/_party_recommendation.html.haml
@@ -1,0 +1,4 @@
+%p{ class: "party-recommendation #{party_recommendation.site}" }
+  &#x2705 Good Swap (according to
+  = party_recommendation.site
+  )

--- a/app/views/recommendations/_party_recommendation.html.haml
+++ b/app/views/recommendations/_party_recommendation.html.haml
@@ -1,14 +1,17 @@
 %p{ class: "party-recommendation #{party_recommendation.last.site}" }
   - if party_recommendation.first != :unknown
     - if party_recommendation.first == :good
-      &#x2705 Good Swap -
+      &#x2705
+      = link_to URI.parse(party_recommendation.last.link).host, party_recommendation.last.link
+      recommend
+      = party_recommendation.last.party.name
     - else
-      &#x274C Bad Swap -
-    = link_to URI.parse(party_recommendation.last.link).host, party_recommendation.last.link
-    recommend
-    = party_recommendation.last.text
+      &#x274C
+      = link_to URI.parse(party_recommendation.last.link).host, party_recommendation.last.link
+      recommend
+      = party_recommendation.last.text
   - else
-    &#x1F937 unknown -
+    &#x1F937
     = party_recommendation.last.site
     has no recommendation
 

--- a/app/views/user/swaps/_swap_profile.html.haml
+++ b/app/views/user/swaps/_swap_profile.html.haml
@@ -19,7 +19,7 @@
       .recommendations-header
         Tactical Recommendations
       = render :partial => 'recommendations/recommendation', :collection => recommendations
-  - party_recommendations = party_recommendations_for(other_user.constituency, other_user.willing_party)
+  - party_recommendations = full_party_recommendations_for(other_user.constituency, other_user.willing_party)
   - if party_recommendations.size > 0
     %h6.text-center.mt-2
       Does this help your vote count ? (2)

--- a/app/views/user/swaps/_swap_profile.html.haml
+++ b/app/views/user/swaps/_swap_profile.html.haml
@@ -11,12 +11,12 @@
   :javascript
     drawPollChart("poll_#{other_user.id}", #{poll_data});
 - unless other_user.constituency.nil?
-  - party_recommendations = fullest_recommendations_for(other_user.constituency, other_user.willing_party)
-  - if party_recommendations.size > 0
+  - recommendations = fullest_recommendations_for(other_user.constituency, other_user.willing_party)
+  - if recommendations.size > 0
     %h6.text-center.mt-2
       Does this help your vote count ?
     .profile-recommendations.text-center.smv-card
       .recommendations-header
         Recommendations for
         = other_user.constituency.name
-      = render :partial => 'recommendations/party_recommendation', :collection => party_recommendations
+      = render :partial => 'recommendations/party_recommendation', :collection => recommendations, :as => :rec

--- a/app/views/user/swaps/_swap_profile.html.haml
+++ b/app/views/user/swaps/_swap_profile.html.haml
@@ -19,3 +19,11 @@
       .recommendations-header
         Tactical Recommendations
       = render :partial => 'recommendations/recommendation', :collection => recommendations
+  - party_recommendations = party_recommendations_for(other_user.constituency, other_user.willing_party)
+  - if party_recommendations.size > 0
+    %h6.text-center.mt-2
+      Does this help your vote count ? (2)
+    .profile-recommendations.text-center.smv-card
+      .recommendations-header
+        Tactical Recommendations (2)
+      = render :partial => 'recommendations/party_recommendation', :collection => party_recommendations

--- a/app/views/user/swaps/_swap_profile.html.haml
+++ b/app/views/user/swaps/_swap_profile.html.haml
@@ -25,5 +25,6 @@
       Does this help your vote count ? (2)
     .profile-recommendations.text-center.smv-card
       .recommendations-header
-        Tactical Recommendations (2)
+        Recommendations for
+        = other_user.constituency.name
       = render :partial => 'recommendations/party_recommendation', :collection => party_recommendations

--- a/app/views/user/swaps/_swap_profile.html.haml
+++ b/app/views/user/swaps/_swap_profile.html.haml
@@ -11,7 +11,7 @@
   :javascript
     drawPollChart("poll_#{other_user.id}", #{poll_data});
 - unless other_user.constituency.nil?
-  - party_recommendations = full_party_recommendations_for(other_user.constituency, other_user.willing_party)
+  - party_recommendations = fullest_recommendations_for(other_user.constituency, other_user.willing_party)
   - if party_recommendations.size > 0
     %h6.text-center.mt-2
       Does this help your vote count ?

--- a/app/views/user/swaps/_swap_profile.html.haml
+++ b/app/views/user/swaps/_swap_profile.html.haml
@@ -11,18 +11,10 @@
   :javascript
     drawPollChart("poll_#{other_user.id}", #{poll_data});
 - unless other_user.constituency.nil?
-  - recommendations = recommendations_for(other_user.constituency)
-  - if recommendations.size > 0
-    %h6.text-center.mt-2
-      Does this help your vote count ?
-    .profile-recommendations.text-center.smv-card
-      .recommendations-header
-        Tactical Recommendations
-      = render :partial => 'recommendations/recommendation', :collection => recommendations
   - party_recommendations = full_party_recommendations_for(other_user.constituency, other_user.willing_party)
   - if party_recommendations.size > 0
     %h6.text-center.mt-2
-      Does this help your vote count ? (2)
+      Does this help your vote count ?
     .profile-recommendations.text-center.smv-card
       .recommendations-header
         Recommendations for

--- a/db/fixtures/tactical_vote_sprintforpr_csv.rb
+++ b/db/fixtures/tactical_vote_sprintforpr_csv.rb
@@ -4,7 +4,7 @@
 require("csv")
 
 class TacticalVoteSprintforprCsv
-  attr_reader :file_name, :link, :site
+  attr_reader :file_name, :site
 
   FILE_NAME = "db/fixtures/tactical_vote_sprintforpr.csv"
 
@@ -15,7 +15,6 @@ class TacticalVoteSprintforprCsv
 
   def initialize
     @file_name = FILE_NAME
-    @link = "https://sprintforpr.uk/plan"
     @site = "sprint-for-pr"
   end
 

--- a/db/fixtures/tactical_vote_sprintforpr_recs.rb
+++ b/db/fixtures/tactical_vote_sprintforpr_recs.rb
@@ -47,7 +47,6 @@ class TacticalVoteSprintforprRecs
 
       rec_key = { constituency_ons_id: ons_id, site: advisor.site }
       rec = Recommendation.find_or_initialize_by(rec_key)
-      rec.link = advisor.link
       source_advice = row[:advice]
 
       # ------------------------------------------------------------------------

--- a/db/fixtures/tactical_vote_sprintforpr_recs.rb
+++ b/db/fixtures/tactical_vote_sprintforpr_recs.rb
@@ -47,6 +47,7 @@ class TacticalVoteSprintforprRecs
 
       rec_key = { constituency_ons_id: ons_id, site: advisor.site }
       rec = Recommendation.find_or_initialize_by(rec_key)
+      rec.link = advisor.link
       source_advice = row[:advice]
 
       # ------------------------------------------------------------------------
@@ -77,7 +78,6 @@ class TacticalVoteSprintforprRecs
 
       # ------------------------------------------------------------------------
 
-      rec.link = advisor.link
       rec.save!
       print "." # to signify update
     end

--- a/db/fixtures/tactical_vote_sprintforpr_recs.rb
+++ b/db/fixtures/tactical_vote_sprintforpr_recs.rb
@@ -5,6 +5,8 @@ require_relative "tactical_vote_sprintforpr_csv"
 require_relative "mysociety_constituencies_csv"
 
 class TacticalVoteSprintforprRecs
+  attr_reader :advisor, :mysoc_constituencies
+
   ACCEPTABLE_NON_PARTY_ADVICE = [:not_labour]
   SMV_CODES_BY_ADVICE_TEXT = {
     lib_dem: :libdem,
@@ -13,8 +15,6 @@ class TacticalVoteSprintforprRecs
     green: :green,
     snp: :snp
   }
-
-  attr_reader :advisor, :mysoc_constituencies
 
   def initialize
     @advisor = TacticalVoteSprintforprCsv.new
@@ -71,7 +71,7 @@ class TacticalVoteSprintforprRecs
           print "X" # to signify delete
         end
 
-        not_recognised.add({ advice: source_advice })
+        not_recognised.add({ advice: source_advice, canonical_advice: canonical_advice })
 
         next
       end

--- a/db/fixtures/tactical_vote_sprintforpr_recs.rb
+++ b/db/fixtures/tactical_vote_sprintforpr_recs.rb
@@ -57,11 +57,11 @@ class TacticalVoteSprintforprRecs
       non_party_advice = ACCEPTABLE_NON_PARTY_ADVICE.include?(canonical_advice) ? canonical_advice : nil
 
       if party_smv_code && parties_by_smv_code[party_smv_code]
-        rec.text = party_smv_code.to_s.titleize
         party = parties_by_smv_code[party_smv_code]
+        rec.text = party.name
         rec.update_parties([party])
       elsif non_party_advice && non_party_advice == :not_labour
-        rec.text = "Not Lab"
+        rec.text = "Not Labour"
         rec.update_parties(non_labour_parties)
       else
         # if we can't turn it into a recommendation we must delete any existing entry

--- a/db/fixtures/tactical_vote_stt_csv.rb
+++ b/db/fixtures/tactical_vote_stt_csv.rb
@@ -5,7 +5,7 @@
 require("csv")
 
 class TacticalVoteCsv
-  attr_reader :file_name, :link, :site
+  attr_reader :file_name, :site
 
   FILE_NAME = "db/fixtures/tactical_vote_stt.csv"
 
@@ -16,7 +16,6 @@ class TacticalVoteCsv
 
   def initialize
     @file_name = FILE_NAME
-    @link = "https://stopthetories.vote/"
     @site = "stop-the-tories"
   end
 

--- a/db/fixtures/tactical_vote_stt_recs.rb
+++ b/db/fixtures/tactical_vote_stt_recs.rb
@@ -45,7 +45,6 @@ class TacticalVoteSttRecs
 
       rec_key = { constituency_ons_id: ons_id, site: advisor.site }
       rec = Recommendation.find_or_initialize_by(rec_key)
-      rec.link = advisor.link
       source_advice = row[:advice]
 
       # ------------------------------------------------------------------------

--- a/db/fixtures/tactical_vote_stt_recs.rb
+++ b/db/fixtures/tactical_vote_stt_recs.rb
@@ -39,6 +39,7 @@ class TacticalVoteSttRecs
       ons_id = ons_id_by_mysoc_short_code[row[:mysoc_short_code]]
       rec_key = { constituency_ons_id: ons_id, site: advisor.site }
       rec = Recommendation.find_or_initialize_by(rec_key)
+      rec.link = advisor.link
       source_advice = row[:advice]
 
       # ------------------------------------------------------------------------
@@ -69,7 +70,6 @@ class TacticalVoteSttRecs
 
       # ------------------------------------------------------------------------
 
-      rec.link = advisor.link
       rec.save!
       print "." # to signify update
     end

--- a/db/fixtures/tactical_vote_stt_recs.rb
+++ b/db/fixtures/tactical_vote_stt_recs.rb
@@ -55,8 +55,8 @@ class TacticalVoteSttRecs
       non_party_advice = ACCEPTABLE_NON_PARTY_ADVICE.include?(canonical_advice) ? canonical_advice : nil
 
       if party_smv_code && parties_by_smv_code[party_smv_code]
-        rec.text = party_smv_code.to_s.titleize
         party = parties_by_smv_code[party_smv_code]
+        rec.text = party.name
         rec.update_parties([party])
       elsif non_party_advice && non_party_advice == :heart
         rec.text = "Any"

--- a/db/fixtures/tactical_vote_tacticalvote_csv.rb
+++ b/db/fixtures/tactical_vote_tacticalvote_csv.rb
@@ -4,7 +4,7 @@
 require("csv")
 
 class TacticalVoteTacticalVoteCsv
-  attr_reader :file_name, :link, :site
+  attr_reader :file_name, :site
 
   FILE_NAME = "db/fixtures/tactical_vote_tacticalvote.csv"
 
@@ -15,7 +15,6 @@ class TacticalVoteTacticalVoteCsv
 
   def initialize
     @file_name = FILE_NAME
-    @link = "https://tactical.vote/all/"
     @site = "tactical-vote"
   end
 

--- a/db/fixtures/tactical_vote_tacticalvote_recs.rb
+++ b/db/fixtures/tactical_vote_tacticalvote_recs.rb
@@ -39,6 +39,7 @@ class TacticalVoteTacticalVoteRecs
       ons_id = ons_id_by_mysoc_name[row[:constituency_name]]
       rec_key = { constituency_ons_id: ons_id, site: advisor.site }
       rec = Recommendation.find_or_initialize_by(rec_key)
+      rec.link = advisor.link
       source_advice = row[:advice]
 
       # ------------------------------------------------------------------------
@@ -65,7 +66,6 @@ class TacticalVoteTacticalVoteRecs
 
       # ------------------------------------------------------------------------
 
-      rec.link = advisor.link
       rec.save!
       print "." # to signify update
     end

--- a/db/fixtures/tactical_vote_tacticalvote_recs.rb
+++ b/db/fixtures/tactical_vote_tacticalvote_recs.rb
@@ -55,8 +55,8 @@ class TacticalVoteTacticalVoteRecs
       non_party_advice = ACCEPTABLE_NON_PARTY_ADVICE.include?(canonical_advice) ? canonical_advice : nil
 
       if party_smv_code && parties_by_smv_code[party_smv_code]
-        rec.text = party_smv_code.to_s.titleize
         party = parties_by_smv_code[party_smv_code]
+        rec.text = party.name
         rec.update_parties([party])
       elsif non_party_advice
         # actually, here we mean a party not in our database so we can't link to a party record

--- a/db/fixtures/tactical_vote_tacticalvote_recs.rb
+++ b/db/fixtures/tactical_vote_tacticalvote_recs.rb
@@ -45,7 +45,6 @@ class TacticalVoteTacticalVoteRecs
 
       rec_key = { constituency_ons_id: ons_id, site: advisor.site }
       rec = Recommendation.find_or_initialize_by(rec_key)
-      rec.link = advisor.link
       source_advice = row[:advice]
 
       # ------------------------------------------------------------------------

--- a/db/fixtures/tactical_vote_tacticalvote_recs.rb
+++ b/db/fixtures/tactical_vote_tacticalvote_recs.rb
@@ -5,6 +5,8 @@ require_relative "tactical_vote_tacticalvote_csv"
 require_relative "mysociety_constituencies_csv"
 
 class TacticalVoteTacticalVoteRecs
+  attr_reader :advisor, :mysoc_constituencies
+
   ACCEPTABLE_NON_PARTY_ADVICE = [:alliance, :sinn_fein, :sdlp]
   SMV_CODES_BY_ADVICE_TEXT = {
     lib_dem: :libdem,
@@ -13,8 +15,6 @@ class TacticalVoteTacticalVoteRecs
     green: :green,
     snp: :snp
   }
-
-  attr_reader :advisor, :mysoc_constituencies
 
   def initialize
     @advisor = TacticalVoteTacticalVoteCsv.new
@@ -37,6 +37,12 @@ class TacticalVoteTacticalVoteRecs
 
     advisor.data.each do |row|
       ons_id = ons_id_by_mysoc_name[row[:constituency_name]]
+
+      unless ons_id
+        puts "\nIGNORING: Constituency lookup failed for #{row}."
+        next
+      end
+
       rec_key = { constituency_ons_id: ons_id, site: advisor.site }
       rec = Recommendation.find_or_initialize_by(rec_key)
       rec.link = advisor.link

--- a/doc/recommendations_import.md
+++ b/doc/recommendations_import.md
@@ -1,0 +1,43 @@
+# doc/recommendations_import
+
+## data structure (planned)
+
+### RecommendationSite
+
+The tactical recommendation site.
+
+Conceptual model only. Anticpate frequent changes to the ordering, site names in UI, site summary, site links.
+
+So most of this will be kept in a helper (since UI related) in a hash keyed by 'site_id' which is an invented unique internal code, only needed to uniquely identify the site. It will be independent of domain name changes of the recommended site and of UI changes.
+
+Present value in site IDs
+
+- stop-the-tories
+- sprint-for-pr
+- tactical-vote
+
+### Recommendation
+
+Active record model
+
+What the recommending site actually said in text, and our inferences from that, such as mapping to full party names.
+
+Aim to keep duplication to a minimum, site_id should link to related info in the helper, such as links etc.
+
+### RecommendedParty
+
+Active record model
+
+Where the recommending site text can be identified as a party in our database, this links to the party by id.
+
+Aim to keep duplication to a minimum, site_id should link to related info in the helper, such as links etc.
+
+## migration
+
+Happening as part of [issue 773 - Annotate Swaps with parties in tactical vote recommendations](https://github.com/swapmyvote/swapmyvote/issues/773)
+
+- add new fields to data structure
+- update tactical.vote import to create Recommendation records for parties not in our database
+- update import scripts to populate new fields
+- update helpers and views to pick up data from new places
+- remove any now-rendundant fields

--- a/doc/recommendations_import.md
+++ b/doc/recommendations_import.md
@@ -36,8 +36,8 @@ Aim to keep duplication to a minimum, site_id should link to related info in the
 
 Happening as part of [issue 773 - Annotate Swaps with parties in tactical vote recommendations](https://github.com/swapmyvote/swapmyvote/issues/773)
 
-- add new fields to data structure
-- update tactical.vote import to create Recommendation records for parties not in our database
-- update import scripts to populate new fields
-- update helpers and views to pick up data from new places
-- remove any now-rendundant fields
+- [X] add new fields to data structure
+- [ ] update tactical.vote import to create Recommendation records for parties not in our database
+- [ ] update import scripts to populate new fields
+- [ ] update helpers and views to pick up data from new places
+- [ ] remove any now-rendundant fields

--- a/doc/recommendations_import.md
+++ b/doc/recommendations_import.md
@@ -38,6 +38,6 @@ Happening as part of [issue 773 - Annotate Swaps with parties in tactical vote r
 
 - [X] add new fields to data structure
 - [X] update tactical.vote import to create Recommendation records for parties not in our database
-- [ ] update import scripts to populate new fields
+- [X] update import scripts to populate new fields
 - [ ] update helpers and views to pick up data from new places
 - [ ] remove any now-rendundant fields

--- a/doc/recommendations_import.md
+++ b/doc/recommendations_import.md
@@ -40,4 +40,4 @@ Happening as part of [issue 773 - Annotate Swaps with parties in tactical vote r
 - [X] update tactical.vote import to create Recommendation records for parties not in our database
 - [X] update import scripts to populate new fields
 - [X] update helpers and views to pick up data from new places
-- [ ] remove any now-rendundant fields
+- [X] remove any now-rendundant fields

--- a/doc/recommendations_import.md
+++ b/doc/recommendations_import.md
@@ -39,5 +39,5 @@ Happening as part of [issue 773 - Annotate Swaps with parties in tactical vote r
 - [X] add new fields to data structure
 - [X] update tactical.vote import to create Recommendation records for parties not in our database
 - [X] update import scripts to populate new fields
-- [ ] update helpers and views to pick up data from new places
+- [X] update helpers and views to pick up data from new places
 - [ ] remove any now-rendundant fields

--- a/doc/recommendations_import.md
+++ b/doc/recommendations_import.md
@@ -37,7 +37,7 @@ Aim to keep duplication to a minimum, site_id should link to related info in the
 Happening as part of [issue 773 - Annotate Swaps with parties in tactical vote recommendations](https://github.com/swapmyvote/swapmyvote/issues/773)
 
 - [X] add new fields to data structure
-- [ ] update tactical.vote import to create Recommendation records for parties not in our database
+- [X] update tactical.vote import to create Recommendation records for parties not in our database
 - [ ] update import scripts to populate new fields
 - [ ] update helpers and views to pick up data from new places
 - [ ] remove any now-rendundant fields

--- a/spec/helpers/recommendations_helper_spec.rb
+++ b/spec/helpers/recommendations_helper_spec.rb
@@ -18,41 +18,23 @@ RSpec.describe RecommendationsHelper, type: :helper do
   describe "#recommendations_for" do
     let(:constituency) { instance_double(OnsConstituency) }
     let(:real_recs) do
-      rec_models = LivefrombrexitRecommendationsJson.new.constituencies.first["recs"].map do |recs_hash|
-        rec = Recommendation.new(recs_hash.slice("site"))
-        rec.text = recs_hash["recommendation"]
-        rec.link = recs_hash["link"]
+      rec_models = %w[tactical-vote stop-the-tories].map do |recs_site|
+        rec = Recommendation.new(site: recs_site)
+        rec.text = "#{recs_site}-recommendation"
+        rec.link = "#{recs_site}-link"
         rec
-      end
-      # Now jumble them up so we have a real test
-      rec_models.sort do |a, b|
-        a.site <=> b.site
       end
     end
 
     before { allow(constituency).to receive(:recommendations).and_return(real_recs) }
 
     specify "returns sites in required order" do
-      expected_order = [
-        "get-voting",
-        "peoples-vote",
-        "remain-united",
-        "tacticalvote-co-uk",
-        "tactical-vote",
-        "avaaz-votesmart",
-        "one-uk",
-        "unite-2-leave"
+      expected_order = %w[
+        stop-the-tories
+        tactical-vote
       ]
 
       expect(helper.recommendations_for(constituency).map{ |s|  s.site }).to eq(expected_order)
-    end
-  end
-
-  describe "#recommendations_sites" do
-    it "has keys matching the recommendations json" do
-      LivefrombrexitRecommendationsJson.new.unique_sites.each do |site|
-        expect(helper.recommendations_sites).to have_key(site)
-      end
     end
   end
 end

--- a/spec/helpers/recommendations_helper_spec.rb
+++ b/spec/helpers/recommendations_helper_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RecommendationsHelper, type: :helper do
   describe "#recommendations_for" do
     let(:constituency) { instance_double(OnsConstituency) }
     let(:real_recs) do
-      rec_models = %w[tactical-vote stop-the-tories].map do |recs_site|
+      %w[tactical-vote stop-the-tories].map do |recs_site|
         rec = Recommendation.new(site: recs_site)
         rec.text = "#{recs_site}-recommendation"
         rec.link = "#{recs_site}-link"
@@ -36,5 +36,15 @@ RSpec.describe RecommendationsHelper, type: :helper do
 
       expect(helper.recommendations_for(constituency).map{ |s|  s.site }).to eq(expected_order)
     end
+  end
+
+  describe "#recommendation_site_models_in_order" do
+    subject { helper.recommendation_site_models_in_order }
+
+    specify { is_expected.not_to be_empty }
+
+    specify { is_expected.to all(respond_to(:id)) }
+    specify { is_expected.to all(respond_to(:order)) }
+    specify { is_expected.to all(respond_to(:link)) }
   end
 end

--- a/spec/views/user/swaps/show.html.haml_spec.rb
+++ b/spec/views/user/swaps/show.html.haml_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe "user/swaps/show", type: :view do
 
   context "with recommendations and potential swaps" do
     specify do
-      rec1 = build(:recommendation, site: "peoples-vote")
-      rec2 = build(:recommendation, site: "get-voting")
+      rec1 = build(:recommendation, site: "stop-the-tories")
+      rec2 = build(:recommendation, site: "tactical-vote")
       willing_party = build(:party)
       preferred_party = build(:party)
       constituency1 = build(:ons_constituency, ons_id: "one", id: 1)


### PR DESCRIPTION
Closes #773 and #230

Shows tactical voting recomended sites as sentences on swaps listing

Several phases

# Phase 1 - basics - show good swaps

- basics of showing the new ticks recommendations
- correct population of links on recommendation party table
- add link to recommendation party
- show the original recommendation text
- remove ambiguity about recommendation constituency

# Phase 2 - now show bad swaps

- now also showing bad swaps
- remove the tabular display of recommendations
- reduce site list in helpers/recommendations

# Phase 3 - show recommedation sites that have no recommendations

- add unknowns to recommendations
- some party names fully resolved

# Phase 4 - refactor, normalise data, always use full party name

- document: the plan
- make recommendation site more like AR model
- add basics to RecommendationSite for migration
- quick fix for NI issue - parties become text only
- align the TV imports, look for refactoring opportunities
- use full party names where we can
- passing all normalised data to view
- passing all normalised data to view - part 2
- dont populate the fields we dont need right now

