### PR TITLE
issue 800 bug in user seeding

### DIFF
--- a/db/seeds/development/users.seeds.rb
+++ b/db/seeds/development/users.seeds.rb
@@ -1,4 +1,4 @@
-
+# rubocop:disable Metrics/MethodLength
 def create_random_user(i, preferred_party_id, willing_party_id)
   gender = rand > 0.5 ? "female" : "male"
   firstname = gender == "male" ? Random.firstname_male : Random.firstname_female
@@ -15,11 +15,16 @@ def create_random_user(i, preferred_party_id, willing_party_id)
     willing_party_id: willing_party_id
   )
 
+  unless user.valid?
+    puts "User not created: #{user.errors.full_messages}"
+    return
+  end
+
   build_identity(user.id, i, gender)
 end
 
 def build_identity(user_id, i, gender)
-  Identity.create(
+  Identity.create!(
     user_id: user_id,
     provider: provider_array.sample,
     image_url: format("https://api.randomuser.me/portraits/med/%s/#{i}.jpg",
@@ -30,6 +35,8 @@ end
 def provider_array
   [:twitter, :facebook]
 end
+
+puts "Creating users"
 
 5.times do |i|
   create_random_user(i, 1, 2)

--- a/db/seeds/development/users.seeds.rb
+++ b/db/seeds/development/users.seeds.rb
@@ -16,7 +16,7 @@ def create_random_user(i, preferred_party_id, willing_party_id)
   )
 
   unless user.valid?
-    puts "User not created: #{user.errors.full_messages}"
+    puts "User #{user.email} not created: #{user.errors.full_messages}"
     return
   end
 
@@ -38,6 +38,10 @@ end
 
 puts "Creating users"
 
+starting_user_count = User.count
+puts starting_user_count.zero? ? "No existing users" : "#{starting_user_count} users already in database"
+puts "\n"
+
 5.times do |i|
   create_random_user(i, 1, 2)
   create_random_user(i, 1, 3)
@@ -57,3 +61,5 @@ puts "Creating users"
   create_random_user(i, 4, 3)
   create_random_user(i, 3, 4)
 end
+
+puts "\nFinished user creation, #{User.count} users in database, #{User.count - starting_user_count} users added"

--- a/db/seeds/development/users.seeds.rb
+++ b/db/seeds/development/users.seeds.rb
@@ -9,7 +9,7 @@ def create_random_user(i, preferred_party_id, willing_party_id)
 
   user = User.create(
     name: "#{firstname} #{Random.lastname}",
-    email: "#{firstname.downcase}@example.com",
+    email: "#{firstname.downcase}.#{i}-#{preferred_party_id}-#{willing_party_id}@example.com",
     constituency_ons_id: ons_id,
     preferred_party_id: preferred_party_id,
     willing_party_id: willing_party_id


### PR DESCRIPTION
Closes #800

It became evident on re-running seeds that odd things were happening with users. We were neither re-using the existing users, nor were we adding a full set of new users.

Turns out email addresses were not unique, and creates were failing silently. Even on the first seed run.

Fixed by making emails much more unique, by appending party_ids to first name in email address.

- step 1: report the error when it happens
- make email address unique
- give developer feedback on user creation
