### PR TITLE
allow verification of mobile whilst waiting for potential swaps

### DIFF
--- a/app/views/mobile_phone/_form.html.haml
+++ b/app/views/mobile_phone/_form.html.haml
@@ -2,3 +2,11 @@
   %label.mb-0 My mobile number is
 
   = telephone_field_tag "mobile_phone[full]", mobile_number, size: 14, class: "form-control"
+
+  - if mobile_verified?
+    Verified!
+  - elsif allow_verification
+    = button_tag "Verify",
+                 formaction: verify_mobile_path,
+                 formmethod: :get,
+                 class: "btn btn-secondary"

--- a/app/views/user/swaps/_searching_for_swap.html.haml
+++ b/app/views/user/swaps/_searching_for_swap.html.haml
@@ -21,7 +21,8 @@
     account is genuine.
 
   = form_for @user, url: user_path do
-    = render partial: 'mobile_phone/form', locals: {mobile_number: @mobile_number}
+    = render partial: 'mobile_phone/form',
+             locals: {allow_verification: true, mobile_number: @mobile_number}
 
 %h3 Spread the word!
 

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -41,7 +41,7 @@
             = render partial: "users/email_field", locals: { f: f }
 
           = render partial: 'mobile_phone/form',
-            locals: {mobile_number: @mobile_number}
+                   locals: {allow_verification: false, mobile_number: @mobile_number}
 
           %p.subdued.small
             = render partial: "why_need_email"


### PR DESCRIPTION
When there are no swaps available, there's no other call to action so it makes sense to capitalise on the waiting time to get the user to verify their mobile, so that they're ready to swap when a partner materialises.

This is still WIP with issues:

- failing tests

- "Verified!" appears the line below the number field, rather than to the right

- probably there's a more elegant way to do it than this `allow_verification` local