### PR TITLE
Improve mobile phone verification flow

### DIFF
--- a/app/controllers/user/swaps_controller.rb
+++ b/app/controllers/user/swaps_controller.rb
@@ -60,8 +60,7 @@ class User::SwapsController < ApplicationController
   def assert_mobile_phone_verified
     return unless @user.mobile_verification_missing?
 
-    flash[:errors] = ["Please verify your mobile phone number before you swap!"]
-    redirect_to edit_user_path
+    redirect_to verify_mobile_path
   end
 
   def assert_has_email

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,12 +45,6 @@ class UsersController < ApplicationController
   end
 
   def redirect_path
-    # If the user came from the edit path, and the mobile still needs verification, return there
-    if params[:user] && mobile_set_but_not_verified?
-      flash[:errors] = ["Please click the Verify button to verify the mobile phone number you provided."]
-      return edit_user_path
-    end
-
     return edit_user_path unless @user.valid?
 
     # Otherwise, return to the user path - user will see a verification prompt if needed

--- a/app/views/mobile_phone/_form.html.haml
+++ b/app/views/mobile_phone/_form.html.haml
@@ -1,12 +1,4 @@
-.form-group
+.form-group.form-group-short
   %label.mb-0 My mobile number is
-  = telephone_field_tag "mobile_phone[full]", mobile_number, size: 14, class: "form-control"
 
-  - if mobile_number.present?
-    - if mobile_verified?
-      Verified!
-    - else
-      = button_tag "Verify", formaction: verify_mobile_path,
-        formmethod: :get, class: "btn btn-secondary"
-  - else
-    = submit_tag("Save", class: "btn btn-secondary")
+  = telephone_field_tag "mobile_phone[full]", mobile_number, size: 14, class: "form-control"

--- a/app/views/mobile_phone/verify_create.html.haml
+++ b/app/views/mobile_phone/verify_create.html.haml
@@ -3,7 +3,7 @@
     - if mobile_verified?
       .card
         .card-header
-          %h1.h4.mb-0 Already verified!
+          %h1.h4.mb-0 Already verified
 
         .card-body
           %p

--- a/app/views/user/constituencies/edit.html.haml
+++ b/app/views/user/constituencies/edit.html.haml
@@ -12,13 +12,14 @@
             = render partial: "users/why_need_email"
             = link_to "Your details will stay private with us.", privacy_path
 
-      = render partial: "users/postcode_field"
-
       %p.ui-widget
         My constituency is
         = f.collection_select :constituency_ons_id, @constituencies,
                               :ons_id, :name,
                               selected: @default_constituency_ons_id,
                               prompt: true
+
+      = render partial: "users/postcode_field"
+
       %p.text-center
         = submit_tag("Save", class: "btn btn-primary")

--- a/app/views/users/_postcode_field.html.haml
+++ b/app/views/users/_postcode_field.html.haml
@@ -1,5 +1,6 @@
+%label.mb-0 Or find my constituency using my postcode
+
 .form-group.form-group-short
-  %label.mb-0 My postcode is
   .input-group
     %input.form-control#txt-postcode{ type: "text", size: 10, minlength: 5,
                                       maxlength: 9, spellcheck: "false" }

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -26,8 +26,6 @@
                                     selected: @user.willing_party_id },
                                   { class: "form-control" }
 
-          = render partial: "postcode_field"
-
           .form-group
             %label.mb-0 My constituency is
             %br
@@ -36,6 +34,8 @@
                                   { prompt: "...",
                                     selected: @user.constituency_ons_id },
                                   { class: "form-control" }
+
+          = render partial: "postcode_field"
 
           .form-group
             = render partial: "users/email_field", locals: { f: f }

--- a/spec/controllers/user/swaps_controller_spec.rb
+++ b/spec/controllers/user/swaps_controller_spec.rb
@@ -296,19 +296,18 @@ RSpec.describe User::SwapsController, type: :controller do
     end
 
     describe "POST #create" do
-      it "redirects to user page" do
+      it "redirects to mobile verification page" do
         expect(new_user.swap).to be_nil
 
         post :create, params: { user_id: swap_user.id }
 
-        expect(response).to redirect_to :edit_user
-        expect(flash[:errors].first).to eq "Please verify your mobile phone number before you swap!"
+        expect(response).to redirect_to "/mobile_phone/verify_create"
         expect(new_user.swap).to be_nil
       end
     end
 
     describe "PUT #update" do
-      it "confirms the swap if all ducks are lined up" do
+      it "redirects to mobile verification page" do
         swap = Swap.create(chosen_user_id: swap_user.id)
         new_user.incoming_swap = swap
         swap_user.outgoing_swap = swap
@@ -317,8 +316,7 @@ RSpec.describe User::SwapsController, type: :controller do
 
         put :update, params: { swap: { confirmed: true } }
 
-        expect(response).to redirect_to :edit_user
-        expect(flash[:errors].first).to eq "Please verify your mobile phone number before you swap!"
+        expect(response).to redirect_to "/mobile_phone/verify_create"
         expect(swap_user.swap.confirmed).to be nil
       end
     end


### PR DESCRIPTION
The main differences are:

1. Swap the order of the postcode and constituency fields, and make it clear that the postcode is only to find the constituency (this has bugged me for ages)
2. You don't get asked to verify your phone number until the very last moment - when you ask to swap. This is a pain for the user, we want to get them almost to the end of the process (and hooked) before asking for this extra effort.
3. The "Save" and "Verify" buttons are gone from the mobile phone field. It all just happens at the point where you need it to.

Closes #166