### PR TITLE
issue 794 party colours in poll chart

### DIFF
--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -18,7 +18,7 @@ class Party < ApplicationRecord
     for_britain: { name: "For Britain" },
     freedom_alliance: { name: "Freedom Alliance" },
     independent: { name: "Independent" },
-    reform: { name: "Reform", ge_default: true },
+    reform: { name: "Reform", color: "#5bc0de", ge_default: true },
     rejoin_eu: { name: "Rejoin eu" },
     workers: { name: "Workers" },
     yorkshire: { name: "Yorkshire" },

--- a/db/seeds_for_general_election.rb
+++ b/db/seeds_for_general_election.rb
@@ -20,7 +20,7 @@ parties_for_ge = Party.master_list.select { |p| p[:ge_default] }
 
 parties_for_ge.each do |party_attributes|
   party = Party.find_or_initialize_by(name: party_attributes[:name])
-  party.update!(party_attributes.slice(:smv_code, :colour))
+  party.update!(party_attributes.slice(:smv_code, :color))
   puts party_attributes.slice(:name, :smv_code)
 end
 


### PR DESCRIPTION
Closes #794

Previous refactoring lost the colouring of parties during the seeding process.

- pick the right attribute for colo(u)r
- fill in missing colour for reform
