### PR TITLE
Fix broken FAQ link on the React Contact page

### DIFF
--- a/app/frontend/components/static/Contact.test.tsx
+++ b/app/frontend/components/static/Contact.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 import { Contact } from "@/components/static/Contact";
-import { STATIC_PATHS } from "@/lib/staticPaths";
 
 function renderContact() {
   return render(
@@ -20,10 +19,12 @@ describe("Contact", () => {
     ).toBeInTheDocument();
   });
 
-  it("links to the FAQ as an in-SPA route (client-side navigation)", () => {
+  it("links the not-yet-migrated FAQ to the HAML route (full-page)", () => {
     renderContact();
+    // FAQ is deferred to M2 and has no SPA route — an in-SPA <Link> would
+    // render a blank page.
     const faqLink = screen.getByRole("link", { name: /faq/i });
-    expect(faqLink).toHaveAttribute("href", STATIC_PATHS.faq);
+    expect(faqLink).toHaveAttribute("href", "/faq");
   });
 
   it("offers a mailto link to the team", () => {

--- a/app/frontend/components/static/Contact.tsx
+++ b/app/frontend/components/static/Contact.tsx
@@ -1,19 +1,16 @@
-import { Link } from "react-router-dom";
 import { StaticPage } from "@/components/static/StaticPage";
-import { STATIC_PATHS } from "@/lib/staticPaths";
 
 // Ported from app/views/static_pages/contact.html.haml. Static content page;
-// the FAQ reference is an in-SPA <Link> (both pages live in the SPA), while
-// the email is an external mailto <a>.
+// the FAQ is not yet migrated (M2) so it is a full-page <a> to the HAML route,
+// matching the Footer, and the email is an external mailto <a>.
 export function Contact() {
   return (
     <StaticPage>
       <h2>Contact details</h2>
 
       <p>
-        Before contacting us, please first check our{" "}
-        <Link to={STATIC_PATHS.faq}>FAQ</Link> to see if your question has
-        already been answered.
+        Before contacting us, please first check our <a href="/faq">FAQ</a> to
+        see if your question has already been answered.
       </p>
 
       <p>

--- a/app/frontend/lib/staticPaths.ts
+++ b/app/frontend/lib/staticPaths.ts
@@ -7,8 +7,9 @@
 // paths. Centralising them here means cutover is a single edit: drop the
 // `/app` prefix (and update config/routes.rb + the HAML controller) once a
 // page is verified and ready to serve production traffic.
+// Only migrated pages belong here — the FAQ is deferred to M2, so links to it
+// stay full-page anchors to the HAML route (`/faq`) until it is ported.
 export const STATIC_PATHS = {
-  faq: "/app/faq",
   about: "/app/about",
   contact: "/app/contact",
   terms: "/app/terms",


### PR DESCRIPTION
## What

`Contact.tsx` linked to the FAQ with an in-SPA `<Link to={STATIC_PATHS.faq}>` (`/app/faq`). That path is in **neither** the `SpaController` allow-list in `config/routes.rb` nor the react-router route table in `App.tsx`, so clicking it rendered a blank page.

The FAQ is deferred to M2 and is still served by HAML at `/faq`. Fixed by using a full-page `<a href="/faq">` — exactly what `Footer.tsx` already does for the same destination.

Also dropped the dead `faq: "/app/faq"` key from `STATIC_PATHS`, so nothing else can link to a route that doesn't exist yet. It re-lands when the FAQ is actually ported.

## Why it wasn't caught

The Contact spec asserted the broken behaviour (`toHaveAttribute("href", STATIC_PATHS.faq)`) — it checked the href matched the constant, not that the route existed. Updated to assert `/faq`.

## Reviewer notes

- Frontend only; no backend change, so no rspec run.
- `yarn lint`, `yarn typecheck`, `yarn test` (23 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)