### PR TITLE
Prevent name from being an email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,8 +38,8 @@ class User < ApplicationRecord
   validates :email, presence: true
   validates :consent_to_data_processing, acceptance: true
 
-  # Name cannot be the same as email
-  validate :check_email_and_name
+  # Name cannot look like an email
+  validate :check_name_is_not_email
 
   include UsersHelper
   include ::UserErrorsConcern
@@ -396,8 +396,8 @@ class User < ApplicationRecord
     email_uniqueness_errors(existing_user)
   end
 
-  def check_email_and_name
-    errors.add(:name, "can't be the same as email") if email == name
+  def check_name_is_not_email
+    errors.add(:name, "can't be an email") if name.include? "@"
   end
 
   def find_existing_email(email)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -487,6 +487,12 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "name validation" do
+    it "prevents name that looks like an email" do
+      expect{create(:user, name: "foo@bar.com", email: "bar@foo.com")}.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
   context "when user has email login" do
     before do
       subject.email = "foo@example.com"


### PR DESCRIPTION
We reject names that have an "@" in them.

Closes #953