### PR TITLE
issue 951 willing party id nil

### DIFF
--- a/app/views/users/review.haml
+++ b/app/views/users/review.haml
@@ -3,21 +3,43 @@
 
 .plain-pattern.border-bottom
   .container.container-narrow
+    - constituency = @user.constituency
+    - party = @user.willing_party
 
-    .profile-poll
+    - if !party || !constituency
       .text-center.small
-        Predicted GE2024 results for #{@user.constituency.try(:name) or "Unknown"}
-      .poll-chart{ id: "poll_#{@user.id}" }
-      - poll_data = poll_data_for(@user.constituency)
-      :javascript
-        drawPollChart("poll_#{@user.id}", #{poll_data});
+        Whoops, you shouldn't be here.
+        - if !party
+          We don't know the party you are offering to vote for.
+        - if !constituency
+          We don't know the constituency you're going to vote in.
+        Please go and edit your profile details, and that should bring you back here when you're done.
+        = link_to "Edit Profile", edit_user_path, class: "btn btn-primary"
 
-    %p.text-center
-      - poll = @user.constituency.polls.detect { |poll| poll.party_id == @user.willing_party.id }
-      = render partial: "user/swaps/polls_interpretation_self", locals: { poll: poll, party: @user.willing_party, constituency: @user.constituency }
-    %p.text-center
-      %strong
-        Do you want to proceed with this party, or change your offered vote?
-    %p.text-center
-      = link_to "Proceed", user_path, class: "btn btn-primary"
-      = link_to "Change", edit_user_path, class: "btn btn-primary"
+    - else
+      .profile-poll
+        .text-center.small
+          Predicted GE2024 results for #{constituency.try(:name) or "Unknown"}
+          - logger.debug @user.inspect
+        .poll-chart{ id: "poll_chart_self" }
+        - poll_data = poll_data_for(constituency)
+        :javascript
+          drawPollChart("poll_chart_self", #{poll_data});
+
+      %p.text-center
+        - poll = constituency.polls.detect { |poll| poll.party_id == party.id }
+        - if poll
+          = render partial: "user/swaps/polls_interpretation_self", locals: { poll: poll, party: party, constituency: constituency }
+        - else
+          No polling data found for
+          = party.name
+          in
+          = constituency.name
+          so we can't interpret that for you.
+
+      %p.text-center
+        %strong
+          Do you want to proceed with this party, or change your offered vote?
+      %p.text-center
+        = link_to "Proceed", user_path, class: "btn btn-primary"
+        = link_to "Change", edit_user_path, class: "btn btn-primary"

--- a/spec/controllers/mobile_phone_controller_spec.rb
+++ b/spec/controllers/mobile_phone_controller_spec.rb
@@ -51,6 +51,13 @@ RSpec.describe MobilePhoneController, type: :controller do
         expect(response).to have_http_status(:success)
         expect(response).to render_template "verify_create"
       end
+
+      it "redirects to use page if no mobile number" do
+        stub_verify_create
+        get :verify_create
+        expect(flash[:errors]).to include("Please enter your mobile phone number before you swap")
+        expect(response).to redirect_to(edit_user_path)
+      end
     end
   end
 end

--- a/spec/views/users/review.html.haml_spec.rb
+++ b/spec/views/users/review.html.haml_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe "users/review", type: :view do
+  context "user with preferred_party nil and constituency nil" do
+    # replicates error in https://github.com/swapmyvote/swapmyvote/issues/951
+    specify do
+      assign(:user, build(:user))
+      expect { render }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Closes #951

Issue #951 should not happen again because, although we can't recreate it, the spec here sets up exactly the same conditions, however that happened.

This is presently built on the fix-crash branch so either
* merge this when happy with both, or
* cherry-pick this commit somewher else if not merging fix-crash

- **issue-951: fix for id nil on /user/review**
- **Ensure we have a mobile number before sending verification message**
