### PR TITLE
disable logins during `closed-warm-up` mode

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,6 +31,11 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def require_logins_open
+    return if logins_open?
+    redirect_to root_path
+  end
+
   def require_swapping_open
     return if swapping_open?
     redirect_to root_path

--- a/app/controllers/concerns/app_mode_concern.rb
+++ b/app/controllers/concerns/app_mode_concern.rb
@@ -14,7 +14,7 @@ module AppModeConcern
     "closed-and-voting",
     # The fancy new mode where we keep swaps open but don't allow users
     # with confirmed swaps to cancel or change their voting preferences
-    # or constituency.
+    # or constituency or delete their profile.
     "open-and-voting",
 
     # Post-election aftermath
@@ -41,6 +41,21 @@ module AppModeConcern
 
   def raise_invalid_mode(type, mode)
     raise "Invalid #{type} '#{mode}'; should be one of: #{VALID_MODES}"
+  end
+
+  def logins_open?
+    # During closed-warm-up the database should be empty, and most
+    # likely we're furiously coding and getting everything ready.
+    # At this point we don't want to mislead users into thinking
+    # there is anything usable, and or testers into thinking that
+    # they can test on the main site.
+    #
+    # At all other times, logins should be open.  In particular,
+    # closed-wind-down should allow logins so that users can delete
+    # their account via users#edit (although note this deletion is
+    # prevented via restricted_when_voting_open during open-and-voting
+    # mode).
+    return app_mode != "closed-warm-up"
   end
 
   def swapping_open?

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
+  before_action :require_logins_open
   before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -49,7 +49,7 @@
 
       - if logged_in?
         = render partial: "layouts/current_user"
-      - else
+      - elsif logins_open?
         = render partial: "layouts/login"
 
     - if flash[:errors]


### PR DESCRIPTION
This is confusing our testers and also potentially anyone else who notices this way of logging in.

Fixes #798.