### PR TITLE
environments/development: reintroduce debug log_level to config

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,6 +3,10 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = :debug
+
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.


### PR DESCRIPTION
This was accidentally dropped by 29874551 during the Rails upgrade.  Originally introduced by #767 in 36ff5531.