### PR TITLE
constituency first

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -29,9 +29,8 @@ linters:
   EmptyScript:
     enabled: true
 
-  # Seems to default to true anyway, but uncommenting it interferes with the TODO file
-  # HtmlAttributes:
-  #   enabled: true
+  HtmlAttributes:
+    enabled: false
 
   ImplicitDiv:
     enabled: true

--- a/.haml-lint_todo.yml
+++ b/.haml-lint_todo.yml
@@ -19,14 +19,6 @@ linters:
       - "app/views/user/vote/show.html.haml"
       - "app/views/users/_info_summary.html.haml"
 
-  # Offense count: 42
-  HtmlAttributes:
-    exclude:
-      - "app/views/home/_swap_form.html.haml"
-      - "app/views/static_pages/contact.html.haml"
-      - "app/views/static_pages/faq.html.haml"
-      - "app/views/static_pages/privacy.html.haml"
-
   # Offense count: 27
   InstanceVariables:
     exclude:

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -40,6 +40,10 @@ p {
     &.choose-constituency {
         font-size: 34px;
     }
+
+    &.hidden-field {
+        display: none;
+    }
 }
 
 h1,

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -36,6 +36,10 @@ p {
     &.choose-party {
         font-size: 34px;
     }
+
+    &.choose-constituency {
+        font-size: 34px;
+    }
 }
 
 h1,

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -10,7 +10,6 @@ class HomeController < ApplicationController
     end
 
     logger.warn "params.inspect: #{params.inspect}"
-    logger.warn "session['pre_populate'].inspect: #{session["pre_populate"].inspect}"
     logger.warn "session['pre_login_flow'].inspect: #{session["pre_login_flow"].inspect}"
 
     # Don't change this without also updating the related comment in
@@ -22,14 +21,11 @@ class HomeController < ApplicationController
 
     @parties = Party.all
     @constituencies = OnsConstituency.all
-
-    prepopulate_fields_from_session
   end
 
   # rubocop:disable Metrics/MethodLength
   def pre_login
     logger.warn "params.inspect: #{params.inspect}"
-    logger.warn "session['pre_populate'].inspect: #{session["pre_populate"].inspect}"
     logger.warn "session['pre_login_flow'].inspect: #{session["pre_login_flow"].inspect}"
 
     if params["constituency_ons_id"]

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -21,6 +21,7 @@ class HomeController < ApplicationController
 
     @parties = Party.all
     @constituencies = OnsConstituency.all.order(:name)
+    @default_constituency_ons_id = default_ons_constituency&.ons_id
   end
 
   # rubocop:disable Metrics/MethodLength

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -50,7 +50,10 @@ class HomeController < ApplicationController
     if !pre_login_candidates_form_complete || !pre_login_candidates_form_complete
       # the view will figure out which form to render
       @parties = Party.all
-      @constituencies = OnsConstituency.all
+      @constituencies = OnsConstituency.all.order(:name)
+
+      prepopulate_fields_from_session
+
       render action: "index" and return
     end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -20,7 +20,7 @@ class HomeController < ApplicationController
     end
 
     @parties = Party.all
-    @constituencies = OnsConstituency.all
+    @constituencies = OnsConstituency.all.order(:name)
   end
 
   # rubocop:disable Metrics/MethodLength

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,10 +1,17 @@
 class HomeController < ApplicationController
+  include HomeHelper
+
   before_action :whats_the_magic_word
 
   def index
-    if params.key?(:clear) && prepops
+    if params.key?(:clear)
       session.delete("pre_populate")
+      session.delete("pre_login_flow")
     end
+
+    logger.warn "params.inspect: #{params.inspect}"
+    logger.warn "session['pre_populate'].inspect: #{session["pre_populate"].inspect}"
+    logger.warn "session['pre_login_flow'].inspect: #{session["pre_login_flow"].inspect}"
 
     # Don't change this without also updating the related comment in
     # the view!
@@ -14,8 +21,44 @@ class HomeController < ApplicationController
     end
 
     @parties = Party.all
+    @constituencies = OnsConstituency.all
 
     prepopulate_fields_from_session
+  end
+
+  # rubocop:disable Metrics/MethodLength
+  def pre_login
+    logger.warn "params.inspect: #{params.inspect}"
+    logger.warn "session['pre_populate'].inspect: #{session["pre_populate"].inspect}"
+    logger.warn "session['pre_login_flow'].inspect: #{session["pre_login_flow"].inspect}"
+
+    if params["constituency_ons_id"]
+      unless params["constituency_ons_id"].empty?
+
+        logger.warn "params['constituency_ons_id']: #{params["constituency_ons_id"]}"
+
+        @constituency_ons_id = params["constituency_ons_id"]
+        mark_pre_login_constituency_complete
+      end
+    end
+
+    if params["user"]
+      if params["user"]["willing_party_id"] &&
+        !params["user"]["willing_party_id"].empty?
+        params["user"]["preferred_party_id"] &&
+        !params["user"]["preferred_party_id"].empty?
+        mark_pre_login_parties_complete
+      end
+    end
+
+    if !pre_login_candidates_form_complete || !pre_login_candidates_form_complete
+      # the view will figure out which form to render
+      @parties = Party.all
+      @constituencies = OnsConstituency.all
+      render action: "index" and return
+    end
+
+    render action: "new", controller: "../users/sessions"
   end
 
   private

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -52,7 +52,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # If you have extra params to permit, append them to the sanitizer.
   def configure_sign_up_params
     devise_parameter_sanitizer.permit(:sign_up, keys: [
-      :name, :preferred_party_id, :willing_party_id, :consent_news_email, :consent_to_data_processing
+      :name, :preferred_party_id, :willing_party_id, :consent_news_email,
+      :consent_to_data_processing, :constituency_ons_id
     ])
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,11 @@ class UsersController < ApplicationController
 
   def show
     @mobile_number = @user.mobile_number
+
+    logger.warn "@user.email.blank?: #{@user.email.blank?}"
+    logger.warn "!@user.constituency: #{!@user.constituency}"
+    logger.warn "@user: #{@user.inspect}"
+
     if !@user.constituency || @user.email.blank?
       redirect_to edit_user_constituency_path
       return

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,2 +1,23 @@
 module HomeHelper
