### PR TITLE
rake task to send email reminders to get swapping

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -76,6 +76,7 @@ class AdminController < ApplicationController
 
       UserMailer.not_swapped_follow_up(current_user).deliver_now
       UserMailer.partner_has_voted(current_user).deliver_now
+      UserMailer.reminder_to_get_swapping(current_user).deliver_now
       UserMailer.reminder_to_vote(current_user).deliver_now
       UserMailer.no_swap(current_user).deliver_now
       UserMailer.swap_not_confirmed(current_user).deliver_now

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -58,6 +58,12 @@ class UserMailer < ApplicationMailer
     mail(to: @user.email, subject: "#{@user.swapped_with.name} has voted for you!")
   end
 
+  def reminder_to_get_swapping(user)
+    return nil if user.email.blank?
+    @user = user
+    mail(to: @user.email, subject: "It's not too late to swap your vote!")
+  end
+
   def reminder_to_vote(user)
     return nil if user.email.blank?
     @user = user

--- a/app/models/sent_email.rb
+++ b/app/models/sent_email.rb
@@ -1,4 +1,6 @@
 class SentEmail < ApplicationRecord
   belongs_to :user
+
   WELCOME = :welcome_email
+  REMINDER_GET_SWAPPING = :reminder_get_swapping
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -305,6 +305,16 @@ class User < ApplicationRecord
     !email.blank? && sent_emails.where(template: SentEmail::WELCOME).none?
   end
 
+  def send_get_swapping_reminder_email
+    return unless can_receive_email?("get swapping")
+    if SentEmail.find_by(user_id: id, template: SentEmail::REMINDER_GET_SWAPPING)
+      logger.info "Already sent get swapping reminder email to #{name_and_email}"
+      return
+    end
+    UserMailer.reminder_to_get_swapping(self).deliver_now
+    sent_emails.create!(template: SentEmail::REMINDER_GET_SWAPPING)
+  end
+
   def send_vote_reminder_email
     return if sent_vote_reminder_email
     self.sent_vote_reminder_email = true

--- a/app/views/home/_closed_wind_down.html.haml
+++ b/app/views/home/_closed_wind_down.html.haml
@@ -16,7 +16,7 @@
                   and are now looking forward to see the results.
 
       %p
-        We will run SwapMyVote again for the next elections,
+        We will run Swap My Vote again for the next elections,
         whenever that turns out to be.
 
       %p

--- a/app/views/user_mailer/reminder_to_get_swapping.html.haml
+++ b/app/views/user_mailer/reminder_to_get_swapping.html.haml
@@ -1,0 +1,37 @@
+- utm = '?utm_source=email&utm_medium=reminder-get-swapping&utm_campaign=site'
+
+%p
+  Hello #{@user.name},
+
+%p
+  You're signed up to Swap My Vote but you haven't found a swap
+  yet.  There's still time!
+
+- if @user.willing_party
+  %p
+    If you haven't been offered a swap yet or have had your offers
+    declined, please
+
+    = succeed "." do
+      = link_to "review whether #{@user.willing_party.name} in your constituency is helpful to potential vote swap partners.", review_user_url + utm
+
+%p
+  If you just haven't had time to look for a swap yet, or were waiting
+  for more choices,
+
+  = succeed "!" do
+    = link_to "visit Swap My Vote now", root_url + utm
+
+- if voting_open?
+  %p
+    As it's polling day, once a swap is offered and confirmed, it isn't
+    possible to change it, so please offer or confirm only if you're
+    definitely happy with the swap.
+
+%p
+  To a better democracy,
+
+%p
+  <a href="https://www.swapmyvote.uk/#{utm}">Swap My Vote</a>
+  %br
+  = render partial: "footer_fixed_links"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,6 +45,11 @@ Rails.application.configure do
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
+  # Uncomment to tell Action Mailer not to deliver emails to the real world.
+  # The :test delivery method accumulates sent emails in the
+  # ActionMailer::Base.deliveries array.
+  # config.action_mailer.delivery_method = :test
+
   # Raise exceptions for disallowed deprecations.
   config.active_support.disallowed_deprecation = :raise
 

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,4 +1,15 @@
 namespace :users do
