### PR TITLE
user/edit: show errors if willing/preferred parties missing

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,6 +45,13 @@ class UsersController < ApplicationController
       end
     end
 
+    unless @user.willing_party
+      (flash[:errors] ||= []).append "You must state which party you are willing to vote for."
+    end
+    unless @user.preferred_party
+      (flash[:errors] ||= []).append "You must state which party you would prefer to vote for."
+    end
+
     no_flash_errors = (!flash[:errors] || flash[:errors].size.zero?)
 
     if @user.valid? && no_flash_errors && review_required

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -5,7 +5,13 @@ RSpec.describe UsersController, type: :controller do
 
   context "when user is logged in" do
     let(:logged_in_user) do
-      create(:ready_to_swap_user1, id: 111, constituency: build(:ons_constituency), willing_party: build(:party))
+      create(
+        :ready_to_swap_user1,
+        id: 111,
+        constituency: build(:ons_constituency),
+        willing_party: build(:party),
+        preferred_party: build(:party, name: "another party")
+      )
     end
 
     before do
@@ -93,9 +99,13 @@ RSpec.describe UsersController, type: :controller do
       end
 
       it "redirects to #review if user has changed willing party" do
-        post :update, params: { user: { willing_party_id: (logged_in_user.willing_party_id + 1) } }
-        expect(response).to redirect_to(review_user_path)
+        post :update, params: {
+               user: {
+                 willing_party_id: create(:party).id
+               }
+             }
         expect(flash[:errors]).not_to be_present
+        expect(response).to redirect_to(review_user_path)
       end
     end
 


### PR DESCRIPTION
Currently if you sign up, you land on `/user/edit` with empty parties due to bug #824.  If you then hit Save, it goes nowhere but doesn't explain why, so add flash errors for this.

However, this increases the risk of the willing party review being accidentally skipped (i.e. if preferred party was left blank), for reasons described here:

https://github.com/swapmyvote/swapmyvote/issues/960#issuecomment-2207404365

Given the last 24 hours, I'm nervous about this change and it needs careful testing.