### PR TITLE
Migrate to GA4

### DIFF
--- a/app/views/layouts/_google_analytics.html.haml
+++ b/app/views/layouts/_google_analytics.html.haml
@@ -3,11 +3,13 @@
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    })(window,document,'script','https://www.googletagmanager.com/gtag/js', 'gtag');
 
-    ga('create', '#{ENV['GOOGLE_ANALYTICS_ID']}', 'auto');
-    ga('set', 'anonymizeIp', true);
-    ga('send', 'pageview');
+    console.log("#{ENV['GOOGLE_ANALYTICS_ID']}");
+    gtag('config', '#{ENV['GOOGLE_ANALYTICS_ID']}', 'auto');
+    gtag('create', '#{ENV['GOOGLE_ANALYTICS_ID']}', 'auto');
+    gtag('set', 'anonymizeIp', true);
+    gtag('send', 'pageview');
 
 - else
   <!-- GOOGLE_ANALYTICS_ID not set -->

--- a/app/views/layouts/_google_analytics.html.haml
+++ b/app/views/layouts/_google_analytics.html.haml
@@ -5,11 +5,15 @@
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','https://www.googletagmanager.com/gtag/js', 'gtag');
 
-    console.log("#{ENV['GOOGLE_ANALYTICS_ID']}");
     gtag('config', '#{ENV['GOOGLE_ANALYTICS_ID']}', 'auto');
-    gtag('create', '#{ENV['GOOGLE_ANALYTICS_ID']}', 'auto');
     gtag('set', 'anonymizeIp', true);
-    gtag('send', 'pageview');
+    // GA4 automatically tracks pageviews, adding it explicitly risks double counting, so removed intentionally
+
+    // Example syntax to send a custom event
+    /* gtag("event", "click", {
+      "event_category": "foo",
+      "event_label": "bar"
+    });*/
 
 - else
   <!-- GOOGLE_ANALYTICS_ID not set -->


### PR DESCRIPTION
Migration to GA4, mostly removing old code that's no longer needed

Notes on the GA4 migration

* GA4 is already up and running and tracking page views, google did the migration for us automatically
* If you want to keep old analytics data for comparison, you should download it as recommended by GA - optional if we just want the latest data
* Otherwise, I think we're ready to click the button to complete GA migration


One possibly-related thing: https://tacticalvote.co.uk/ still has outdated references to ga, is this our code? Because if so, we should make a fix there. I couldn't find it in the swapmyvote codebase