### PR TITLE
Disable Hound's rubocop review to stop unrecognized-cop errors

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,5 +1,10 @@
+# Hound's rubocop review is disabled. Its newest bundled rubocop (1.22.1) ships a
+# rubocop-rails older than 2.14, so it cannot recognize the Rails/I18nLocaleTexts
+# cop referenced in .rubocop.yml and errors out on every Ruby file. Ruby linting is
+# already covered authoritatively by the GitHub Actions `lint` job (bin/rake lint),
+# which uses the rubocop-rails pinned in Gemfile.lock.
 rubocop:
-  enabled: true
+  enabled: false
   config_file: .rubocop.yml
   version: 1.22.1
 


### PR DESCRIPTION
Fixes #1023.

## Problem

Hound (Houndci bot) fails to review Ruby files on **every** PR, posting:

> Error: unrecognized cop or department `Rails/I18nLocaleTexts` found in .rubocop.yml. Did you mean `Rails/I18nLocaleAssignment`?

Because this error aborts config loading, Hound can review **no** Ruby file on any PR.

## Root cause

`.rubocop.yml` references the `Rails/I18nLocaleTexts` cop (to disable it). That cop was added in **rubocop-rails 2.14.0**. Hound bundles an older rubocop-rails — the error's "Did you mean `Rails/I18nLocaleAssignment`?" (added in 2.11.0) proves Hound's plugin is in the `[2.11, 2.14)` range.

Hound's newest supported rubocop is **1.22.1**, which `.hound.yml` already pins, and it ships that pre-2.14 rubocop-rails. Hound exposes no way to bump only the rubocop-rails plugin, so **there is no `.hound.yml` change that makes Hound recognize the cop.**

The cop cannot be removed from `.rubocop.yml`: the repo's own rubocop-rails (`2.15.2`, per `Gemfile.lock`) defines it, and the GitHub Actions `lint` job passes.

## Why #1027 didn't fix it

The earlier attempt in #1027 pinned the repo's **core `rubocop`** to exactly `1.22.1` in `Gemfile`/`Gemfile.lock`, aiming to "synchronise the version of rubocop used by Hound with the version locked locally." That couldn't work, for two reasons:

1. The failing gem is **`rubocop-rails`**, not core `rubocop` — and `rubocop-rails` was left unpinned.
2. **Hound doesn't read the repo's `Gemfile.lock`.** It runs its own bundled gems selected by the `.hound.yml` `version` key, so repo-side gem pins have no effect on what Hound executes.

Those changes are harmless and untouched here; this PR only edits `.hound.yml`.

## Fix

Disable Hound's `rubocop` section. Ruby is already linted authoritatively by the GitHub Actions `lint` job (`bin/rake lint`), which uses the rubocop-rails pinned in `Gemfile.lock` — so Hound's Ruby review was redundant. Hound continues reviewing scss/jshint/haml.

## Verification

- The repo's own rubocop is untouched; the `lint` CI job continues to run `Rails/I18nLocaleTexts` via rubocop-rails 2.15.2 (green on this PR).
- Hound passes on this PR with no "unrecognized cop" error. Since this PR changes no Ruby files, the live confirmation that a Ruby-touching PR no longer errors will land on the next such PR after merge; the fix is structural (rubocop disabled = never loaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)