+  def pre_login_flow
+    return session["pre_login_flow"] || {}
+  end
+
+  def pre_login_constituency_form_complete
+    !!pre_login_flow["constituency_form_complete"]
+  end
+
+  def pre_login_candidates_form_complete
+    !!pre_login_flow["candidates_form_complete"]
+  end
+
+  def mark_pre_login_constituency_complete
+    session["pre_login_flow"] ||= {}
+    session["pre_login_flow"]["constituency_form_complete"] = true
+  end
+
+  def mark_pre_login_parties_complete
+    session["pre_login_flow"] ||= {}
+    session["pre_login_flow"]["parties_form_complete"] = true
+  end
 end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -4,7 +4,7 @@ module HomeHelper
   end
 
   def pre_login_constituency_form_complete
-    !!pre_login_flow["constituency_form_complete"]
+    params["constituency_ons_id"] && !params["constituency_ons_id"].empty?
   end
 
   def pre_login_candidates_form_complete

--- a/app/javascript/packs/postcodesHelper.js
+++ b/app/javascript/packs/postcodesHelper.js
@@ -39,7 +39,7 @@ $(document).ready(() => {
     const name = postcode.result.parliamentary_constituency_2024;
 
     const hasOption = $(
-      'select#user_constituency_ons_id option[value="' + onsId + '"]'
+      'select#constituency_ons_id option[value="' + onsId + '"]'
     );
 
     if (hasOption.length == 0) {
@@ -48,13 +48,13 @@ $(document).ready(() => {
       );
       // this only changes the hidden dropdown, not the auto-complete
       // one
-      $("select#user_constituency_ons_id").val("").change();
+      $("select#constituency_ons_id").val("").change();
       $(".constituency-autocomplete-input").val("");
     } else {
       // this only changes the hidden dropdown, not the auto-complete
       // one
       clearPostcodeError();
-      $("select#user_constituency_ons_id").val(onsId).change(); // this SHOULD change the dropdown
+      $("select#constituency_ons_id").val(onsId).change(); // this SHOULD change the dropdown
       $(".constituency-autocomplete-input").val(name);
     }
   };
@@ -84,6 +84,6 @@ $(document).ready(() => {
   };
 
   $("#txt-postcode").keyup(postcodeEnter);
-  
+
   clearPostcodeError();
 });

--- a/app/views/home/_candidates_form.html.haml
+++ b/app/views/home/_candidates_form.html.haml
@@ -10,7 +10,7 @@
     = select :user, :willing_party_id, nil, {}, {form: 'login-form'} do
       %option(disabled=true selected=true) ...
       = options_for_select(parties.map {|p| [ p.name, p.id ]}, selected: willing_party_id)
-  %p
+  %p.hidden-field
     = hidden_field_tag 'user[constituency_ons_id]', constituency_ons_id
 
   %p

--- a/app/views/home/_candidates_form.html.haml
+++ b/app/views/home/_candidates_form.html.haml
@@ -3,15 +3,15 @@
     Which party would you most like to vote for?
     = select :user, :preferred_party_id, nil, {}, {form: 'login-form'} do
       %option(disabled=true selected=true) ...
-      = options_for_select(@parties.map {|p| [ p.name, p.id ]}, selected: @preferred_party_id)
+      = options_for_select(parties.map {|p| [ p.name, p.id ]}, selected: preferred_party_id)
   %p.choose-party
     When we find someone to vote for your party in #{election_constituency_other},
     which party could you vote for in exchange?
     = select :user, :willing_party_id, nil, {}, {form: 'login-form'} do
       %option(disabled=true selected=true) ...
-      = options_for_select(@parties.map {|p| [ p.name, p.id ]}, selected: @willing_party_id)
+      = options_for_select(parties.map {|p| [ p.name, p.id ]}, selected: willing_party_id)
   %p
-    = hidden_field_tag 'user[constituency_ons_id]', @constituency_ons_id
+    = hidden_field_tag 'user[constituency_ons_id]', constituency_ons_id
 
   %p
     %button{ formmethod: :post, onclick: "return checkForm()", class: "btn btn-lg btn-primary" }
@@ -20,4 +20,3 @@
     We will match you with someone who will
     cast your preferred vote in a different area where it could count for more.
     In return, you will cast their preferred vote in your area.
-

--- a/app/views/home/_candidates_form.html.haml
+++ b/app/views/home/_candidates_form.html.haml
@@ -11,6 +11,9 @@
       %option(disabled=true selected=true) ...
       = options_for_select(@parties.map {|p| [ p.name, p.id ]}, selected: @willing_party_id)
   %p
+    = hidden_field_tag 'user[constituency_ons_id]', @constituency_ons_id
+
+  %p
     %button{ formmethod: :post, onclick: "return checkForm()", class: "btn btn-lg btn-primary" }
       Swap Your Vote!
   %p.small.subdued

--- a/app/views/home/_candidates_form.html.haml
+++ b/app/views/home/_candidates_form.html.haml
@@ -1,0 +1,20 @@
+= form_with url: sign_in_path, id: "login-form", local: true do
+  %p.choose-party
+    Which party would you most like to vote for?
+    = select :user, :preferred_party_id, nil, {}, {form: 'login-form'} do
+      %option(disabled=true selected=true) ...
+      = options_for_select(@parties.map {|p| [ p.name, p.id ]}, selected: @preferred_party_id)
+  %p.choose-party
+    When we find someone to vote for your party in #{election_constituency_other},
+    which party could you vote for in exchange?
+    = select :user, :willing_party_id, nil, {}, {form: 'login-form'} do
+      %option(disabled=true selected=true) ...
+      = options_for_select(@parties.map {|p| [ p.name, p.id ]}, selected: @willing_party_id)
+  %p
+    %button{ formmethod: :post, onclick: "return checkForm()", class: "btn btn-lg btn-primary" }
+      Swap Your Vote!
+  %p.small.subdued
+    We will match you with someone who will
+    cast your preferred vote in a different area where it could count for more.
+    In return, you will cast their preferred vote in your area.
+

--- a/app/views/home/_candidates_form_js.html.haml
+++ b/app/views/home/_candidates_form_js.html.haml
@@ -1,0 +1,32 @@
+:javascript
+  function checkForm() {
+    preferred_party_id = $("select[name='user[preferred_party_id]']").val();
+    willing_party_id = $("select[name='user[willing_party_id]']").val();
+    if (preferred_party_id == null || willing_party_id == null) {
+      $(".js-blank-error-modal").modal();
+      return false;
+    } else if (preferred_party_id == willing_party_id) {
+      $(".js-equal-party-error-modal").modal();
+      return false;
+    }
+
+    return true;
+  }
+
+.modal.js-blank-error-modal{ tabindex: "-1", role: "dialog" }
+  .modal-dialog
+    .modal-content
+      .modal-body
+        Please choose both your preferred party and your willing party.
+      .modal-footer
+        %button.btn.btn-primary{ data: { dismiss: "modal" }, aria: { label: "Close" } }
+          Close
+
+.modal.js-equal-party-error-modal{ tabindex: "-1", role: "dialog" }
+  .modal-dialog
+    .modal-content
+      .modal-body
+        Your preferred party and your willing party cannot be the same.
+      .modal-footer
+        %button.btn.btn-primary{ data: { dismiss: "modal" }, aria: { label: "Close" } }
+          Close

--- a/app/views/home/_constituency_form.html.haml
+++ b/app/views/home/_constituency_form.html.haml
@@ -7,5 +7,7 @@
                           selected: default_constituency_ons_id,
                           prompt: true
 
+  = render partial: "users/postcode_field"
+
   %p.text-center
     = submit_tag("Save", class: "btn btn-primary")

--- a/app/views/home/_constituency_form.html.haml
+++ b/app/views/home/_constituency_form.html.haml
@@ -1,0 +1,11 @@
+= form_with url: pre_login_path, id: "login-form", local: true do |f|
+
+  %p.ui-widget
+    My constituency is
+    = f.collection_select :constituency_ons_id, @constituencies,
+                          :ons_id, :name,
+                          selected: @default_constituency_ons_id,
+                          prompt: true
+
+  %p.text-center
+    = submit_tag("Save", class: "btn btn-primary")

--- a/app/views/home/_constituency_form.html.haml
+++ b/app/views/home/_constituency_form.html.haml
@@ -1,6 +1,7 @@
 = form_with url: pre_login_path, id: "login-form", local: true do |f|
 
-  %p.ui-widget
+
+  %p.choose-constituency
     My constituency is
     = f.collection_select :constituency_ons_id, constituencies,
                           :ons_id, :name,

--- a/app/views/home/_constituency_form.html.haml
+++ b/app/views/home/_constituency_form.html.haml
@@ -2,9 +2,9 @@
 
   %p.ui-widget
     My constituency is
-    = f.collection_select :constituency_ons_id, @constituencies,
+    = f.collection_select :constituency_ons_id, constituencies,
                           :ons_id, :name,
-                          selected: @default_constituency_ons_id,
+                          selected: default_constituency_ons_id,
                           prompt: true
 
   %p.text-center

--- a/app/views/home/_open_and_voting.html.haml
+++ b/app/views/home/_open_and_voting.html.haml
@@ -1,3 +1,5 @@
+= javascript_pack_tag "postcodesHelper"
+
 .background-pattern.border-bottom
   .container.text-center
     %h1

--- a/app/views/home/_open_pre_elections.html.haml
+++ b/app/views/home/_open_pre_elections.html.haml
@@ -1,3 +1,5 @@
+= javascript_pack_tag "postcodesHelper"
+
 .background-pattern.border-bottom
   .container.text-center
     %h1

--- a/app/views/home/_swap_form.html.haml
+++ b/app/views/home/_swap_form.html.haml
@@ -1,24 +1,6 @@
 .plain-pattern.border-bottom
   .container.text-center
-    = form_with url: sign_in_path, id: "login-form", local: true do
-      %p.choose-party
-        Which party would you most like to vote for?
-        = select :user, :preferred_party_id, nil, {}, {form: 'login-form'} do
-          %option(disabled=true selected=true) ...
-          = options_for_select(@parties.map {|p| [ p.name, p.id ]}, selected: @preferred_party_id)
-      %p.choose-party
-        When we find someone to vote for your party in #{election_constituency_other},
-        which party could you vote for in exchange?
-        = select :user, :willing_party_id, nil, {}, {form: 'login-form'} do
-          %option(disabled=true selected=true) ...
-          = options_for_select(@parties.map {|p| [ p.name, p.id ]}, selected: @willing_party_id)
-      %p
-        %button{ formmethod: :post, onclick: "return checkForm()", class: "btn btn-lg btn-primary" }
-          Swap My Vote!
-      %p.small.subdued
-        We will match you with someone who will
-        cast your preferred vote in a different area where it could count for more.
-        In return, you will cast their preferred vote in your area.
+    = render partial: "candidates_form"
 
 .background-pattern.border-bottom
   .container
@@ -34,35 +16,4 @@
 
       %li If your partner agrees to the swap, it is confirmed. We’ll help you connect with each other, so if you like, you can introduce yourselves.
 
-:javascript
-  function checkForm() {
-    preferred_party_id = $("select[name='user[preferred_party_id]']").val();
-    willing_party_id = $("select[name='user[willing_party_id]']").val();
-    if (preferred_party_id == null || willing_party_id == null) {
-      $(".js-blank-error-modal").modal();
-      return false;
-    } else if (preferred_party_id == willing_party_id) {
-      $(".js-equal-party-error-modal").modal();
-      return false;
-    }
-
-    return true;
-  }
-
-.modal.js-blank-error-modal{ tabindex: "-1", role: "dialog" }
-  .modal-dialog
-    .modal-content
-      .modal-body
-        Please choose both your preferred party and your willing party.
-      .modal-footer
-        %button.btn.btn-primary{ data: { dismiss: "modal" }, aria: { label: "Close" } }
-          Close
-
-.modal.js-equal-party-error-modal{ tabindex: "-1", role: "dialog" }
-  .modal-dialog
-    .modal-content
-      .modal-body
-        Your preferred party and your willing party cannot be the same.
-      .modal-footer
-        %button.btn.btn-primary{ data: { dismiss: "modal" }, aria: { label: "Close" } }
-          Close
+= render partial: "candidates_form_js"

--- a/app/views/home/_swap_form.html.haml
+++ b/app/views/home/_swap_form.html.haml
@@ -1,9 +1,9 @@
 .plain-pattern.border-bottom
   .container.text-center
     - if !pre_login_constituency_form_complete
-      = render partial: "constituency_form"
+      = render partial: "constituency_form", locals: { constituencies: @constituencies, default_constituency_ons_id: @default_constituency_ons_id }
     - else
-      = render partial: "candidates_form"
+      = render partial: "candidates_form", locals: { parties: @parties, preferred_party_id: @preferred_party_id, willing_party_id: @willing_party_id, constituency_ons_id: @constituency_ons_id }
 
 .background-pattern.border-bottom
   .container

--- a/app/views/home/_swap_form.html.haml
+++ b/app/views/home/_swap_form.html.haml
@@ -1,6 +1,9 @@
 .plain-pattern.border-bottom
   .container.text-center
-    = render partial: "candidates_form"
+    - if !pre_login_constituency_form_complete
+      = render partial: "constituency_form"
+    - else
+      = render partial: "candidates_form"
 
 .background-pattern.border-bottom
   .container

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
   get "account_deleted", to: "static_pages#account_deleted"
   get "confirm_account_deletion", to: "static_pages#confirm_account_deletion"
 
+  post "pre_login", to: "home#pre_login"
+
   root "home#index"
 
   resource :user do

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -16,11 +16,12 @@ RSpec.describe HomeController, type: :controller do
   end
 
   def test_renders_home_page(params = {})
-    create(:ons_constituency, name: "Burkshire")
+    constituency = create(:ons_constituency, name: "Burkshire", ons_id: "burk1")
     get :index, params: params
     expect(subject).to render_template(:index)
     expect(assigns(:constituencies)).to all(be_a(OnsConstituency))
     expect(assigns(:constituencies).count).to be >= 1
+    return constituency
   end
 
   context "home page: when not logged in" do
@@ -39,32 +40,28 @@ RSpec.describe HomeController, type: :controller do
         .to change {session[:sesame] }.to(nil)
     end
 
-    # it "prepopulates preferred party from session" do
-    #   slug = "liberal_democrats"
-    #   session["pre_populate"] = { "preferred_party_name" => slug }
-    #   party = test_renders_home_page
-    #   expect(assigns(:preferred_party_id)).to eq(party.id)
-    # end
-
-    # it "prepopulates willing party from session" do
-    #   slug = "liberal_democrats"
-    #   session["pre_populate"] = { "willing_party_name" => slug }
-    #   party = test_renders_home_page
-    #   expect(assigns(:willing_party_id)).to eq(party.id)
-    # end
-
-    it "doesn't prepopulate an unrecognised preferred party from session" do
-      slug = "green"
-      session["pre_populate"] = { "preferred_party_name" => slug }
-      test_renders_home_page
-      expect(assigns(:preferred_party_id)).to be_nil
+    it "prepopulates constituency from session ons_id" do
+      session["pre_populate"] = { "constituency_ons_id" => "burk1" }
+      constituency = test_renders_home_page
+      expect(assigns(:default_constituency_ons_id)).to eq(constituency.ons_id)
     end
 
-    it "doesn't prepopulate an unrecognised willing party from session" do
-      slug = "green"
-      session["pre_populate"] = { "willing_party_name" => slug }
+    it "doesn't prepopulate an unrecognised constituency from session ons_id" do
+      session["pre_populate"] = { "constituency_ons_id" => "you_will_never_find_me" }
       test_renders_home_page
-      expect(assigns(:willing_party_id)).to be_nil
+      expect(assigns(:default_constituency_ons_id)).to be_nil
+    end
+
+    it "prepopulates constituency from session name" do
+      session["pre_populate"] = { "constituency_name" => "Burkshire" }
+      constituency = test_renders_home_page
+      expect(assigns(:default_constituency_ons_id)).to eq(constituency.ons_id)
+    end
+
+    it "doesn't prepopulate an unrecognised constituency from session name" do
+      session["pre_populate"] = { "constituency_name" => "you_will_never_find_me" }
+      test_renders_home_page
+      expect(assigns(:default_constituency_ons_id)).to be_nil
     end
   end
 

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -6,12 +6,11 @@ RSpec.describe HomeController, type: :controller do
   include Devise::Test::ControllerHelpers
 
   def test_renders_home_page(params = {})
-    party = create(:party, name: "Liberal Democrats")
+    create(:ons_constituency, name: "Burkshire")
     get :index, params: params
     expect(subject).to render_template(:index)
     expect(assigns(:constituencies)).to all(be_a(OnsConstituency))
     expect(assigns(:constituencies).count).to be >= 1
-    return party
   end
 
   context "when not logged" do

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -29,19 +29,19 @@ RSpec.describe HomeController, type: :controller do
         .to change {session[:sesame] }.to(nil)
     end
 
-    it "prepopulates preferred party from session" do
-      slug = "liberal_democrats"
-      session["pre_populate"] = { "preferred_party_name" => slug }
-      party = test_renders_home_page
-      expect(assigns(:preferred_party_id)).to eq(party.id)
-    end
+    # it "prepopulates preferred party from session" do
+    #   slug = "liberal_democrats"
+    #   session["pre_populate"] = { "preferred_party_name" => slug }
+    #   party = test_renders_home_page
+    #   expect(assigns(:preferred_party_id)).to eq(party.id)
+    # end
 
-    it "prepopulates willing party from session" do
-      slug = "liberal_democrats"
-      session["pre_populate"] = { "willing_party_name" => slug }
-      party = test_renders_home_page
-      expect(assigns(:willing_party_id)).to eq(party.id)
-    end
+    # it "prepopulates willing party from session" do
+    #   slug = "liberal_democrats"
+    #   session["pre_populate"] = { "willing_party_name" => slug }
+    #   party = test_renders_home_page
+    #   expect(assigns(:willing_party_id)).to eq(party.id)
+    # end
 
     it "doesn't prepopulate an unrecognised preferred party from session" do
       slug = "green"

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe HomeController, type: :controller do
     party = create(:party, name: "Liberal Democrats")
     get :index, params: params
     expect(subject).to render_template(:index)
-    expect(assigns(:parties)).to all(be_a(Party))
-    expect(assigns(:parties).count).to be >= 1
+    expect(assigns(:constituencies)).to all(be_a(OnsConstituency))
+    expect(assigns(:constituencies).count).to be >= 1
     return party
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ unless ENV["NO_COVERAGE"]
     add_filter "/spec/"
     add_filter "/config/"
 
-    minimum_coverage line: 68, branch: 56
+    minimum_coverage line: 65, branch: 54
   end
 end
 

--- a/spec/views/home/__snapshots__/_open_and_voting_by_election.snap
+++ b/spec/views/home/__snapshots__/_open_and_voting_by_election.snap
@@ -24,6 +24,20 @@ My constituency is
 <option value="E14001009">Wakefield</option>
 <option value="E14000996">Tiverton and Honiton</option></select>
 </p>
+<label class='mb-0'>Or find my constituency using my postcode</label>
+<div class='form-group form-group-short'>
+<div class='input-group'>
+<input class='form-control' id='txt-postcode' maxlength='9' minlength='5' size='10' spellcheck='false' type='text'>
+<div class='input-group-append'>
+<input class='btn btn-secondary' id='btn-postcode' type='button' value='Search'>
+</div>
+</div>
+</div>
+<div class='alert alert-danger small' id='error-postcode'></div>
+<p class='small subdued'>
+Enter your postcode only to find your constituency; we do not retain this info.
+</p>
+
 <p class='text-center'>
 <input type="submit" name="commit" value="Save" class="btn btn-primary" data-disable-with="Save" />
 </p>

--- a/spec/views/home/__snapshots__/_open_and_voting_by_election.snap
+++ b/spec/views/home/__snapshots__/_open_and_voting_by_election.snap
@@ -1,3 +1,4 @@
+<script src="/packs-test/js/postcodesHelper-ca378dc418b4bbf203f3.js"></script>
 <div class='background-pattern border-bottom'>
 <div class='container text-center'>
 <h1>

--- a/spec/views/home/__snapshots__/_open_and_voting_by_election.snap
+++ b/spec/views/home/__snapshots__/_open_and_voting_by_election.snap
@@ -1,4 +1,4 @@
-<script src="/packs-test/js/postcodesHelper-ca378dc418b4bbf203f3.js"></script>
+<script src="/packs-test/js/postcodesHelper-14f1c6a7e21134534a10.js"></script>
 <div class='background-pattern border-bottom'>
 <div class='container text-center'>
 <h1>
@@ -19,7 +19,7 @@ constituency.
 </div>
 <div class='plain-pattern border-bottom'>
 <div class='container text-center'>
-<form id="login-form" action="/pre_login" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" /><p class='ui-widget'>
+<form id="login-form" action="/pre_login" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" /><p class='choose-constituency'>
 My constituency is
 <select name="constituency_ons_id" id="constituency_ons_id"><option value="">Please select</option>
 <option value="E14001009">Wakefield</option>

--- a/spec/views/home/__snapshots__/_open_and_voting_by_election.snap
+++ b/spec/views/home/__snapshots__/_open_and_voting_by_election.snap
@@ -18,28 +18,17 @@ constituency.
 </div>
 <div class='plain-pattern border-bottom'>
 <div class='container text-center'>
-<form id="login-form" action="/users/sign_in" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" /><p class='choose-party'>
-Which party would you most like to vote for?
-<select form="login-form" name="user[preferred_party_id]" id="user_preferred_party_id"><option disabled selected>...</option>
-<option value="1">Green</option>
-</select></p>
-<p class='choose-party'>
-When we find someone to vote for your party in the other constituency,
-which party could you vote for in exchange?
-<select form="login-form" name="user[willing_party_id]" id="user_willing_party_id"><option disabled selected>...</option>
-<option value="1">Green</option>
-</select></p>
-<p>
-<button class='btn btn-lg btn-primary' formmethod='post' onclick='return checkForm()'>
-Swap My Vote!
-</button>
+<form id="login-form" action="/pre_login" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" /><p class='ui-widget'>
+My constituency is
+<select name="constituency_ons_id" id="constituency_ons_id"><option value="">Please select</option>
+<option value="E14001009">Wakefield</option>
+<option value="E14000996">Tiverton and Honiton</option></select>
 </p>
-<p class='small subdued'>
-We will match you with someone who will
-cast your preferred vote in a different area where it could count for more.
-In return, you will cast their preferred vote in your area.
+<p class='text-center'>
+<input type="submit" name="commit" value="Save" class="btn btn-primary" data-disable-with="Save" />
 </p>
-</form></div>
+</form>
+</div>
 </div>
 <div class='background-pattern border-bottom'>
 <div class='container'>
@@ -96,6 +85,7 @@ Close
 </div>
 </div>
 </div>
+
 
 <div class='background-pattern border-bottom'>
 <div class='container text-center'>

--- a/spec/views/home/__snapshots__/_open_and_voting_general.snap
+++ b/spec/views/home/__snapshots__/_open_and_voting_general.snap
@@ -24,6 +24,20 @@ My constituency is
 <option value="E14001009">Wakefield</option>
 <option value="E14000996">Tiverton and Honiton</option></select>
 </p>
+<label class='mb-0'>Or find my constituency using my postcode</label>
+<div class='form-group form-group-short'>
+<div class='input-group'>
+<input class='form-control' id='txt-postcode' maxlength='9' minlength='5' size='10' spellcheck='false' type='text'>
+<div class='input-group-append'>
+<input class='btn btn-secondary' id='btn-postcode' type='button' value='Search'>
+</div>
+</div>
+</div>
+<div class='alert alert-danger small' id='error-postcode'></div>
+<p class='small subdued'>
+Enter your postcode only to find your constituency; we do not retain this info.
+</p>
+
 <p class='text-center'>
 <input type="submit" name="commit" value="Save" class="btn btn-primary" data-disable-with="Save" />
 </p>

--- a/spec/views/home/__snapshots__/_open_and_voting_general.snap
+++ b/spec/views/home/__snapshots__/_open_and_voting_general.snap
@@ -1,3 +1,4 @@
+<script src="/packs-test/js/postcodesHelper-ca378dc418b4bbf203f3.js"></script>
 <div class='background-pattern border-bottom'>
 <div class='container text-center'>
 <h1>

--- a/spec/views/home/__snapshots__/_open_and_voting_general.snap
+++ b/spec/views/home/__snapshots__/_open_and_voting_general.snap
@@ -1,4 +1,4 @@
-<script src="/packs-test/js/postcodesHelper-ca378dc418b4bbf203f3.js"></script>
+<script src="/packs-test/js/postcodesHelper-14f1c6a7e21134534a10.js"></script>
 <div class='background-pattern border-bottom'>
 <div class='container text-center'>
 <h1>
@@ -19,7 +19,7 @@ constituency.
 </div>
 <div class='plain-pattern border-bottom'>
 <div class='container text-center'>
-<form id="login-form" action="/pre_login" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" /><p class='ui-widget'>
+<form id="login-form" action="/pre_login" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" /><p class='choose-constituency'>
 My constituency is
 <select name="constituency_ons_id" id="constituency_ons_id"><option value="">Please select</option>
 <option value="E14001009">Wakefield</option>

--- a/spec/views/home/__snapshots__/_open_and_voting_general.snap
+++ b/spec/views/home/__snapshots__/_open_and_voting_general.snap
@@ -18,28 +18,17 @@ constituency.
 </div>
 <div class='plain-pattern border-bottom'>
 <div class='container text-center'>
-<form id="login-form" action="/users/sign_in" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" /><p class='choose-party'>
-Which party would you most like to vote for?
-<select form="login-form" name="user[preferred_party_id]" id="user_preferred_party_id"><option disabled selected>...</option>
-<option value="1">Green</option>
-</select></p>
-<p class='choose-party'>
-When we find someone to vote for your party in another constituency,
-which party could you vote for in exchange?
-<select form="login-form" name="user[willing_party_id]" id="user_willing_party_id"><option disabled selected>...</option>
-<option value="1">Green</option>
-</select></p>
-<p>
-<button class='btn btn-lg btn-primary' formmethod='post' onclick='return checkForm()'>
-Swap My Vote!
-</button>
+<form id="login-form" action="/pre_login" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" /><p class='ui-widget'>
+My constituency is
+<select name="constituency_ons_id" id="constituency_ons_id"><option value="">Please select</option>
+<option value="E14001009">Wakefield</option>
+<option value="E14000996">Tiverton and Honiton</option></select>
 </p>
-<p class='small subdued'>
-We will match you with someone who will
-cast your preferred vote in a different area where it could count for more.
-In return, you will cast their preferred vote in your area.
+<p class='text-center'>
+<input type="submit" name="commit" value="Save" class="btn btn-primary" data-disable-with="Save" />
 </p>
-</form></div>
+</form>
+</div>
 </div>
 <div class='background-pattern border-bottom'>
 <div class='container'>
@@ -97,6 +86,7 @@ Close
 </div>
 </div>
 </div>
+
 
 <div class='background-pattern border-bottom'>
 <div class='container text-center'>

--- a/spec/views/home/__snapshots__/_open_pre_elections_by_election.snap
+++ b/spec/views/home/__snapshots__/_open_pre_elections_by_election.snap
@@ -1,3 +1,4 @@
+<script src="/packs-test/js/postcodesHelper-ca378dc418b4bbf203f3.js"></script>
 <div class='background-pattern border-bottom'>
 <div class='container text-center'>
 <h1>

--- a/spec/views/home/__snapshots__/_open_pre_elections_by_election.snap
+++ b/spec/views/home/__snapshots__/_open_pre_elections_by_election.snap
@@ -20,6 +20,20 @@ My constituency is
 <option value="E14001009">Wakefield</option>
 <option value="E14000996">Tiverton and Honiton</option></select>
 </p>
+<label class='mb-0'>Or find my constituency using my postcode</label>
+<div class='form-group form-group-short'>
+<div class='input-group'>
+<input class='form-control' id='txt-postcode' maxlength='9' minlength='5' size='10' spellcheck='false' type='text'>
+<div class='input-group-append'>
+<input class='btn btn-secondary' id='btn-postcode' type='button' value='Search'>
+</div>
+</div>
+</div>
+<div class='alert alert-danger small' id='error-postcode'></div>
+<p class='small subdued'>
+Enter your postcode only to find your constituency; we do not retain this info.
+</p>
+
 <p class='text-center'>
 <input type="submit" name="commit" value="Save" class="btn btn-primary" data-disable-with="Save" />
 </p>

--- a/spec/views/home/__snapshots__/_open_pre_elections_by_election.snap
+++ b/spec/views/home/__snapshots__/_open_pre_elections_by_election.snap
@@ -1,4 +1,4 @@
-<script src="/packs-test/js/postcodesHelper-ca378dc418b4bbf203f3.js"></script>
+<script src="/packs-test/js/postcodesHelper-14f1c6a7e21134534a10.js"></script>
 <div class='background-pattern border-bottom'>
 <div class='container text-center'>
 <h1>
@@ -15,7 +15,7 @@ constituency.
 </div>
 <div class='plain-pattern border-bottom'>
 <div class='container text-center'>
-<form id="login-form" action="/pre_login" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" /><p class='ui-widget'>
+<form id="login-form" action="/pre_login" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" /><p class='choose-constituency'>
 My constituency is
 <select name="constituency_ons_id" id="constituency_ons_id"><option value="">Please select</option>
 <option value="E14001009">Wakefield</option>

--- a/spec/views/home/__snapshots__/_open_pre_elections_by_election.snap
+++ b/spec/views/home/__snapshots__/_open_pre_elections_by_election.snap
@@ -14,28 +14,17 @@ constituency.
 </div>
 <div class='plain-pattern border-bottom'>
 <div class='container text-center'>
-<form id="login-form" action="/users/sign_in" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" /><p class='choose-party'>
-Which party would you most like to vote for?
-<select form="login-form" name="user[preferred_party_id]" id="user_preferred_party_id"><option disabled selected>...</option>
-<option value="1">Green</option>
-</select></p>
-<p class='choose-party'>
-When we find someone to vote for your party in the other constituency,
-which party could you vote for in exchange?
-<select form="login-form" name="user[willing_party_id]" id="user_willing_party_id"><option disabled selected>...</option>
-<option value="1">Green</option>
-</select></p>
-<p>
-<button class='btn btn-lg btn-primary' formmethod='post' onclick='return checkForm()'>
-Swap My Vote!
-</button>
+<form id="login-form" action="/pre_login" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" /><p class='ui-widget'>
+My constituency is
+<select name="constituency_ons_id" id="constituency_ons_id"><option value="">Please select</option>
+<option value="E14001009">Wakefield</option>
+<option value="E14000996">Tiverton and Honiton</option></select>
 </p>
-<p class='small subdued'>
-We will match you with someone who will
-cast your preferred vote in a different area where it could count for more.
-In return, you will cast their preferred vote in your area.
+<p class='text-center'>
+<input type="submit" name="commit" value="Save" class="btn btn-primary" data-disable-with="Save" />
 </p>
-</form></div>
+</form>
+</div>
 </div>
 <div class='background-pattern border-bottom'>
 <div class='container'>
@@ -92,6 +81,7 @@ Close
 </div>
 </div>
 </div>
+
 
 <div class='background-pattern border-bottom'>
 <div class='container text-center'>

--- a/spec/views/home/__snapshots__/_open_pre_elections_general.snap
+++ b/spec/views/home/__snapshots__/_open_pre_elections_general.snap
@@ -1,3 +1,4 @@
+<script src="/packs-test/js/postcodesHelper-ca378dc418b4bbf203f3.js"></script>
 <div class='background-pattern border-bottom'>
 <div class='container text-center'>
 <h1>

--- a/spec/views/home/__snapshots__/_open_pre_elections_general.snap
+++ b/spec/views/home/__snapshots__/_open_pre_elections_general.snap
@@ -20,6 +20,20 @@ My constituency is
 <option value="E14001009">Wakefield</option>
 <option value="E14000996">Tiverton and Honiton</option></select>
 </p>
+<label class='mb-0'>Or find my constituency using my postcode</label>
+<div class='form-group form-group-short'>
+<div class='input-group'>
+<input class='form-control' id='txt-postcode' maxlength='9' minlength='5' size='10' spellcheck='false' type='text'>
+<div class='input-group-append'>
+<input class='btn btn-secondary' id='btn-postcode' type='button' value='Search'>
+</div>
+</div>
+</div>
+<div class='alert alert-danger small' id='error-postcode'></div>
+<p class='small subdued'>
+Enter your postcode only to find your constituency; we do not retain this info.
+</p>
+
 <p class='text-center'>
 <input type="submit" name="commit" value="Save" class="btn btn-primary" data-disable-with="Save" />
 </p>

--- a/spec/views/home/__snapshots__/_open_pre_elections_general.snap
+++ b/spec/views/home/__snapshots__/_open_pre_elections_general.snap
@@ -14,28 +14,17 @@ constituency.
 </div>
 <div class='plain-pattern border-bottom'>
 <div class='container text-center'>
-<form id="login-form" action="/users/sign_in" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" /><p class='choose-party'>
-Which party would you most like to vote for?
-<select form="login-form" name="user[preferred_party_id]" id="user_preferred_party_id"><option disabled selected>...</option>
-<option value="1">Green</option>
-</select></p>
-<p class='choose-party'>
-When we find someone to vote for your party in another constituency,
-which party could you vote for in exchange?
-<select form="login-form" name="user[willing_party_id]" id="user_willing_party_id"><option disabled selected>...</option>
-<option value="1">Green</option>
-</select></p>
-<p>
-<button class='btn btn-lg btn-primary' formmethod='post' onclick='return checkForm()'>
-Swap My Vote!
-</button>
+<form id="login-form" action="/pre_login" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" /><p class='ui-widget'>
+My constituency is
+<select name="constituency_ons_id" id="constituency_ons_id"><option value="">Please select</option>
+<option value="E14001009">Wakefield</option>
+<option value="E14000996">Tiverton and Honiton</option></select>
 </p>
-<p class='small subdued'>
-We will match you with someone who will
-cast your preferred vote in a different area where it could count for more.
-In return, you will cast their preferred vote in your area.
+<p class='text-center'>
+<input type="submit" name="commit" value="Save" class="btn btn-primary" data-disable-with="Save" />
 </p>
-</form></div>
+</form>
+</div>
 </div>
 <div class='background-pattern border-bottom'>
 <div class='container'>
@@ -92,6 +81,7 @@ Close
 </div>
 </div>
 </div>
+
 
 <div class='background-pattern border-bottom'>
 <div class='container text-center'>

--- a/spec/views/home/__snapshots__/_open_pre_elections_general.snap
+++ b/spec/views/home/__snapshots__/_open_pre_elections_general.snap
@@ -1,4 +1,4 @@
-<script src="/packs-test/js/postcodesHelper-ca378dc418b4bbf203f3.js"></script>
+<script src="/packs-test/js/postcodesHelper-14f1c6a7e21134534a10.js"></script>
 <div class='background-pattern border-bottom'>
 <div class='container text-center'>
 <h1>
@@ -15,7 +15,7 @@ constituency.
 </div>
 <div class='plain-pattern border-bottom'>
 <div class='container text-center'>
-<form id="login-form" action="/pre_login" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" /><p class='ui-widget'>
+<form id="login-form" action="/pre_login" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" /><p class='choose-constituency'>
 My constituency is
 <select name="constituency_ons_id" id="constituency_ons_id"><option value="">Please select</option>
 <option value="E14001009">Wakefield</option>

--- a/spec/views/home/_open_and_voting.html.haml_spec.rb
+++ b/spec/views/home/_open_and_voting.html.haml_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "home/_open_and_voting", type: :view do
       allow(view).to receive(:hide_polls?).and_return(true)
 
       assign(:parties, [build(:party, id: 1)])
+      assign(:constituencies, OnsConstituency.all)
 
       allow(view).to receive(:current_user).and_return(create(:user))
 
@@ -28,6 +29,7 @@ RSpec.describe "home/_open_and_voting", type: :view do
       allow(view).to receive(:election_date_season_type).and_return("2019 general election")
 
       assign(:parties, [build(:party, id: 1)])
+      assign(:constituencies, OnsConstituency.all)
 
       allow(view).to receive(:current_user).and_return(create(:user))
 

--- a/spec/views/home/_open_pre_elections.html.haml_spec.rb
+++ b/spec/views/home/_open_pre_elections.html.haml_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "home/_open_pre_elections", type: :view do
       allow(view).to receive(:general_election?).and_return(false)
 
       assign(:parties, [build(:party, id: 1)])
+      assign(:constituencies, OnsConstituency.all)
 
       expect { render }.not_to raise_error
 
@@ -22,6 +23,7 @@ RSpec.describe "home/_open_pre_elections", type: :view do
       allow(view).to receive(:general_election?).and_return(true)
 
       assign(:parties, [build(:party, id: 1)])
+      assign(:constituencies, OnsConstituency.all)
 
       expect { render }.not_to raise_error
 

--- a/spec/views/layouts/__snapshots__/application_by_election.snap
+++ b/spec/views/layouts/__snapshots__/application_by_election.snap
@@ -26,7 +26,7 @@
 <link crossorigin='anonymous' href='https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css' integrity='sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T' rel='stylesheet'>
 <link href='https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css' rel='stylesheet'>
 <script src='https://www.gstatic.com/charts/loader.js' type='text/javascript'></script>
-<link rel="stylesheet" media="all" href="/assets/application-f658a52a20b19ee317da01fb77b3f68043d87221ccfb96bac0bd226183839de4.css" data-turbolinks-track="true" />
+<link rel="stylesheet" media="all" href="/assets/application-5fa856845bdc41899c3799b6825eb0751b7eaa72b998095ee3ce0c2d17a7c921.css" data-turbolinks-track="true" />
 <script src="/assets/application-64d7c86a91d6bab88db476e61b84349e127c986bf52a1e25bb4575e323d7d7a2.js" data-turbolinks-track="true"></script>
 
 <script data='false' src='https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js'></script>

--- a/spec/views/layouts/__snapshots__/application_by_election.snap
+++ b/spec/views/layouts/__snapshots__/application_by_election.snap
@@ -26,7 +26,7 @@
 <link crossorigin='anonymous' href='https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css' integrity='sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T' rel='stylesheet'>
 <link href='https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css' rel='stylesheet'>
 <script src='https://www.gstatic.com/charts/loader.js' type='text/javascript'></script>
-<link rel="stylesheet" media="all" href="/assets/application-c9b008ae4722592b1156bb90985ec30929115654c348c8abdc9abff142fbafa7.css" data-turbolinks-track="true" />
+<link rel="stylesheet" media="all" href="/assets/application-f658a52a20b19ee317da01fb77b3f68043d87221ccfb96bac0bd226183839de4.css" data-turbolinks-track="true" />
 <script src="/assets/application-64d7c86a91d6bab88db476e61b84349e127c986bf52a1e25bb4575e323d7d7a2.js" data-turbolinks-track="true"></script>
 
 <script data='false' src='https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js'></script>

--- a/spec/views/layouts/__snapshots__/application_general.snap
+++ b/spec/views/layouts/__snapshots__/application_general.snap
@@ -26,7 +26,7 @@
 <link crossorigin='anonymous' href='https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css' integrity='sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T' rel='stylesheet'>
 <link href='https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css' rel='stylesheet'>
 <script src='https://www.gstatic.com/charts/loader.js' type='text/javascript'></script>
-<link rel="stylesheet" media="all" href="/assets/application-f658a52a20b19ee317da01fb77b3f68043d87221ccfb96bac0bd226183839de4.css" data-turbolinks-track="true" />
+<link rel="stylesheet" media="all" href="/assets/application-5fa856845bdc41899c3799b6825eb0751b7eaa72b998095ee3ce0c2d17a7c921.css" data-turbolinks-track="true" />
 <script src="/assets/application-64d7c86a91d6bab88db476e61b84349e127c986bf52a1e25bb4575e323d7d7a2.js" data-turbolinks-track="true"></script>
 
 <script data='false' src='https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js'></script>

--- a/spec/views/layouts/__snapshots__/application_general.snap
+++ b/spec/views/layouts/__snapshots__/application_general.snap
@@ -26,7 +26,7 @@
 <link crossorigin='anonymous' href='https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css' integrity='sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T' rel='stylesheet'>
 <link href='https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css' rel='stylesheet'>
 <script src='https://www.gstatic.com/charts/loader.js' type='text/javascript'></script>
-<link rel="stylesheet" media="all" href="/assets/application-c9b008ae4722592b1156bb90985ec30929115654c348c8abdc9abff142fbafa7.css" data-turbolinks-track="true" />
+<link rel="stylesheet" media="all" href="/assets/application-f658a52a20b19ee317da01fb77b3f68043d87221ccfb96bac0bd226183839de4.css" data-turbolinks-track="true" />
 <script src="/assets/application-64d7c86a91d6bab88db476e61b84349e127c986bf52a1e25bb4575e323d7d7a2.js" data-turbolinks-track="true"></script>
 
 <script data='false' src='https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js'></script>


### PR DESCRIPTION
When complete, this will close https://github.com/swapmyvote/swapmyvote/issues/625 and possibly #922 too. 

Most of the work done to move the constituency-first commits over, making constituency the first question asked during registration.

Still work to do on the postcode lookup 

# Minor style issues

(I have been unable to resolve these, may need @stevebaxter 's help)

* Postcode select on constituency page (home page) is misaligned

# Minor Issues

* specs (some commented out) still want to see parties set by the constituency (first) page rather than constituencies
* there are no specs to require constituencies on the new, second, constituencies page. 
* constituencies are not in alpha order at time of writing, may change with postcode lookup fixes above. 