### PR TITLE
Add an invisible CAPTCHA

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,8 @@ gem "haml_lint"
 
 gem "webpacker", "~> 5.x"
 
+gem "invisible_captcha", "~> 2.3"
+
 # These need to be outside the development group for Rakefile to
 # be happy in Heroku.
 gem "rubocop", "~> 1.22.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,8 @@ GEM
     hashie (5.0.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    invisible_captcha (2.3.0)
+      rails (>= 5.2)
     jazz_fingers (6.2.0)
       amazing_print (~> 1.3)
       pry (~> 0.10)
@@ -498,6 +500,7 @@ DEPENDENCIES
   guard-yarn
   haml-rails
   haml_lint
+  invisible_captcha (~> 2.3)
   jazz_fingers
   jquery-rails
   jquery-ui-rails

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,6 +2,7 @@
 
 class Users::RegistrationsController < Devise::RegistrationsController
   before_action :configure_sign_up_params, only: [:create]
+  invisible_captcha only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -32,6 +32,8 @@
             <%= f.label  :consent_news_email, "Opt-in to Forward Democracy email updates", class: "mb-0 form-check-label" %>
           </div>
 
+          <%= invisible_captcha %>
+
           <%= render "devise/shared/error_messages", resource: resource %>
 
           <div class="actions">


### PR DESCRIPTION
We add an invisible CAPTCHA using https://github.com/markets/invisible_captcha. This is added to the email sign-up form.

Closes #861