### PR TITLE
issue 1023 hound warning

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -10,6 +10,7 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,7 +1,7 @@
 rubocop:
   enabled: true
   config_file: .rubocop.yml
-  version: 1.22.3
+  version: 1.22.1
 
 scss:
   config_file: .scss-lint.yml

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,7 +1,7 @@
 rubocop:
   enabled: true
   config_file: .rubocop.yml
-  version: 1.22.1
+  version: 1.22.3
 
 scss:
   config_file: .scss-lint.yml

--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem "invisible_captcha", "~> 2.3"
 
 # These need to be outside the development group for Rakefile to
 # be happy in Heroku.
-gem "rubocop", "~> 1.22.1"
+gem "rubocop", "1.22.1"
 gem "rubocop-rails"
 gem "rubocop-rspec"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,7 +285,7 @@ GEM
       rack
     orm_adapter (0.5.0)
     parallel (1.25.1)
-    parser (3.3.2.0)
+    parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
     pg (1.5.6)
@@ -353,8 +353,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.6)
-      strscan
+    rexml (3.3.9)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -379,7 +378,7 @@ GEM
       awesome_print (> 1.0.0)
       rspec (> 3.0.0)
     rspec-support (3.9.4)
-    rubocop (1.22.3)
+    rubocop (1.22.1)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -388,7 +387,7 @@ GEM
       rubocop-ast (>= 1.12.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.31.3)
+    rubocop-ast (1.36.1)
       parser (>= 3.3.1.0)
     rubocop-rails (2.15.2)
       activesupport (>= 4.2.0)
@@ -436,7 +435,6 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.7.3)
       mini_portile2 (~> 2.8.0)
-    strscan (3.1.0)
     sysexits (1.2.0)
     temple (0.10.3)
     terminal-notifier-guard (1.7.0)
@@ -447,7 +445,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (2.5.0)
+    unicode-display_width (2.6.0)
     unicode_utils (1.4.0)
     uri (0.13.0)
     version_gem (1.1.4)
@@ -521,7 +519,7 @@ DEPENDENCIES
   random_data
   rspec-rails (~> 4.0)
   rspec-snapshot
-  rubocop (~> 1.22.1)
+  rubocop (= 1.22.1)
   rubocop-rails
   rubocop-rspec
   sassc-rails


### PR DESCRIPTION
Fixes #1023 (Error: unrecognized cop or department Rails/I18nLocaleTexts found in .rubocop.yml)

- **issue-1023: synchronise version of rubocop used by hound CI with version locked locally**
- **issue-1023: allow manual runs of CI (hound) to debug issue 1023**
