### PR TITLE
Change "log in" to "log in or sign up"

### DIFF
--- a/app/views/layouts/_login.html.haml
+++ b/app/views/layouts/_login.html.haml
@@ -5,7 +5,7 @@
   .modal-dialog
     .modal-content
       .modal-header
-        %h2{ class: "h4 mb-0" } Log in
+        %h2{ class: "h4 mb-0" } Log In or Sign Up
         %button.close{ type: "button", data: { dismiss: "modal" },
                        aria: { label: "Close" } }
           %i.fa.fa-times.subdued
@@ -19,18 +19,18 @@
               %button{ formaction: facebook_login_path, formmethod: :post,
                       class: "btn btn-facebook btn-block" }
                 = image_tag('facebook_icon.png')
-                Log in with Facebook
+                Log in or sign up with Facebook
           - if log_in_with_twitter?
             %p.text-center
               %button{ formaction: twitter_login_path, formmethod: :post,
                       class: "btn btn-twitter btn-block" }
                 %i.fa.fa-fw.fa-twitter
-                Log in with Twitter
+                Log in or sign up with Twitter
           - if log_in_with_email?
             %p.text-center
               %button{ formaction: new_user_session_path, formmethod: :post,
                       class: "btn btn-dark btn-block" }
-                Log in with email
+                Log in or sign up with email
           .form-check
             %input.form-check-input{ type: "checkbox", id: "data-consent",
                     name: "data-consent", required: true }

--- a/spec/views/layouts/_login.html.haml_spec.rb
+++ b/spec/views/layouts/_login.html.haml_spec.rb
@@ -24,17 +24,17 @@ RSpec.describe "layouts/_login", type: :view do
 
     it "login modal allows Facebook login" do
       render
-      expect(rendered).to include "Log in with Facebook"
+      expect(rendered).to include "Log in or sign up with Facebook"
     end
 
     it "login modal doesn't allow Twitter login" do
       render
-      expect(rendered).not_to include "Log in with Twitter"
+      expect(rendered).not_to include "Log in or sign up with Twitter"
     end
 
     it "login modal doesn't allow email login" do
       render
-      expect(rendered).not_to include "Log in with email"
+      expect(rendered).not_to include "Log in or sign up with email"
     end
   end
 
@@ -45,17 +45,17 @@ RSpec.describe "layouts/_login", type: :view do
 
     it "login modal doesn't allow Facebook login" do
       render
-      expect(rendered).not_to include "Log in with Facebook"
+      expect(rendered).not_to include "Log in or sign up with Facebook"
     end
 
     it "login modal allows Twitter login" do
       render
-      expect(rendered).to include "Log in with Twitter"
+      expect(rendered).to include "Log in or sign up with Twitter"
     end
 
     it "login modal doesn't allow email login" do
       render
-      expect(rendered).not_to include "Log in with email"
+      expect(rendered).not_to include "Log in or sign up with email"
     end
   end
 
@@ -66,17 +66,17 @@ RSpec.describe "layouts/_login", type: :view do
 
     it "login modal doesn't allow Facebook login" do
       render
-      expect(rendered).not_to include "Log in with Facebook"
+      expect(rendered).not_to include "Log in or sign up with Facebook"
     end
 
     it "login modal doesn't allow Twitter login" do
       render
-      expect(rendered).not_to include "Log in with Twitter"
+      expect(rendered).not_to include "Log in or sign up with Twitter"
     end
 
     it "login modal allows email login" do
       render
-      expect(rendered).to include "Log in with email"
+      expect(rendered).to include "Log in or sign up with email"
     end
   end
 end


### PR DESCRIPTION
On the user page we need to make it clear that you can log in or sign up.

Partially addresses #591.