### PR TITLE
Fix issue with missing emails

### DIFF
--- a/app/controllers/user/constituencies_controller.rb
+++ b/app/controllers/user/constituencies_controller.rb
@@ -18,7 +18,7 @@ class User::ConstituenciesController < ApplicationController
 
     else
 
-      flash.now[:errors] = ["You must tell us your constituency. Without it, the swaps we offer may not make sense"]
+      flash.now[:errors] = ["You must tell us your constituency. Without it, the swaps we offer may not make sense."]
       edit
       render "edit"
 

--- a/app/controllers/user/swaps_controller.rb
+++ b/app/controllers/user/swaps_controller.rb
@@ -6,6 +6,7 @@ class User::SwapsController < ApplicationController
   before_action :assert_parties_exist, only: [:show]
   before_action :assert_has_email, only: [:new, :create, :update]
   before_action :assert_has_constituency, only: [:new, :create, :update]
+  before_action :assert_mobile_phone_present, only: [:new, :create, :update]
   before_action :assert_mobile_phone_verified, only: [:new, :create, :update]
   before_action :hide_polls?, only: [:show, :new]
 
@@ -57,6 +58,13 @@ class User::SwapsController < ApplicationController
 
   private
 
+  def assert_mobile_phone_present
+    return unless @user.mobile_phone.blank?
+
+    flash[:errors] = ["Please enter your mobile phone number before you swap"]
+    redirect_to edit_user_path
+  end
+
   def assert_mobile_phone_verified
     return unless @user.mobile_verification_missing?
 
@@ -66,14 +74,14 @@ class User::SwapsController < ApplicationController
   def assert_has_email
     return unless @user.email.blank?
 
-    flash[:errors] = ["Please enter your email address before you swap!"]
+    flash[:errors] = ["Please enter your email address before you swap"]
     redirect_to edit_user_path
   end
 
   def assert_has_constituency
     return unless @user.constituency_ons_id.blank?
 
-    flash[:errors] = ["Please enter your postcode or constituency before you swap!"]
+    flash[:errors] = ["Please enter your postcode or constituency before you swap"]
     redirect_to edit_user_path
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,8 +33,13 @@ class User < ApplicationRecord
   # Additional validation for emails, :validatable has already added basic validation
   validate :email_uniqueness, on: :create
 
+  # Required fields
   validates :name, presence: true
+  validates :email, presence: true
   validates :consent_to_data_processing, acceptance: true
+
+  # Name cannot be the same as email
+  validate :check_email_and_name
 
   include UsersHelper
   include ::UserErrorsConcern
@@ -389,6 +394,10 @@ class User < ApplicationRecord
     return unless existing_user
 
     email_uniqueness_errors(existing_user)
+  end
+
+  def check_email_and_name
+    errors.add(:name, "can't be the same as email") if email == name
   end
 
   def find_existing_email(email)

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -9,7 +9,7 @@
         <%= render "devise/shared/error_messages", resource: resource %>
 
         <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-          <div class="form-group">
+          <div class="form-group required">
             <%= f.label :email, class: "mb-0" %>
             <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
           </div>

--- a/app/views/mobile_phone/_form.html.haml
+++ b/app/views/mobile_phone/_form.html.haml
@@ -1,4 +1,4 @@
-.form-group.form-group-short
+.form-group.form-group-short.required
   %label.mb-0 My mobile number is
 
   = telephone_field_tag "mobile_phone[full]", mobile_number, size: 14, class: "form-control"

--- a/app/views/mobile_phone/verify_token.html.haml
+++ b/app/views/mobile_phone/verify_token.html.haml
@@ -3,14 +3,15 @@
     - if @new_verification
       .card
         .card-header
-          %h1.h4.mb-0 Verification successful!
+          %h1.h4.mb-0 Verification successful
 
         .card-body
           %p
             Thank you for verifying your mobile phone number.
 
-          = link_to user_path do
-            = button_tag "Continue", class: 'btn btn-primary'
+          .d-flex.justify-content-center
+            = link_to user_path do
+              = button_tag "Continue", class: 'btn btn-primary'
 
     - else
       .card
@@ -21,5 +22,6 @@
           %p
             Your mobile phone number was already verified.
 
-          = link_to user_path do
-            = button_tag "Continue", class: 'btn btn-primary'
+          .d-flex.justify-content-center
+            = link_to user_path do
+              = button_tag "Continue", class: 'btn btn-primary'

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -10,7 +10,7 @@
           Edit profile
       .card-body
         = form_for @user, url: user_path do |f|
-          .form-group
+          .form-group.required
             %label.mb-0 My preferred party is
             = f.collection_select :preferred_party_id, @parties,
                                   :id, :name,
@@ -18,7 +18,7 @@
                                     selected: @user.preferred_party_id },
                                   { class: "form-control" }
 
-          .form-group
+          .form-group.required
             %label.mb-0 but I'm willing to vote for
             = f.collection_select :willing_party_id, @parties,
                                   :id, :name,
@@ -26,7 +26,7 @@
                                     selected: @user.willing_party_id },
                                   { class: "form-control" }
 
-          .form-group
+          .form-group.required
             %label.mb-0 My constituency is
             %br
             = f.collection_select :constituency_ons_id, @constituencies,
@@ -37,7 +37,7 @@
 
           = render partial: "postcode_field"
 
-          .form-group
+          .form-group.required
             = render partial: "users/email_field", locals: { f: f }
 
           = render partial: 'mobile_phone/form',


### PR DESCRIPTION
If the user doesn't have a verified mobile number and they try to swap then we send the validation code to them. Unfortunately if they don't have a number at all then we will crash as there's no mobile number to send the code to!

To fix this, if the user has no mobile number at all we redirect to the user edit page for them to provide it.

We also add a check that the email and name aren't the same, this fixes #953.

Finally we tidy up some more UI:

1. Adding required stars to things that are required
2. Centre buttons so we're consistent
3. Remove "!" from UI text

Closes #953
Closes #952
Closes #950