+  desc "Send reminder emails to everyone without any swap"
+  task send_get_swapping_reminder_emails: :environment do
+    for user in User.left_outer_joins(:incoming_swap).where(swap_id: nil, "swaps.chosen_user_id": nil)
+      begin
+        user.send_get_swapping_reminder_email
+      rescue => e
+        print "Failed to send vote reminder"
+      end
+    end
+  end
+
   desc "Send vote reminder emails to everyone with a confirmed swap"
   task send_vote_reminder_emails: :environment do
     for swap in Swap.where(confirmed: true)

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,5 +1,5 @@
 namespace :users do
-  desc "Send vote reminder emails to everyone"
+  desc "Send vote reminder emails to everyone with a confirmed swap"
   task send_vote_reminder_emails: :environment do
     for swap in Swap.where(confirmed: true)
       begin

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -294,6 +294,27 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#send_get_swapping_reminder_email" do
+    context "when the user has an email address" do
+      before { subject.update(email: "some@email.address", willing_party: build(:party)) }
+
+      describe "sends a reminder email" do
+        before { subject.sent_emails.clear }
+
+        let(:an_email) { double(:an_email) }
+
+        it "sends only one email" do
+          expect(an_email).to receive(:deliver_now)
+          expect(UserMailer).to receive(:reminder_to_get_swapping).with(subject).and_return(an_email)
+          subject.send_get_swapping_reminder_email
+
+          expect(UserMailer).not_to receive(:reminder_to_get_swapping)
+          subject.send_get_swapping_reminder_email
+        end
+      end
+    end
+  end
+
   describe "#send_welcome_email (after_save callback)" do
     context "when the user DOES have an email address" do
       before { subject.update(email: "some@email.address") }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -280,6 +280,20 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#can_receive_email?" do
+    it "returns false for test users" do
+      expect(subject.can_receive_email?("welcome")).to be_falsey
+    end
+
+    it "returns false for users with blank email" do
+      expect(build(:user, email: "").can_receive_email?("welcome")).to be_falsey
+    end
+
+    it "returns true for non-test users" do
+      expect(build(:user, email: "real@address.honest.com").can_receive_email?("welcome")).to be_truthy
+    end
+  end
+
   describe "#send_welcome_email (after_save callback)" do
     context "when the user DOES have an email address" do
       before { subject.update(email: "some@email.address") }

--- a/spec/views/home/__snapshots__/_closed_wind_down_by_election.snap
+++ b/spec/views/home/__snapshots__/_closed_wind_down_by_election.snap
@@ -11,7 +11,7 @@ We closed swaps shortly before the polls closed, and are now
 looking forward to see the results.
 </p>
 <p>
-We will run SwapMyVote again for the next elections,
+We will run Swap My Vote again for the next elections,
 whenever that turns out to be.
 </p>
 <p>

--- a/spec/views/home/__snapshots__/_closed_wind_down_general.snap
+++ b/spec/views/home/__snapshots__/_closed_wind_down_general.snap
@@ -11,7 +11,7 @@ We closed swaps shortly before the polls closed, and are now
 looking forward to see the results.
 </p>
 <p>
-We will run SwapMyVote again for the next elections,
+We will run Swap My Vote again for the next elections,
 whenever that turns out to be.
 </p>
 <p>

--- a/spec/views/user_mailer/__snapshots__/reminder_to_get_swapping_by_election.snap
+++ b/spec/views/user_mailer/__snapshots__/reminder_to_get_swapping_by_election.snap
@@ -1,0 +1,36 @@
+<p>
+Hello John (test user),
+</p>
+<p>
+You're signed up to Swap My Vote but you haven't found a swap
+yet.  There's still time!
+</p>
+<p>
+If you haven't been offered a swap yet or have had your offers
+declined, please
+<a href="http://test.host/user/review">review whether PartyB in your constituency is helpful to potential vote swap partners.</a>.
+</p>
+<p>
+If you just haven't had time to look for a swap yet, or were waiting
+for more choices,
+<a href="http://test.host/">visit Swap My Vote now</a>!
+</p>
+<p>
+As it's polling day, once a swap is offered and confirmed, it isn't
+possible to change it, so please offer or confirm only if you're
+definitely happy with the swap.
+</p>
+<p>
+We'll email again when we close???
+</p>
+<p>
+To a better democracy,
+</p>
+<p>
+<a href="https://www.swapmyvote.uk/?utm_source=email&utm_medium=welcome_email&utm_campaign=site">Swap My Vote</a>
+<br>
+<a href="https://twitter.com/intent/follow?screen_name=swapmyvote">Follow us on Twitter</a>
+<br>
+<a href="https://facebook.com/swapmyvote">Like us on Facebook</a>
+
+</p>

