### PR TITLE
set default env variables correctly for user seeding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,7 +43,7 @@ export SWAPMYVOTE_MODE=open
 
 # Uncomment this to allow test users (example.com / Facebook test
 # users) to skip mobile verification
-# export TEST_USERS_SKIP_MOBILE_VERIFICATION=yes
+export TEST_USERS_SKIP_MOBILE_VERIFICATION=yes
 
 # Set to "all" to disable any login method other than email.
 # export DISABLE_LOG_INS=facebook


### PR DESCRIPTION
Closes #846. Without this setting, seeding the database with users will fail
