### PR TITLE
issue 229 tactical campaign names

### DIFF
--- a/app/helpers/recommendations_helper.rb
+++ b/app/helpers/recommendations_helper.rb
@@ -68,7 +68,7 @@ module RecommendationsHelper
         order: 1,
         name: "Stop The Tories",
         meta_desc: "Your vote is your power. " + \
-                   "Use it tactically to get the Tories out, then influence your new MP and the next government. ",
+                   "Use it tactically to get the Tories out, then influence your new MP and the next government.",
         link: "https://stopthetories.vote/"
       },
       "sprint-for-pr" => {

--- a/app/helpers/recommendations_helper.rb
+++ b/app/helpers/recommendations_helper.rb
@@ -65,28 +65,28 @@ module RecommendationsHelper
   def recommendations_sites
     {
       "stop-the-tories" => {
-        order: 1 ,
+        order: 1,
         link: "https://stopthetories.vote/"
       },
       "sprint-for-pr" => {
         order: 2,
         link: "https://sprintforpr.uk/plan"
       },
-        "tactical-vote" => {
-          order: 3,
-          link: "https://tactical.vote/all/"
+      "tactical-vote" => {
+        order: 3,
+        link: "https://tactical.vote/all/"
       },
       "scotland-in-union" => {
-          order: 4,
-          link: "https://scotlandinunion.co.uk/"
+        order: 4,
+        link: "https://scotlandinunion.co.uk/"
       },
       "tacticalvote-co-uk" => {
-          order: 5,
-          link: "https://tacticalvote.co.uk/"
+        order: 5,
+        link: "https://tacticalvote.co.uk/"
       },
       "get-voting-org" => {
-          order: 6,
-          link: "https://getvoting.org/"
+        order: 6,
+        link: "https://getvoting.org/"
       }
     }
   end

--- a/app/helpers/recommendations_helper.rb
+++ b/app/helpers/recommendations_helper.rb
@@ -66,26 +66,32 @@ module RecommendationsHelper
     {
       "stop-the-tories" => {
         order: 1,
+        name: "Stop The Tories",
         link: "https://stopthetories.vote/"
       },
       "sprint-for-pr" => {
         order: 2,
+        name: "Sprint for PR",
         link: "https://sprintforpr.uk/plan"
       },
       "tactical-vote" => {
         order: 3,
+        name: "Tactical (dot) Vote",
         link: "https://tactical.vote/all/"
       },
       "scotland-in-union" => {
         order: 4,
+        name: "Scotland in Union",
         link: "https://scotlandinunion.co.uk/"
       },
       "tacticalvote-co-uk" => {
         order: 5,
+        name: "Tactical Vote UK",
         link: "https://tacticalvote.co.uk/"
       },
       "get-voting-org" => {
         order: 6,
+        name: "Get Voting",
         link: "https://getvoting.org/"
       }
     }

--- a/app/helpers/recommendations_helper.rb
+++ b/app/helpers/recommendations_helper.rb
@@ -67,30 +67,38 @@ module RecommendationsHelper
       "stop-the-tories" => {
         order: 1,
         name: "Stop The Tories",
+        meta_desc: "Your vote is your power. " + \
+                   "Use it tactically to get the Tories out, then influence your new MP and the next government. ",
         link: "https://stopthetories.vote/"
       },
       "sprint-for-pr" => {
         order: 2,
         name: "Sprint for PR",
+        meta_desc: "How and where to vote tactically in the next general election " + \
+                   "to advocate for proportional representation",
         link: "https://sprintforpr.uk/plan"
       },
       "tactical-vote" => {
         order: 3,
+        meta_desc: "How to vote tactically to get the Tories out in the 2024 General Election",
         name: "Tactical (dot) Vote",
         link: "https://tactical.vote/all/"
       },
       "scotland-in-union" => {
         order: 4,
+        meta_desc: "Campaigning to keep Scotland in the UK, challenging the independence agenda from the SNP",
         name: "Scotland in Union",
         link: "https://scotlandinunion.co.uk/"
       },
       "tacticalvote-co-uk" => {
         order: 5,
+        meta_desc: "Want to get the Tories out? Tactical Voting is the answer.",
         name: "Tactical Vote UK",
         link: "https://tacticalvote.co.uk/"
       },
       "get-voting-org" => {
         order: 6,
+        meta_desc: "A tactical voting & voter informaton campaign from Best for Britain.",
         name: "Get Voting",
         link: "https://getvoting.org/"
       }

--- a/app/views/recommendations/_party_recommendation.html.haml
+++ b/app/views/recommendations/_party_recommendation.html.haml
@@ -2,9 +2,9 @@
   - if rec.match != :unknown
     - if rec.match == :good
       &#x2705
-    = link_to rec.site.name, rec.site.link, :title => "#{rec.site.name} say: #{rec.site.meta_desc}"
+    = link_to rec.site.name, rec.site.link, :title => "#{rec.site.name}: \"#{rec.site.meta_desc}\""
     recommend
     = rec.recommendation.text
   - else
-    = link_to rec.site.name, rec.site.link, :title => "#{rec.site.name} say: #{rec.site.meta_desc}"
+    = link_to rec.site.name, rec.site.link, :title => "#{rec.site.name}: \"#{rec.site.meta_desc}\""
     has no recommendation

--- a/app/views/recommendations/_party_recommendation.html.haml
+++ b/app/views/recommendations/_party_recommendation.html.haml
@@ -2,9 +2,9 @@
   - if rec.match != :unknown
     - if rec.match == :good
       &#x2705
-    = link_to URI.parse(rec.site.link).host, rec.site.link
+    = link_to rec.site.name, rec.site.link, :title => "#{rec.site.name} say: #{rec.site.meta_desc}"
     recommend
     = rec.recommendation.text
   - else
-    = link_to URI.parse(rec.site.link).host, rec.site.link
+    = link_to rec.site.name, rec.site.link, :title => "#{rec.site.name} say: #{rec.site.meta_desc}"
     has no recommendation


### PR DESCRIPTION
Closes issue #229, providing name for all the TV campaigns

- **issue-229: correct formatting**
- **issue-229: add names to TV site data**
- **issue-229: add meta description info for each site**
- **issue-229: replace host names with TV site names on the website**

Demonstrating mouse-over:

<img width="568" alt="image" src="https://github.com/swapmyvote/swapmyvote/assets/55932/478118e5-d3a4-4bf2-9ef0-2b1425b7c2fb">
