### PR TITLE
Fix profile image placement on Firefox

### DIFF
--- a/app/views/user/swaps/_swap_profile.html.haml
+++ b/app/views/user/swaps/_swap_profile.html.haml
@@ -1,4 +1,4 @@
-.profile
+.profile.d-flex
   = render partial: "user/swaps/swap_profile_inner", locals: { other_user: other_user }
 
 - poll_data = poll_data_for(other_user.constituency)


### PR DESCRIPTION
We were rendering divs in a random order which happened to work on Chrome but not on other browsers. Use flexbox to set the order.

Closes #802