### PR TITLE
issue-878: dont allow 9.7 to show in floating point

### DIFF
--- a/app/views/user/swaps/_polls_advice.html.haml
+++ b/app/views/user/swaps/_polls_advice.html.haml
@@ -1,6 +1,6 @@
 %p
   - polls_percent = poll.marginal_score/100.0
-  - percent_score = (polls_percent >= 10 ? "%d%%" : "%.1g%%") % [polls_percent]
+  - percent_score = (polls_percent >= 9 ? "%d%%" : "%.1g%%") % [polls_percent]
   - if poll.marginal_score < 1000
     - lead_trail = poll.signed_marginal_score.positive? ? "leading" : "only trailing the leading party"
     &#x2B50; Looks like this swap could make a difference for


### PR DESCRIPTION
Without this change, values >= 9.5 and < 10 get rounded up to 10 but the 'g' format still applies, and the result is in floating point

Closes #878

Before: 
<img width="467" alt="image" src="https://github.com/swapmyvote/swapmyvote/assets/55932/4c305cbc-b2c9-43de-b1f9-e7d7d72e3c67">

After:
<img width="454" alt="image" src="https://github.com/swapmyvote/swapmyvote/assets/55932/2896581a-d20b-43f0-979d-7e2135c1eaf3">