--- a/spec/views/user_mailer/__snapshots__/reminder_to_get_swapping_by_election_open-and-voting.snap
+++ b/spec/views/user_mailer/__snapshots__/reminder_to_get_swapping_by_election_open-and-voting.snap
@@ -1,0 +1,33 @@
+<p>
+Hello John (test user),
+</p>
+<p>
+You're signed up to Swap My Vote but you haven't found a swap
+yet.  There's still time!
+</p>
+<p>
+If you haven't been offered a swap yet or have had your offers
+declined, please
+<a href="http://test.host/user/review?utm_source=email&amp;utm_medium=reminder-get-swapping&amp;utm_campaign=site">review whether PartyB in your constituency is helpful to potential vote swap partners.</a>.
+</p>
+<p>
+If you just haven't had time to look for a swap yet, or were waiting
+for more choices,
+<a href="http://test.host/?utm_source=email&amp;utm_medium=reminder-get-swapping&amp;utm_campaign=site">visit Swap My Vote now</a>!
+</p>
+<p>
+As it's polling day, once a swap is offered and confirmed, it isn't
+possible to change it, so please offer or confirm only if you're
+definitely happy with the swap.
+</p>
+<p>
+To a better democracy,
+</p>
+<p>
+<a href="https://www.swapmyvote.uk/?utm_source=email&amp;utm_medium=reminder-get-swapping&amp;utm_campaign=site">Swap My Vote</a>
+<br>
+<a href="https://twitter.com/intent/follow?screen_name=swapmyvote">Follow us on Twitter</a>
+<br>
+<a href="https://facebook.com/swapmyvote">Like us on Facebook</a>
+
+</p>

--- a/spec/views/user_mailer/__snapshots__/reminder_to_get_swapping_by_election_open.snap
+++ b/spec/views/user_mailer/__snapshots__/reminder_to_get_swapping_by_election_open.snap
@@ -1,0 +1,28 @@
+<p>
+Hello John (test user),
+</p>
+<p>
+You're signed up to Swap My Vote but you haven't found a swap
+yet.  There's still time!
+</p>
+<p>
+If you haven't been offered a swap yet or have had your offers
+declined, please
+<a href="http://test.host/user/review?utm_source=email&amp;utm_medium=reminder-get-swapping&amp;utm_campaign=site">review whether PartyB in your constituency is helpful to potential vote swap partners.</a>.
+</p>
+<p>
+If you just haven't had time to look for a swap yet, or were waiting
+for more choices,
+<a href="http://test.host/?utm_source=email&amp;utm_medium=reminder-get-swapping&amp;utm_campaign=site">visit Swap My Vote now</a>!
+</p>
+<p>
+To a better democracy,
+</p>
+<p>
+<a href="https://www.swapmyvote.uk/?utm_source=email&amp;utm_medium=reminder-get-swapping&amp;utm_campaign=site">Swap My Vote</a>
+<br>
+<a href="https://twitter.com/intent/follow?screen_name=swapmyvote">Follow us on Twitter</a>
+<br>
+<a href="https://facebook.com/swapmyvote">Like us on Facebook</a>
+
+</p>

--- a/spec/views/user_mailer/__snapshots__/reminder_to_get_swapping_general.snap
+++ b/spec/views/user_mailer/__snapshots__/reminder_to_get_swapping_general.snap
@@ -1,0 +1,36 @@
+<p>
+Hello John (test user),
+</p>
+<p>
+You're signed up to Swap My Vote but you haven't found a swap
+yet.  There's still time!
+</p>
+<p>
+If you haven't been offered a swap yet or have had your offers
+declined, please
+<a href="http://test.host/user/review">review whether PartyB in your constituency is helpful to potential vote swap partners.</a>.
+</p>
+<p>
+If you just haven't had time to look for a swap yet, or were waiting
+for more choices,
+<a href="http://test.host/">visit Swap My Vote now</a>!
+</p>
+<p>
+As it's polling day, once a swap is offered and confirmed, it isn't
+possible to change it, so please offer or confirm only if you're
+definitely happy with the swap.
+</p>
+<p>
+We'll email again when we close???
+</p>
+<p>
+To a better democracy,
+</p>
+<p>
+<a href="https://www.swapmyvote.uk/?utm_source=email&utm_medium=welcome_email&utm_campaign=site">Swap My Vote</a>
+<br>
+<a href="https://twitter.com/intent/follow?screen_name=swapmyvote">Follow us on Twitter</a>
+<br>
+<a href="https://facebook.com/swapmyvote">Like us on Facebook</a>
+
+</p>

