### PR TITLE
don't hardcode hostname into privacy link URL

### DIFF
--- a/app/views/static_pages/faq.html.haml
+++ b/app/views/static_pages/faq.html.haml
@@ -90,8 +90,7 @@
       We only collect the minimum of data to allow us to find you a
       swap - see our
 
-      = link_to "privacy policy",
-                "http://www.swapmyvote.uk/privacy"
+      = link_to("privacy policy", privacy_path)
 
       for more about how we use cookies to monitor visits to the site.
 


### PR DESCRIPTION
This could redirect testers from staging to production, which we don't want to happen.

There are a bunch of other hardcoded mentions of swapmyvote.uk:

- Some need keeping (e.g. OpenGraph)
- Some (e.g. email footers) first need DRY refactoring to use helpers