### PR TITLE
remove ActiveRecord#update_attributes which was removed in Rails 6.1

### DIFF
--- a/app/controllers/mobile_phone_controller.rb
+++ b/app/controllers/mobile_phone_controller.rb
@@ -47,7 +47,7 @@ class MobilePhoneController < ApplicationController
   def rescue_error(message_text)
     # Make sure the number is removed if we could not send verification
     # or if it is a duplicate
-    phone.update_attributes(number: nil)
+    phone.update(number: nil)
     flash[:errors] = message_text
     redirect_back fallback_location: edit_user_path
     return


### PR DESCRIPTION
https://guides.rubyonrails.org/6_1_release_notes.html#active-record-removals
https://stackoverflow.com/questions/21605186/undefined-method-update-attributes-in-rails

Fixes #918.