--- a/spec/views/user_mailer/__snapshots__/reminder_to_get_swapping_general_election_open-and-voting.snap
+++ b/spec/views/user_mailer/__snapshots__/reminder_to_get_swapping_general_election_open-and-voting.snap
@@ -1,0 +1,33 @@
+<p>
+Hello John (test user),
+</p>
+<p>
+You're signed up to Swap My Vote but you haven't found a swap
+yet.  There's still time!
+</p>
+<p>
+If you haven't been offered a swap yet or have had your offers
+declined, please
+<a href="http://test.host/user/review?utm_source=email&amp;utm_medium=reminder-get-swapping&amp;utm_campaign=site">review whether PartyB in your constituency is helpful to potential vote swap partners.</a>.
+</p>
+<p>
+If you just haven't had time to look for a swap yet, or were waiting
+for more choices,
+<a href="http://test.host/?utm_source=email&amp;utm_medium=reminder-get-swapping&amp;utm_campaign=site">visit Swap My Vote now</a>!
+</p>
+<p>
+As it's polling day, once a swap is offered and confirmed, it isn't
+possible to change it, so please offer or confirm only if you're
+definitely happy with the swap.
+</p>
+<p>
+To a better democracy,
+</p>
+<p>
+<a href="https://www.swapmyvote.uk/?utm_source=email&amp;utm_medium=reminder-get-swapping&amp;utm_campaign=site">Swap My Vote</a>
+<br>
+<a href="https://twitter.com/intent/follow?screen_name=swapmyvote">Follow us on Twitter</a>
+<br>
+<a href="https://facebook.com/swapmyvote">Like us on Facebook</a>
+
+</p>

--- a/spec/views/user_mailer/__snapshots__/reminder_to_get_swapping_general_election_open.snap
+++ b/spec/views/user_mailer/__snapshots__/reminder_to_get_swapping_general_election_open.snap
@@ -1,0 +1,28 @@
+<p>
+Hello John (test user),
+</p>
+<p>
+You're signed up to Swap My Vote but you haven't found a swap
+yet.  There's still time!
+</p>
+<p>
+If you haven't been offered a swap yet or have had your offers
+declined, please
+<a href="http://test.host/user/review?utm_source=email&amp;utm_medium=reminder-get-swapping&amp;utm_campaign=site">review whether PartyB in your constituency is helpful to potential vote swap partners.</a>.
+</p>
+<p>
+If you just haven't had time to look for a swap yet, or were waiting
+for more choices,
+<a href="http://test.host/?utm_source=email&amp;utm_medium=reminder-get-swapping&amp;utm_campaign=site">visit Swap My Vote now</a>!
+</p>
+<p>
+To a better democracy,
+</p>
+<p>
+<a href="https://www.swapmyvote.uk/?utm_source=email&amp;utm_medium=reminder-get-swapping&amp;utm_campaign=site">Swap My Vote</a>
+<br>
+<a href="https://twitter.com/intent/follow?screen_name=swapmyvote">Follow us on Twitter</a>
+<br>
+<a href="https://facebook.com/swapmyvote">Like us on Facebook</a>
+
+</p>

--- a/spec/views/user_mailer/reminder_to_get_swapping.html.haml_spec.rb
+++ b/spec/views/user_mailer/reminder_to_get_swapping.html.haml_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe "user_mailer/reminder_to_get_swapping", type: :view do
+  before do
+    allow(OnsConstituency).to receive(:all).and_return([build(:wakefield), build(:tiverton)])
+  end
+
+  %w[by general].each do |election_type|
+    %w[open open-and-voting].each do |mock_app_mode|
+      context "in a by-election" do
+        specify "matches snapshot" do
+          allow(view).to receive(:general_election?).and_return(election_type == "general")
+          allow(view).to receive(:app_mode).and_return(mock_app_mode)
+
+          assign(:user, build(:ready_to_swap_user1))
+
+          expect { render }.not_to raise_error
+
+          expect(rendered).to match_snapshot("reminder_to_get_swapping_#{election_type}_election_#{mock_app_mode}")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
For now, emails are only sent once per user.

Fixes #925.