### PR TITLE
M2: session bootstrap API + phase-aware React navigation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -130,3 +130,5 @@ group :production do
 end
 
 gem "vite_rails", "~> 3.11"
+
+gem "alba", "~> 3.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
       airbrake-ruby (~> 6.0)
     airbrake-ruby (6.2.2)
       rbtree3 (~> 0.6)
+    alba (3.11.0)
     amazing_print (1.6.0)
     ast (2.4.2)
     autoprefixer-rails (10.4.16.0)
@@ -486,6 +487,7 @@ PLATFORMS
 DEPENDENCIES
   addressable
   airbrake
+  alba (~> 3.5)
   autoprefixer-rails
   bootsnap
   bundle-audit

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,67 @@
+module Api
+  module V1
+    # Base class for the JSON API the React SPA consumes.
+    #
+    # The SPA is served same-origin (vite_rails), so the existing Devise
+    # session cookie + Warden authenticate these endpoints with no new auth
+    # code and `current_user` works as-is. CSRF stays `:exception` (inherited
+    # from ApplicationController) — the SPA reads the token from
+    # <meta name="csrf-token"> and sends X-CSRF-Token on every non-GET.
+    #
+    # Errors follow one convention:
+    #   { "error": { "code": "...", "messages": [...], "fields": {...} } }
+    class BaseController < ApplicationController
+      rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+      rescue_from ActiveRecord::RecordInvalid, with: :render_record_invalid
+
+      # ApplicationController answers a forged request with a flash +
+      # redirect_back, which is meaningless to a fetch() caller. Answer with
+      # the JSON error convention instead.
+      def handle_unverified_request
+        render_error(
+          code: "invalid_authenticity_token",
+          status: :unprocessable_entity,
+          messages: ["Something went wrong - please try that again."]
+        )
+      end
+
+      private
+
+      # Guards mirror the legacy before_actions, but return status codes
+      # instead of redirecting. Phase guards (require_swapping_open! etc.)
+      # arrive with the milestones whose endpoints need them; every action
+      # enforces its own gates — the client's copy of the flags is UX only.
+      def require_logged_in!
+        return if logged_in?
+
+        render_error(
+          code: "unauthenticated",
+          status: :unauthorized,
+          messages: ["You need to be logged in to do that."]
+        )
+      end
+
+      def render_error(code:, status:, messages: [], fields: {})
+        render json: { error: { code: code, messages: messages, fields: fields } },
+               status: status
+      end
+
+      def render_not_found(_exception)
+        render_error(
+          code: "not_found",
+          status: :not_found,
+          messages: ["Not found."]
+        )
+      end
+
+      def render_record_invalid(exception)
+        render_error(
+          code: "validation_failed",
+          status: :unprocessable_entity,
+          messages: exception.record.errors.full_messages,
+          fields: exception.record.errors.to_hash(true)
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/session_controller.rb
+++ b/app/controllers/api/v1/session_controller.rb
@@ -1,0 +1,43 @@
+module Api
+  module V1
+    # The SPA's bootstrap endpoint, and the one place it learns who it is
+    # talking as and which operational phase the site is in.
+    #
+    #   GET    /api/v1/session  — the payload (works logged out: currentUser nil)
+    #   DELETE /api/v1/session  — log out (CSRF-protected, login required)
+    class SessionController < BaseController
+      before_action :require_logged_in!, only: :destroy
+
+      def show
+        render json: session_payload
+      end
+
+      def destroy
+        sign_out(current_user)
+        # Answer with a fresh payload rather than 204 so the SPA can prime its
+        # session cache from the response instead of racing a refetch.
+        render json: session_payload
+      end
+
+      private
+
+      def session_payload
+        SessionSerializer.new(
+          SessionPresenter.new(
+            app_mode: app_mode,
+            current_user: current_user,
+            flags: {
+              logins_open: logins_open?,
+              swapping_open: swapping_open?,
+              voting_open: voting_open?,
+              # `swap_confirmed?` is nil (not false) for an unconfirmed swap,
+              # and the flags are a boolean contract — coerce.
+              voting_info_locked: voting_info_locked? || false
+            }
+          ),
+          params: { viewer: current_user }
+        ).to_h
+      end
+    end
+  end
+end

--- a/app/frontend/app/App.tsx
+++ b/app/frontend/app/App.tsx
@@ -7,6 +7,8 @@ import { About } from "@/components/static/About";
 import { Contact } from "@/components/static/Contact";
 import { Cookies } from "@/components/static/Cookies";
 import { Terms } from "@/components/static/Terms";
+import { AppModeProvider } from "@/contexts/AppModeContext";
+import { SessionProvider } from "@/contexts/SessionContext";
 import { queryClient } from "@/lib/queryClient";
 import { STATIC_PATHS } from "@/lib/staticPaths";
 import { Ping } from "@/pages/Ping";
@@ -27,18 +29,24 @@ function Layout({ children }: { children: ReactNode }) {
 
 export function App() {
   return (
+    // SessionProvider wraps everything: auth, operational phase and swap state
+    // all come from one payload, and the chrome needs them on every route.
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <Layout>
-          <Routes>
-            <Route path="/app/ping" element={<Ping />} />
-            <Route path={STATIC_PATHS.about} element={<About />} />
-            <Route path={STATIC_PATHS.contact} element={<Contact />} />
-            <Route path={STATIC_PATHS.cookies} element={<Cookies />} />
-            <Route path={STATIC_PATHS.terms} element={<Terms />} />
-          </Routes>
-        </Layout>
-      </BrowserRouter>
+      <SessionProvider>
+        <AppModeProvider>
+          <BrowserRouter>
+            <Layout>
+              <Routes>
+                <Route path="/app/ping" element={<Ping />} />
+                <Route path={STATIC_PATHS.about} element={<About />} />
+                <Route path={STATIC_PATHS.contact} element={<Contact />} />
+                <Route path={STATIC_PATHS.cookies} element={<Cookies />} />
+                <Route path={STATIC_PATHS.terms} element={<Terms />} />
+              </Routes>
+            </Layout>
+          </BrowserRouter>
+        </AppModeProvider>
+      </SessionProvider>
     </QueryClientProvider>
   );
 }

--- a/app/frontend/components/navigation/Navigation.test.tsx
+++ b/app/frontend/components/navigation/Navigation.test.tsx
@@ -1,10 +1,36 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Navigation } from "@/components/navigation/Navigation";
+import type { SessionContextValue } from "@/contexts/SessionContext";
+import {
+  sessionPayload,
+  sessionValue,
+  TEST_USER,
+  TestSessionProvider,
+} from "@/test/sessionFixtures";
+
+function renderNav(overrides: Partial<SessionContextValue> = {}) {
+  const value = sessionValue(overrides);
+  render(
+    <TestSessionProvider value={value}>
+      <Navigation />
+    </TestSessionProvider>,
+  );
+  return value;
+}
+
+function loggedInAs(user = TEST_USER) {
+  return { session: sessionPayload({ currentUser: user }) };
+}
 
 describe("Navigation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("renders the brand as a full-page link to the (legacy) home route", () => {
-    render(<Navigation />);
+    renderNav();
     const brand = screen.getByRole("link", { name: /swapmyvote/i });
     // A real anchor with href="/" (full page load), not a react-router
     // client-side link — "/" is still served by the legacy HAML home.
@@ -12,10 +38,105 @@ describe("Navigation", () => {
   });
 
   it("shows the SwapMyVote logo image (pink wordmark + icon)", () => {
-    render(<Navigation />);
+    renderNav();
     // The brand is the real logo_nav asset (matching the legacy site), not
     // plain text — its accessible name comes from the img alt.
     const logo = screen.getByRole("img", { name: /swapmyvote/i });
     expect(logo.tagName).toBe("IMG");
+  });
+
+  describe("when logged out", () => {
+    it("offers a log in link while logins are open", () => {
+      renderNav();
+
+      expect(screen.getByRole("link", { name: /log in/i })).toHaveAttribute(
+        "href",
+        "/users/sign_in",
+      );
+    });
+
+    it("offers no log in link while logins are closed (closed-warm-up)", () => {
+      renderNav({
+        session: sessionPayload({
+          appMode: "closed-warm-up",
+          flags: {
+            loginsOpen: false,
+            swappingOpen: false,
+            votingOpen: false,
+            votingInfoLocked: false,
+          },
+        }),
+      });
+
+      expect(screen.queryByRole("link", { name: /log in/i })).toBeNull();
+    });
+
+    it("offers nothing until the session has loaded", () => {
+      renderNav({ session: null, isLoading: true });
+
+      expect(screen.queryByRole("link", { name: /log in/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /log out/i })).toBeNull();
+    });
+  });
+
+  describe("when logged in", () => {
+    it("shows the user's name, linking to the (legacy) profile page", () => {
+      renderNav(loggedInAs());
+
+      const profile = screen.getByRole("link", { name: /ada lovelace/i });
+      expect(profile).toHaveAttribute("href", "/user/edit");
+    });
+
+    it("shows the user's avatar", () => {
+      renderNav(loggedInAs());
+
+      // Decorative: the adjacent name is the accessible label, so the avatar
+      // carries an empty alt and is found by src rather than by role.
+      const avatar = document.querySelector(
+        `img[src="${TEST_USER.imageUrl}"]`,
+      ) as HTMLImageElement;
+      expect(avatar).not.toBeNull();
+      expect(avatar.alt).toBe("");
+    });
+
+    it("offers log out instead of log in", () => {
+      renderNav(loggedInAs());
+
+      expect(screen.getByRole("button", { name: /log out/i })).toBeVisible();
+      expect(screen.queryByRole("link", { name: /log in/i })).toBeNull();
+    });
+
+    it("logs out through the API, then leaves the SPA for the legacy home", async () => {
+      const assign = vi.fn();
+      vi.spyOn(window, "location", "get").mockReturnValue({
+        ...window.location,
+        assign,
+      } as unknown as Location);
+      const logOut = vi
+        .fn()
+        .mockResolvedValue(sessionPayload({ currentUser: null }));
+
+      renderNav({ ...loggedInAs(), logOut });
+
+      await userEvent.click(screen.getByRole("button", { name: /log out/i }));
+
+      expect(logOut).toHaveBeenCalledOnce();
+      expect(assign).toHaveBeenCalledWith("/");
+    });
+
+    it("still leaves for home when logging out fails", async () => {
+      const assign = vi.fn();
+      vi.spyOn(window, "location", "get").mockReturnValue({
+        ...window.location,
+        assign,
+      } as unknown as Location);
+      const logOut = vi.fn().mockRejectedValue(new Error("already logged out"));
+
+      renderNav({ ...loggedInAs(), logOut });
+
+      await userEvent.click(screen.getByRole("button", { name: /log out/i }));
+
+      expect(assign).toHaveBeenCalledWith("/");
+    });
   });
 });

--- a/app/frontend/components/navigation/Navigation.tsx
+++ b/app/frontend/components/navigation/Navigation.tsx
@@ -1,24 +1,52 @@
+import { useState } from "react";
+import Button from "react-bootstrap/Button";
 import Container from "react-bootstrap/Container";
 import Navbar from "react-bootstrap/Navbar";
 import logoNav from "@/assets/images/logo_nav.png";
 import logoNav2x from "@/assets/images/logo_nav@2x.png";
+import { useAppMode } from "@/contexts/useAppMode";
+import { useSession } from "@/contexts/useSession";
+
+// Paths still served by the legacy HAML site. Crossing the SPA→HAML boundary
+// needs a real page load, so these are plain `href`s, never react-router
+// <Link>s. Each becomes a <Link> as its screen is ported.
+const HAML_HOME = "/";
+const HAML_SIGN_IN = "/users/sign_in";
+const HAML_EDIT_PROFILE = "/user/edit";
 
 // Branded top bar. Matches the legacy site's look for now: the pink SwapMyVote
 // wordmark + icon (logo_nav) on a near-white bar with a subtle bottom border —
 // deliberately NOT the tacticalvote black bar, so the SPA doesn't diverge from
-// the live site during migration. Auth/phase-aware state (logged-in menu vs
-// login links) arrives in M2 once the session endpoint exists.
+// the live site during migration.
 //
-// The brand uses a plain `href` (full-page navigation), not a react-router
-// <Link>: "/" is still served by the legacy HAML home controller, so this
-// crosses the SPA→HAML boundary and must do a real page load. It becomes a
-// <Link> once the home page is ported to React (M3).
+// Auth and phase state come from the session payload: the logged-in user's
+// avatar + name + log out, or a log in link — and nothing at all while logins
+// are closed (closed-warm-up), mirroring the legacy _current_user / _login
+// partials and `require_logins_open`.
 export function Navigation() {
+  const { session, logOut } = useSession();
+  const { loginsOpen } = useAppMode();
+  const [loggingOut, setLoggingOut] = useState(false);
+  const currentUser = session?.currentUser ?? null;
+
+  async function handleLogOut() {
+    setLoggingOut(true);
+    try {
+      await logOut();
+    } catch {
+      // A failed log out (already logged out, expired CSRF token) is still
+      // resolved by landing on the server-rendered home page, which re-reads
+      // the real session.
+    }
+    // Home is still legacy HAML, so leave the SPA with a full page load.
+    window.location.assign(HAML_HOME);
+  }
+
   return (
     <div className="sticky-top">
       <Navbar bg="white" expand="md" className="py-2 border-bottom">
         <Container fluid className="px-3">
-          <Navbar.Brand href="/">
+          <Navbar.Brand href={HAML_HOME}>
             <img
               src={logoNav}
               srcSet={`${logoNav} 1x, ${logoNav2x} 2x`}
@@ -27,6 +55,39 @@ export function Navigation() {
               width={173}
             />
           </Navbar.Brand>
+
+          {currentUser ? (
+            <div className="d-flex align-items-center gap-2">
+              <a
+                href={HAML_EDIT_PROFILE}
+                className="d-flex align-items-center gap-2 text-decoration-none"
+              >
+                <img
+                  src={currentUser.imageUrl}
+                  alt=""
+                  width={32}
+                  height={32}
+                  className="rounded-circle"
+                />
+                <span>{currentUser.name}</span>
+              </a>
+              <Button
+                variant="link"
+                size="sm"
+                className="p-0"
+                onClick={handleLogOut}
+                disabled={loggingOut}
+              >
+                Log out
+              </Button>
+            </div>
+          ) : (
+            loginsOpen && (
+              <a href={HAML_SIGN_IN} className="small">
+                Already been here? Log in
+              </a>
+            )
+          )}
         </Container>
       </Navbar>
     </div>

--- a/app/frontend/contexts/AppModeContext.test.tsx
+++ b/app/frontend/contexts/AppModeContext.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useAppMode } from "@/contexts/useAppMode";
+import {
+  sessionPayload,
+  sessionValue,
+  TestSessionProvider,
+} from "@/test/sessionFixtures";
+
+function Probe() {
+  const mode = useAppMode();
+  return (
+    <ul>
+      <li data-testid="appMode">{mode.appMode ?? "unknown"}</li>
+      <li data-testid="loginsOpen">{String(mode.loginsOpen)}</li>
+      <li data-testid="swappingOpen">{String(mode.swappingOpen)}</li>
+      <li data-testid="votingOpen">{String(mode.votingOpen)}</li>
+      <li data-testid="votingInfoLocked">{String(mode.votingInfoLocked)}</li>
+      <li data-testid="isLoaded">{String(mode.isLoaded)}</li>
+    </ul>
+  );
+}
+
+function renderWithSession(session: ReturnType<typeof sessionPayload> | null) {
+  return render(
+    <TestSessionProvider value={sessionValue({ session })}>
+      <Probe />
+    </TestSessionProvider>,
+  );
+}
+
+function flag(name: string) {
+  return screen.getByTestId(name).textContent;
+}
+
+describe("AppModeProvider", () => {
+  it("projects the session flags onto the phase booleans", () => {
+    renderWithSession(
+      sessionPayload({
+        appMode: "open-and-voting",
+        flags: {
+          loginsOpen: true,
+          swappingOpen: true,
+          votingOpen: true,
+          votingInfoLocked: true,
+        },
+      }),
+    );
+
+    expect(flag("appMode")).toBe("open-and-voting");
+    expect(flag("loginsOpen")).toBe("true");
+    expect(flag("swappingOpen")).toBe("true");
+    expect(flag("votingOpen")).toBe("true");
+    expect(flag("votingInfoLocked")).toBe("true");
+    expect(flag("isLoaded")).toBe("true");
+  });
+
+  it("reports closed-warm-up as logins and swapping closed", () => {
+    renderWithSession(
+      sessionPayload({
+        appMode: "closed-warm-up",
+        flags: {
+          loginsOpen: false,
+          swappingOpen: false,
+          votingOpen: false,
+          votingInfoLocked: false,
+        },
+      }),
+    );
+
+    expect(flag("loginsOpen")).toBe("false");
+    expect(flag("swappingOpen")).toBe("false");
+  });
+
+  it("defaults everything closed until the session has loaded", () => {
+    renderWithSession(null);
+
+    expect(flag("appMode")).toBe("unknown");
+    expect(flag("loginsOpen")).toBe("false");
+    expect(flag("swappingOpen")).toBe("false");
+    expect(flag("isLoaded")).toBe("false");
+  });
+});

--- a/app/frontend/contexts/AppModeContext.test.tsx
+++ b/app/frontend/contexts/AppModeContext.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import type { AppModeContextValue } from "@/contexts/AppModeContext";
 import { useAppMode } from "@/contexts/useAppMode";
 import {
   sessionPayload,
@@ -79,5 +80,54 @@ describe("AppModeProvider", () => {
     expect(flag("loginsOpen")).toBe("false");
     expect(flag("swappingOpen")).toBe("false");
     expect(flag("isLoaded")).toBe("false");
+  });
+
+  describe("value identity", () => {
+    // The session is re-fetched on a poll and after every mutation, so a fresh
+    // payload object arrives constantly. Consumers of the phase must not be
+    // re-rendered by that unless the phase itself moved.
+    function renderCapturing(session: ReturnType<typeof sessionPayload>) {
+      const seen: AppModeContextValue[] = [];
+      function Capture() {
+        seen.push(useAppMode());
+        return null;
+      }
+      const view = render(
+        <TestSessionProvider value={sessionValue({ session })}>
+          <Capture />
+        </TestSessionProvider>,
+      );
+      const rerenderWith = (next: ReturnType<typeof sessionPayload>) =>
+        view.rerender(
+          <TestSessionProvider value={sessionValue({ session: next })}>
+            <Capture />
+          </TestSessionProvider>,
+        );
+      return { seen, rerenderWith };
+    }
+
+    it("is stable when a new session payload carries the same flags", () => {
+      const { seen, rerenderWith } = renderCapturing(sessionPayload());
+
+      // A different object, identical phase — e.g. the user's swap changed.
+      rerenderWith(sessionPayload());
+
+      expect(seen.length).toBeGreaterThan(1);
+      expect(seen[seen.length - 1]).toBe(seen[0]);
+    });
+
+    it("changes when a flag actually moves", () => {
+      const { seen, rerenderWith } = renderCapturing(sessionPayload());
+
+      rerenderWith(
+        sessionPayload({
+          appMode: "open-and-voting",
+          flags: { votingOpen: true },
+        }),
+      );
+
+      expect(seen[seen.length - 1]).not.toBe(seen[0]);
+      expect(seen[seen.length - 1].votingOpen).toBe(true);
+    });
   });
 });

--- a/app/frontend/contexts/AppModeContext.tsx
+++ b/app/frontend/contexts/AppModeContext.tsx
@@ -1,0 +1,57 @@
+import { createContext, type ReactNode, useMemo } from "react";
+import { useSession } from "@/contexts/useSession";
+import type { AppMode } from "@/types/api";
+
+export interface AppModeContextValue {
+  /** null until the session has loaded. */
+  appMode: AppMode | null;
+  loginsOpen: boolean;
+  swappingOpen: boolean;
+  votingOpen: boolean;
+  votingInfoLocked: boolean;
+  /** False while the phase is still unknown. */
+  isLoaded: boolean;
+}
+
+// Everything defaults to closed until the server tells us otherwise, so a
+// slow or failed session fetch hides capabilities rather than offering ones
+// the API would then reject.
+export const CLOSED_APP_MODE: AppModeContextValue = {
+  appMode: null,
+  loginsOpen: false,
+  swappingOpen: false,
+  votingOpen: false,
+  votingInfoLocked: false,
+  isLoaded: false,
+};
+
+export const AppModeContext =
+  createContext<AppModeContextValue>(CLOSED_APP_MODE);
+
+/**
+ * The operational phase, split out of the session payload so components that
+ * only care about "is swapping open?" don't re-render on user or swap changes.
+ * Phase rules themselves live in Ruby (AppModeConcern) — this is only their
+ * projection for the UI.
+ */
+export function AppModeProvider({ children }: { children: ReactNode }) {
+  const { session } = useSession();
+
+  const value = useMemo<AppModeContextValue>(() => {
+    if (!session) {
+      return CLOSED_APP_MODE;
+    }
+    return {
+      appMode: session.appMode,
+      loginsOpen: session.flags.loginsOpen,
+      swappingOpen: session.flags.swappingOpen,
+      votingOpen: session.flags.votingOpen,
+      votingInfoLocked: session.flags.votingInfoLocked,
+      isLoaded: true,
+    };
+  }, [session]);
+
+  return (
+    <AppModeContext.Provider value={value}>{children}</AppModeContext.Provider>
+  );
+}

--- a/app/frontend/contexts/AppModeContext.tsx
+++ b/app/frontend/contexts/AppModeContext.tsx
@@ -37,19 +37,29 @@ export const AppModeContext =
 export function AppModeProvider({ children }: { children: ReactNode }) {
   const { session } = useSession();
 
+  // Depend on the individual flags, not the session object: every poll and
+  // refetch produces a fresh object, so memoising on its identity would hand
+  // consumers a new context value whenever the user or swap changed — exactly
+  // the re-renders this provider exists to avoid.
+  const appMode = session?.appMode ?? null;
+  const loginsOpen = session?.flags.loginsOpen ?? false;
+  const swappingOpen = session?.flags.swappingOpen ?? false;
+  const votingOpen = session?.flags.votingOpen ?? false;
+  const votingInfoLocked = session?.flags.votingInfoLocked ?? false;
+
   const value = useMemo<AppModeContextValue>(() => {
-    if (!session) {
+    if (appMode === null) {
       return CLOSED_APP_MODE;
     }
     return {
-      appMode: session.appMode,
-      loginsOpen: session.flags.loginsOpen,
-      swappingOpen: session.flags.swappingOpen,
-      votingOpen: session.flags.votingOpen,
-      votingInfoLocked: session.flags.votingInfoLocked,
+      appMode,
+      loginsOpen,
+      swappingOpen,
+      votingOpen,
+      votingInfoLocked,
       isLoaded: true,
     };
-  }, [session]);
+  }, [appMode, loginsOpen, swappingOpen, votingOpen, votingInfoLocked]);
 
   return (
     <AppModeContext.Provider value={value}>{children}</AppModeContext.Provider>

--- a/app/frontend/contexts/SessionContext.test.tsx
+++ b/app/frontend/contexts/SessionContext.test.tsx
@@ -13,13 +13,16 @@ vi.mock("@/lib/apiClient", () => ({
 }));
 
 function Probe() {
-  const { session, isLoading, isError, logOut } = useSession();
+  const { session, isLoading, isError, refetchSession, logOut } = useSession();
   return (
     <div>
       <span data-testid="state">
         {isLoading ? "loading" : isError ? "error" : "ready"}
       </span>
       <span data-testid="user">{session?.currentUser?.name ?? "none"}</span>
+      <button type="button" onClick={() => refetchSession()}>
+        Refetch
+      </button>
       <button type="button" onClick={() => logOut()}>
         Log out
       </button>
@@ -73,6 +76,23 @@ describe("SessionProvider", () => {
       expect(screen.getByTestId("state")).toHaveTextContent("error");
     });
     expect(screen.getByTestId("user")).toHaveTextContent("none");
+  });
+
+  it("keeps the last good payload when a later refetch fails", async () => {
+    renderWithProvider(<Probe />);
+    await waitFor(() => {
+      expect(screen.getByTestId("user")).toHaveTextContent("Ada Lovelace");
+    });
+
+    vi.mocked(apiClient.get).mockRejectedValue(new Error("network down"));
+    await userEvent.click(screen.getByRole("button", { name: "Refetch" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("state")).toHaveTextContent("error");
+    });
+    // An error does not mean "logged out" — the chrome keeps rendering the
+    // user it last knew about rather than flickering to a logged-out state.
+    expect(screen.getByTestId("user")).toHaveTextContent("Ada Lovelace");
   });
 
   it("logs out through the API and primes the cache from the response", async () => {

--- a/app/frontend/contexts/SessionContext.test.tsx
+++ b/app/frontend/contexts/SessionContext.test.tsx
@@ -1,0 +1,98 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionProvider } from "@/contexts/SessionContext";
+import { useSession } from "@/contexts/useSession";
+import { apiClient } from "@/lib/apiClient";
+import { sessionPayload, TEST_USER } from "@/test/sessionFixtures";
+
+vi.mock("@/lib/apiClient", () => ({
+  apiClient: { get: vi.fn(), delete: vi.fn() },
+}));
+
+function Probe() {
+  const { session, isLoading, isError, logOut } = useSession();
+  return (
+    <div>
+      <span data-testid="state">
+        {isLoading ? "loading" : isError ? "error" : "ready"}
+      </span>
+      <span data-testid="user">{session?.currentUser?.name ?? "none"}</span>
+      <button type="button" onClick={() => logOut()}>
+        Log out
+      </button>
+    </div>
+  );
+}
+
+function renderWithProvider(children: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SessionProvider>{children}</SessionProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("SessionProvider", () => {
+  beforeEach(() => {
+    vi.mocked(apiClient.get).mockResolvedValue(
+      sessionPayload({ currentUser: TEST_USER }),
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches the session payload from the versioned endpoint", async () => {
+    renderWithProvider(<Probe />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user")).toHaveTextContent("Ada Lovelace");
+    });
+    expect(apiClient.get).toHaveBeenCalledWith("/session");
+  });
+
+  it("reports loading before the first fetch resolves", () => {
+    renderWithProvider(<Probe />);
+
+    expect(screen.getByTestId("state")).toHaveTextContent("loading");
+  });
+
+  it("reports an error, with no session, when the fetch fails", async () => {
+    vi.mocked(apiClient.get).mockRejectedValue(new Error("network down"));
+
+    renderWithProvider(<Probe />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("state")).toHaveTextContent("error");
+    });
+    expect(screen.getByTestId("user")).toHaveTextContent("none");
+  });
+
+  it("logs out through the API and primes the cache from the response", async () => {
+    vi.mocked(apiClient.delete).mockResolvedValue(
+      sessionPayload({ currentUser: null }),
+    );
+
+    renderWithProvider(<Probe />);
+    await waitFor(() => {
+      expect(screen.getByTestId("user")).toHaveTextContent("Ada Lovelace");
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Log out" }));
+
+    expect(apiClient.delete).toHaveBeenCalledWith("/session");
+    // No refetch needed: the logged-out payload the server returned is written
+    // straight into the cache.
+    await waitFor(() => {
+      expect(screen.getByTestId("user")).toHaveTextContent("none");
+    });
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/frontend/contexts/SessionContext.tsx
+++ b/app/frontend/contexts/SessionContext.tsx
@@ -1,0 +1,73 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createContext, type ReactNode, useCallback, useMemo } from "react";
+import { apiClient } from "@/lib/apiClient";
+import type { SessionPayload } from "@/types/api";
+
+export const SESSION_PATH = "/session";
+export const SESSION_QUERY_KEY = ["session"] as const;
+
+export interface SessionContextValue {
+  /** null until the first fetch resolves, or if it failed. */
+  session: SessionPayload | null;
+  isLoading: boolean;
+  isError: boolean;
+  /** Re-read the session. Call after any mutation that could change auth,
+   *  phase or swap state. */
+  refetchSession: () => Promise<unknown>;
+  /** Log out, and prime the cache from the logged-out payload the server
+   *  returns so no refetch has to race the redirect. */
+  logOut: () => Promise<SessionPayload>;
+}
+
+// Exported so tests (and Storybook-style harnesses) can supply a session
+// directly instead of standing up react-query and a fetch mock.
+export const SessionContext = createContext<SessionContextValue | null>(null);
+
+export function fetchSession(): Promise<SessionPayload> {
+  return apiClient.get<SessionPayload>(SESSION_PATH);
+}
+
+/**
+ * Holds `GET /api/v1/session` — who we are, which operational phase the site
+ * is in, and the state of our swap. It is the SPA's single source of truth for
+ * all three.
+ *
+ * Swap state changes out of band (a partner confirms or cancels, unconfirmed
+ * swaps expire), so this polls and refetches on window focus rather than
+ * trusting a value fetched once at mount.
+ */
+export function SessionProvider({ children }: { children: ReactNode }) {
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: SESSION_QUERY_KEY,
+    queryFn: fetchSession,
+    staleTime: 15_000,
+    refetchInterval: 60_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const { refetch } = query;
+  const refetchSession = useCallback(() => refetch(), [refetch]);
+
+  const logOut = useCallback(async () => {
+    const payload = await apiClient.delete<SessionPayload>(SESSION_PATH);
+    queryClient.setQueryData(SESSION_QUERY_KEY, payload);
+    return payload;
+  }, [queryClient]);
+
+  const value = useMemo<SessionContextValue>(
+    () => ({
+      session: query.data ?? null,
+      isLoading: query.isPending,
+      isError: query.isError,
+      refetchSession,
+      logOut,
+    }),
+    [query.data, query.isPending, query.isError, refetchSession, logOut],
+  );
+
+  return (
+    <SessionContext.Provider value={value}>{children}</SessionContext.Provider>
+  );
+}

--- a/app/frontend/contexts/SessionContext.tsx
+++ b/app/frontend/contexts/SessionContext.tsx
@@ -7,7 +7,11 @@ export const SESSION_PATH = "/session";
 export const SESSION_QUERY_KEY = ["session"] as const;
 
 export interface SessionContextValue {
-  /** null until the first fetch resolves, or if it failed. */
+  /**
+   * null until the first *successful* fetch resolves. A later failed refetch
+   * leaves the last good payload in place (react-query keeps it), so an error
+   * does not imply a null session — check `isError` for that.
+   */
   session: SessionPayload | null;
   isLoading: boolean;
   isError: boolean;

--- a/app/frontend/contexts/useAppMode.ts
+++ b/app/frontend/contexts/useAppMode.ts
@@ -1,0 +1,9 @@
+import { useContext } from "react";
+import {
+  AppModeContext,
+  type AppModeContextValue,
+} from "@/contexts/AppModeContext";
+
+export function useAppMode(): AppModeContextValue {
+  return useContext(AppModeContext);
+}

--- a/app/frontend/contexts/useSession.ts
+++ b/app/frontend/contexts/useSession.ts
@@ -1,0 +1,13 @@
+import { useContext } from "react";
+import {
+  SessionContext,
+  type SessionContextValue,
+} from "@/contexts/SessionContext";
+
+export function useSession(): SessionContextValue {
+  const value = useContext(SessionContext);
+  if (!value) {
+    throw new Error("useSession must be used inside a <SessionProvider>");
+  }
+  return value;
+}

--- a/app/frontend/lib/apiClient.test.ts
+++ b/app/frontend/lib/apiClient.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError, apiClient } from "@/lib/apiClient";
+
+function jsonResponse(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), { status });
+}
+
+function setCsrfMeta(token: string | null) {
+  document.head.innerHTML =
+    token === null ? "" : `<meta name="csrf-token" content="${token}">`;
+}
+
+function lastRequestInit(): RequestInit {
+  const mock = vi.mocked(global.fetch);
+  return mock.mock.calls[mock.mock.calls.length - 1][1] as RequestInit;
+}
+
+function lastRequestHeaders(): Record<string, string> {
+  return lastRequestInit().headers as Record<string, string>;
+}
+
+async function rejection(promise: Promise<unknown>): Promise<ApiError> {
+  const error = await promise.catch((e: unknown) => e);
+  expect(error).toBeInstanceOf(ApiError);
+  return error as ApiError;
+}
+
+describe("apiClient", () => {
+  beforeEach(() => {
+    setCsrfMeta("test-csrf-token");
+    // A fresh Response per call: a Response body can only be read once, and
+    // several examples make more than one request.
+    global.fetch = vi.fn(async () => jsonResponse(200, { ok: true }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.head.innerHTML = "";
+  });
+
+  it("prefixes paths with the versioned API root", async () => {
+    await apiClient.get("/session");
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/v1/session",
+      expect.anything(),
+    );
+  });
+
+  it("sends the session cookie", async () => {
+    await apiClient.get("/session");
+
+    expect(lastRequestInit().credentials).toBe("same-origin");
+  });
+
+  it("does not send a CSRF token on GET", async () => {
+    await apiClient.get("/session");
+
+    expect(lastRequestHeaders()).not.toHaveProperty("X-CSRF-Token");
+  });
+
+  it("sends the CSRF token from the meta tag on every non-GET", async () => {
+    await apiClient.delete("/session");
+    expect(lastRequestHeaders()["X-CSRF-Token"]).toBe("test-csrf-token");
+
+    await apiClient.post("/session", { a: 1 });
+    expect(lastRequestHeaders()["X-CSRF-Token"]).toBe("test-csrf-token");
+  });
+
+  it("reads the CSRF token afresh each request, in case Rails rotates it", async () => {
+    await apiClient.post("/session");
+    setCsrfMeta("rotated-token");
+    await apiClient.post("/session");
+
+    expect(lastRequestHeaders()["X-CSRF-Token"]).toBe("rotated-token");
+  });
+
+  it("omits the CSRF header when the page has no token", async () => {
+    setCsrfMeta(null);
+
+    await apiClient.post("/session");
+
+    expect(lastRequestHeaders()).not.toHaveProperty("X-CSRF-Token");
+  });
+
+  it("serializes a JSON body and sets the content type", async () => {
+    await apiClient.post("/session", { name: "Ada" });
+
+    expect(lastRequestInit().body).toBe('{"name":"Ada"}');
+    expect(lastRequestHeaders()["Content-Type"]).toBe("application/json");
+  });
+
+  it("sends no body, and no content type, when there is nothing to send", async () => {
+    await apiClient.delete("/session");
+
+    expect(lastRequestInit().body).toBeUndefined();
+    expect(lastRequestHeaders()).not.toHaveProperty("Content-Type");
+  });
+
+  it("returns the parsed response body", async () => {
+    vi.mocked(global.fetch).mockImplementation(async () =>
+      jsonResponse(200, { appMode: "open" }),
+    );
+
+    await expect(apiClient.get("/session")).resolves.toEqual({
+      appMode: "open",
+    });
+  });
+
+  it("returns null for an empty (204) body", async () => {
+    vi.mocked(global.fetch).mockImplementation(
+      async () => new Response(null, { status: 204 }),
+    );
+
+    await expect(apiClient.get("/session")).resolves.toBeNull();
+  });
+
+  it("throws an ApiError carrying the server's error convention", async () => {
+    vi.mocked(global.fetch).mockImplementation(async () =>
+      jsonResponse(422, {
+        error: {
+          code: "validation_failed",
+          messages: ["Name can't be blank"],
+          fields: { name: ["can't be blank"] },
+        },
+      }),
+    );
+
+    const error = await rejection(apiClient.post("/session"));
+
+    expect(error.status).toBe(422);
+    expect(error.code).toBe("validation_failed");
+    expect(error.messages).toEqual(["Name can't be blank"]);
+    expect(error.fields).toEqual({ name: ["can't be blank"] });
+    // The first server message is the human-readable one, so it becomes the
+    // Error's own message.
+    expect(error.message).toBe("Name can't be blank");
+  });
+
+  it("flags a 401 as unauthenticated", async () => {
+    vi.mocked(global.fetch).mockImplementation(async () =>
+      jsonResponse(401, {
+        error: { code: "unauthenticated", messages: ["Log in"], fields: {} },
+      }),
+    );
+
+    const error = await rejection(apiClient.get("/session"));
+
+    expect(error.isUnauthenticated).toBe(true);
+  });
+
+  it("still throws an ApiError when the error body is not JSON", async () => {
+    vi.mocked(global.fetch).mockImplementation(
+      async () => new Response("<html>502 Bad Gateway</html>", { status: 502 }),
+    );
+
+    const error = await rejection(apiClient.get("/session"));
+
+    expect(error.status).toBe(502);
+    expect(error.code).toBe("unknown_error");
+    expect(error.message).toBe("Request failed with status 502");
+  });
+});

--- a/app/frontend/lib/apiClient.ts
+++ b/app/frontend/lib/apiClient.ts
@@ -1,0 +1,89 @@
+import { CSRF_HEADER, csrfToken } from "@/lib/csrf";
+import type { ApiErrorBody } from "@/types/api";
+
+const API_ROOT = "/api/v1";
+
+/**
+ * A non-2xx response from /api/v1, carrying the server's error convention:
+ * `{ error: { code, messages, fields } }`.
+ */
+export class ApiError extends Error {
+  readonly status: number;
+  readonly code: string;
+  readonly messages: string[];
+  readonly fields: Record<string, string[]>;
+
+  constructor(status: number, body: ApiErrorBody | null) {
+    const messages = body?.error?.messages ?? [];
+    super(messages[0] || `Request failed with status ${status}`);
+    this.name = "ApiError";
+    this.status = status;
+    this.code = body?.error?.code ?? "unknown_error";
+    this.messages = messages;
+    this.fields = body?.error?.fields ?? {};
+  }
+
+  /** True when the user is not (or no longer) logged in. */
+  get isUnauthenticated(): boolean {
+    return this.status === 401;
+  }
+}
+
+type Method = "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+
+async function parseBody(response: Response): Promise<unknown> {
+  // 204s and error pages from outside the API (a proxy, say) have no JSON.
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+async function request<T>(
+  method: Method,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const headers: Record<string, string> = { Accept: "application/json" };
+
+  if (body !== undefined) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  if (method !== "GET") {
+    const token = csrfToken();
+    if (token) {
+      headers[CSRF_HEADER] = token;
+    }
+  }
+
+  const response = await fetch(`${API_ROOT}${path}`, {
+    method,
+    headers,
+    // The Devise session cookie is what authenticates us; the SPA is served
+    // same-origin during the migration, so no CORS credentials mode needed.
+    credentials: "same-origin",
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  const parsed = await parseBody(response);
+
+  if (!response.ok) {
+    throw new ApiError(response.status, parsed as ApiErrorBody | null);
+  }
+
+  return parsed as T;
+}
+
+export const apiClient = {
+  get: <T>(path: string) => request<T>("GET", path),
+  post: <T>(path: string, body?: unknown) => request<T>("POST", path, body),
+  patch: <T>(path: string, body?: unknown) => request<T>("PATCH", path, body),
+  put: <T>(path: string, body?: unknown) => request<T>("PUT", path, body),
+  delete: <T>(path: string, body?: unknown) => request<T>("DELETE", path, body),
+};

--- a/app/frontend/lib/csrf.ts
+++ b/app/frontend/lib/csrf.ts
@@ -1,0 +1,17 @@
+/**
+ * Rails renders the per-session CSRF token into the SPA layout via
+ * `csrf_meta_tags` (app/views/layouts/spa.html.haml). Because the SPA is
+ * served same-origin, `protect_from_forgery with: :exception` stays on and
+ * every non-GET must echo this token back in `X-CSRF-Token`.
+ *
+ * Read lazily, never cached: Rails can rotate the token, and a stale copy
+ * means a rejected request.
+ */
+export const CSRF_HEADER = "X-CSRF-Token";
+
+export function csrfToken(): string | null {
+  const meta = document.querySelector<HTMLMetaElement>(
+    'meta[name="csrf-token"]',
+  );
+  return meta?.content || null;
+}

--- a/app/frontend/styles/globals.scss
+++ b/app/frontend/styles/globals.scss
@@ -120,8 +120,14 @@ $theme-colors: map-remove($theme-colors, "info", "warning");
 }
 
 .btn-primary {
-  --bs-btn-color: #fff;
-  --bs-btn-hover-color: #fff;
+  // Dark ink, not white: white on the brand magenta is 2.44:1 (and 2.70:1 on
+  // the darker hover magenta), well under the 4.5:1 WCAG AA needs, and the axe
+  // scan in playwright-tests/accessibility.spec.ts fails on it. #212529 — the
+  // same ink $link-color uses — gives 6.31:1 and 5.71:1 while leaving the
+  // magenta itself untouched. tacticalvote still has the white-on-magenta
+  // rule this was ported from; it needs the same fix.
+  --bs-btn-color: #212529;
+  --bs-btn-hover-color: #212529;
   --bs-btn-hover-bg: var(--mf-pink-dark);
   --bs-btn-hover-border-color: var(--mf-pink-dark);
   --bs-btn-focus-shadow-rgb: 49, 132, 253;

--- a/app/frontend/test/sessionFixtures.tsx
+++ b/app/frontend/test/sessionFixtures.tsx
@@ -4,7 +4,12 @@ import {
   SessionContext,
   type SessionContextValue,
 } from "@/contexts/SessionContext";
-import type { CurrentUser, SessionPayload, SwapSummary } from "@/types/api";
+import type {
+  CurrentUser,
+  SessionFlags,
+  SessionPayload,
+  SwapSummary,
+} from "@/types/api";
 
 // Fixtures + a harness for components that read the session. They inject a
 // SessionContext value directly rather than standing up react-query and a
@@ -48,7 +53,9 @@ export const TEST_SWAP: SwapSummary = {
 };
 
 export function sessionPayload(
-  overrides: Partial<SessionPayload> = {},
+  overrides: Partial<Omit<SessionPayload, "flags">> & {
+    flags?: Partial<SessionFlags>;
+  } = {},
 ): SessionPayload {
   return {
     ...LOGGED_OUT_SESSION,

--- a/app/frontend/test/sessionFixtures.tsx
+++ b/app/frontend/test/sessionFixtures.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from "react";
+import { AppModeProvider } from "@/contexts/AppModeContext";
+import {
+  SessionContext,
+  type SessionContextValue,
+} from "@/contexts/SessionContext";
+import type { CurrentUser, SessionPayload, SwapSummary } from "@/types/api";
+
+// Fixtures + a harness for components that read the session. They inject a
+// SessionContext value directly rather than standing up react-query and a
+// fetch mock — SessionProvider's own wiring is covered by its own test.
+
+export const LOGGED_OUT_SESSION: SessionPayload = {
+  appMode: "open",
+  flags: {
+    loginsOpen: true,
+    swappingOpen: true,
+    votingOpen: false,
+    votingInfoLocked: false,
+  },
+  currentUser: null,
+  swap: null,
+};
+
+export const TEST_USER: CurrentUser = {
+  id: 1,
+  name: "Ada Lovelace",
+  email: "ada@example.com",
+  imageUrl: "https://example.com/ada.png",
+  hasConstituency: true,
+  constituencyName: "Woking",
+  constituencyOnsId: "E14001009",
+  mobileVerified: true,
+  mobileSetButNotVerified: false,
+  preferredParty: { id: 1, name: "Green", color: "#6AB023", smvCode: "grn" },
+  willingParty: { id: 2, name: "Labour", color: "#DC241f", smvCode: "lab" },
+};
+
+export const TEST_SWAP: SwapSummary = {
+  id: 7,
+  state: "outgoing",
+  confirmed: false,
+  partner: {
+    name: "Grace Hopper",
+    imageUrl: "https://example.com/grace.png",
+    constituencyName: "Wakefield",
+  },
+};
+
+export function sessionPayload(
+  overrides: Partial<SessionPayload> = {},
+): SessionPayload {
+  return {
+    ...LOGGED_OUT_SESSION,
+    ...overrides,
+    flags: { ...LOGGED_OUT_SESSION.flags, ...overrides.flags },
+  };
+}
+
+export function sessionValue(
+  overrides: Partial<SessionContextValue> = {},
+): SessionContextValue {
+  return {
+    session: LOGGED_OUT_SESSION,
+    isLoading: false,
+    isError: false,
+    refetchSession: () => Promise.resolve(null),
+    logOut: () => Promise.resolve(LOGGED_OUT_SESSION),
+    ...overrides,
+  };
+}
+
+export function TestSessionProvider({
+  value,
+  children,
+}: {
+  value: SessionContextValue;
+  children: ReactNode;
+}) {
+  return (
+    <SessionContext.Provider value={value}>
+      <AppModeProvider>{children}</AppModeProvider>
+    </SessionContext.Provider>
+  );
+}

--- a/app/frontend/types/api.ts
+++ b/app/frontend/types/api.ts
@@ -1,0 +1,79 @@
+// The FE/BE contract. Every shape here mirrors a serializer under
+// app/serializers/api/v1/ — change one, change the other, and keep the RSpec
+// request specs (spec/requests/api/v1/) asserting the same keys.
+
+/** The five operational phases (AppModeConcern::VALID_MODES). */
+export type AppMode =
+  | "closed-warm-up"
+  | "open"
+  | "closed-and-voting"
+  | "open-and-voting"
+  | "closed-wind-down";
+
+/**
+ * The phases collapsed to what the UI actually branches on. These are for
+ * presentation only — the server re-checks every gate on every request, so a
+ * client that ignores them gains nothing.
+ */
+export interface SessionFlags {
+  loginsOpen: boolean;
+  swappingOpen: boolean;
+  votingOpen: boolean;
+  /** Voting is open and this user's swap is confirmed: their voting info,
+   *  constituency, parties and account are locked. */
+  votingInfoLocked: boolean;
+}
+
+export interface Party {
+  id: number;
+  name: string | null;
+  color: string | null;
+  /** Short code the `.party-*` colour classes key off. */
+  smvCode: string | null;
+}
+
+export interface CurrentUser {
+  id: number;
+  name: string | null;
+  email: string | null;
+  imageUrl: string;
+  hasConstituency: boolean;
+  constituencyName: string | null;
+  constituencyOnsId: string | null;
+  mobileVerified: boolean;
+  mobileSetButNotVerified: boolean;
+  preferredParty: Party | null;
+  willingParty: Party | null;
+}
+
+/** The other side of a swap: strictly less than CurrentUser — no id, no email. */
+export interface SwapPartner {
+  name: string | null;
+  imageUrl: string;
+  constituencyName: string | null;
+}
+
+export interface SwapSummary {
+  id: number;
+  /** "outgoing" = this user chose their partner; "incoming" = they were chosen. */
+  state: "outgoing" | "incoming";
+  confirmed: boolean;
+  partner: SwapPartner | null;
+}
+
+/** `GET /api/v1/session` — the SPA's single source of truth. */
+export interface SessionPayload {
+  appMode: AppMode;
+  flags: SessionFlags;
+  currentUser: CurrentUser | null;
+  swap: SwapSummary | null;
+}
+
+/** Every non-2xx response body from /api/v1. */
+export interface ApiErrorBody {
+  error: {
+    code: string;
+    messages: string[];
+    fields: Record<string, string[]>;
+  };
+}

--- a/app/presenters/api/v1/session_presenter.rb
+++ b/app/presenters/api/v1/session_presenter.rb
@@ -1,0 +1,34 @@
+module Api
+  module V1
+    # Everything `GET /api/v1/session` exposes, gathered into one object so it
+    # can be serialized like any other resource.
+    #
+    # This is the SPA's single source of truth for auth, operational phase and
+    # swap state: it is re-fetched after every mutation and on a poll, so the
+    # client sees out-of-band changes (a partner confirming or cancelling a
+    # swap, Swap.cancel_old expiring one, an ?opensesame= phase override).
+    #
+    # The flags are computed by the controller from AppModeConcern rather than
+    # here, so the server stays the single place the phase rules live.
+    class SessionPresenter
+      FLAGS = [:logins_open, :swapping_open, :voting_open,
+               :voting_info_locked].freeze
+
+      attr_reader :app_mode, :current_user
+
+      def initialize(app_mode:, current_user:, flags:)
+        @app_mode = app_mode
+        @current_user = current_user
+        @flags = flags
+      end
+
+      FLAGS.each do |flag|
+        define_method(flag) { @flags.fetch(flag) }
+      end
+
+      def swap
+        current_user&.swap
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/party_serializer.rb
+++ b/app/serializers/api/v1/party_serializer.rb
@@ -1,0 +1,13 @@
+module Api
+  module V1
+    # A party as the SPA needs it: enough to name it and colour it.
+    # `smvCode` is what utils/party.ts maps to the `.party-*` colour classes.
+    class PartySerializer
+      include Alba::Resource
+
+      transform_keys :lower_camel
+
+      attributes :id, :name, :color, :smv_code
+    end
+  end
+end

--- a/app/serializers/api/v1/session_serializer.rb
+++ b/app/serializers/api/v1/session_serializer.rb
@@ -1,0 +1,26 @@
+module Api
+  module V1
+    # The SPA's bootstrap payload — see SessionPresenter. Shape mirrored in
+    # app/frontend/types/api.ts, which is the FE/BE contract.
+    class SessionSerializer
+      include Alba::Resource
+
+      transform_keys :lower_camel
+
+      attributes :app_mode
+
+      # The five operational phases collapse to these four booleans; the SPA
+      # reads them for UX only (disable/hide), never as authorisation — every
+      # API action re-checks its own gates server-side.
+      nested :flags do
+        attributes :logins_open, :swapping_open, :voting_open,
+                   :voting_info_locked
+      end
+
+      one :current_user, resource: UserSerializer
+
+      # `params[:viewer]` tells SwapSerializer which side of the swap is asking.
+      one :swap, resource: SwapSerializer
+    end
+  end
+end

--- a/app/serializers/api/v1/swap_partner_serializer.rb
+++ b/app/serializers/api/v1/swap_partner_serializer.rb
@@ -1,0 +1,19 @@
+module Api
+  module V1
+    # The *other* side of a swap, as shown to their partner. Strictly less than
+    # UserSerializer: no id, no email (sharing an email address is a separate,
+    # explicitly consented step in the swap flow) — just what's needed to say
+    # who you're swapping with.
+    class SwapPartnerSerializer
+      include Alba::Resource
+
+      transform_keys :lower_camel
+
+      attributes :name, :image_url
+
+      attribute :constituency_name do |user|
+        user.constituency&.name
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/swap_serializer.rb
+++ b/app/serializers/api/v1/swap_serializer.rb
@@ -1,0 +1,33 @@
+module Api
+  module V1
+    # A swap seen from one side. `params[:viewer]` is the user asking, which
+    # decides whether this is their outgoing swap (they chose someone) or
+    # their incoming one (someone chose them) — the two sides drive different
+    # dashboard states and different confirm/cancel affordances.
+    #
+    # Deliberately thin: the session payload only needs enough to render the
+    # chrome and the phase locks. The full swap resource (consent to share
+    # email, partner contact details, ranking) lands with the swap flow.
+    class SwapSerializer
+      include Alba::Resource
+
+      transform_keys :lower_camel
+
+      attributes :id
+
+      attribute :confirmed do |swap|
+        swap.confirmed || false
+      end
+
+      attribute :state do |swap|
+        swap.choosing_user == params[:viewer] ? "outgoing" : "incoming"
+      end
+
+      # `source` is instance_exec'd on the swap, so `choosing_user` /
+      # `chosen_user` below are the swap's own associations.
+      one :partner,
+          resource: SwapPartnerSerializer,
+          source: ->(params) { choosing_user == params[:viewer] ? chosen_user : choosing_user }
+    end
+  end
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,42 @@
+module Api
+  module V1
+    # The logged-in user, as the SPA needs them. Only ever serialized for the
+    # user themselves (inside the session payload), so their own email is
+    # included; a swap partner is serialized by SwapSerializer instead, which
+    # discloses far less.
+    #
+    # The derived booleans mirror the legacy ApplicationHelper predicates the
+    # HAML views branch on, so the React chrome can make the same decisions
+    # without re-deriving them from raw associations.
+    class UserSerializer
+      include Alba::Resource
+
+      transform_keys :lower_camel
+
+      attributes :id, :name, :email, :image_url
+
+      attribute :has_constituency do |user|
+        user.constituency.present?
+      end
+
+      attribute :constituency_name do |user|
+        user.constituency&.name
+      end
+
+      attribute :constituency_ons_id do |user|
+        user.constituency&.ons_id
+      end
+
+      attribute :mobile_verified do |user|
+        user.mobile_phone_verified? || false
+      end
+
+      attribute :mobile_set_but_not_verified do |user|
+        user.mobile_phone.present? && !user.mobile_phone.verified
+      end
+
+      one :preferred_party, resource: PartySerializer
+      one :willing_party, resource: PartySerializer
+    end
+  end
+end

--- a/config/initializers/alba.rb
+++ b/config/initializers/alba.rb
@@ -1,0 +1,4 @@
+# Alba powers the /api/v1 serializers (app/serializers/api/v1/*). The SPA
+# consumes camelCase JSON, so serializers declare snake_case Ruby attributes
+# and transform the keys on the way out; that needs a real inflector.
+Alba.inflector = :active_support

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,15 @@ Rails.application.routes.draw do
 
   post "pre_login", to: "home#pre_login"
 
+  # JSON API consumed by the React SPA. Versioned, and separate from the
+  # legacy top-level ApiController below (which is a redirect helper, not an
+  # API). Served same-origin, so Devise session cookies authenticate it.
+  namespace :api do
+    namespace :v1 do
+      resource :session, only: [:show, :destroy], controller: "session"
+    end
+  end
+
   # React SPA (Vite Ruby). Only migrated paths are routed to SpaController;
   # everything else keeps its HAML controller. Keep this allow-list in lockstep
   # with the react-router route table in app/frontend/app/App.tsx.

--- a/spec/requests/api/v1/session_spec.rb
+++ b/spec/requests/api/v1/session_spec.rb
@@ -1,0 +1,235 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Session", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  def json
+    JSON.parse(response.body)
+  end
+
+  def stub_mode(mode)
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("SWAPMYVOTE_MODE").and_return(mode)
+  end
+
+  describe "GET /api/v1/session" do
+    context "when logged out" do
+      it "succeeds with a null user" do
+        get "/api/v1/session"
+
+        expect(response).to have_http_status(:ok)
+        expect(json["currentUser"]).to be_nil
+        expect(json["swap"]).to be_nil
+      end
+
+      it "reports the operational phase and its flags" do
+        stub_mode("open")
+
+        get "/api/v1/session"
+
+        expect(json["appMode"]).to eq "open"
+        expect(json["flags"]).to eq(
+          "loginsOpen" => true,
+          "swappingOpen" => true,
+          "votingOpen" => false,
+          "votingInfoLocked" => false
+        )
+      end
+
+      it "closes logins and swapping during closed-warm-up" do
+        stub_mode("closed-warm-up")
+
+        get "/api/v1/session"
+
+        expect(json["appMode"]).to eq "closed-warm-up"
+        expect(json["flags"]).to include(
+          "loginsOpen" => false,
+          "swappingOpen" => false
+        )
+      end
+
+      it "opens both swapping and voting during open-and-voting" do
+        stub_mode("open-and-voting")
+
+        get "/api/v1/session"
+
+        expect(json["flags"]).to include(
+          "swappingOpen" => true,
+          "votingOpen" => true
+        )
+      end
+    end
+
+    context "when logged in" do
+      let(:user) { create(:ready_to_swap_user1) }
+
+      before { sign_in user }
+
+      it "serializes the current user in the shape types/api.ts expects" do
+        get "/api/v1/session"
+
+        expect(response).to have_http_status(:ok)
+        expect(json["currentUser"]).to include(
+          "id" => user.id,
+          "name" => user.name,
+          "email" => user.email,
+          "hasConstituency" => true,
+          "constituencyName" => "Constituency1",
+          "constituencyOnsId" => user.constituency.ons_id,
+          "mobileVerified" => false,
+          "mobileSetButNotVerified" => false
+        )
+        expect(json["currentUser"]["imageUrl"]).to be_present
+        expect(json["currentUser"]["preferredParty"]).to include("name" => "PartyA")
+        expect(json["currentUser"]["willingParty"]).to include("name" => "PartyB")
+      end
+
+      it "reports a user with no constituency as incomplete" do
+        sign_in create(:user, name: "Incomplete Ivy")
+
+        get "/api/v1/session"
+
+        expect(json["currentUser"]).to include(
+          "hasConstituency" => false,
+          "constituencyName" => nil,
+          "preferredParty" => nil,
+          "willingParty" => nil
+        )
+      end
+
+      it "distinguishes a set-but-unverified mobile from a verified one" do
+        user.create_mobile_phone!(number: "07771 111 111", verified: false)
+
+        get "/api/v1/session"
+
+        expect(json["currentUser"]).to include(
+          "mobileVerified" => false,
+          "mobileSetButNotVerified" => true
+        )
+      end
+
+      it "has no swap when the user is not swapped" do
+        get "/api/v1/session"
+
+        expect(json["swap"]).to be_nil
+      end
+    end
+
+    context "when the user has a swap" do
+      let(:chooser) { create(:ready_to_swap_user1) }
+      let(:chosen) { create(:ready_to_swap_user2) }
+      let(:swap) do
+        create(:swap, chosen_user: chosen).tap do |s|
+          chooser.update!(outgoing_swap: s)
+        end
+      end
+
+      # `swap` is what wires the two users together, so force it before each
+      # example rather than relying on an assertion to touch it first. The
+      # examples then sign in with a reloaded record: sign_in hands Warden the
+      # object it is given, and these were instantiated before the swap
+      # existed, so their associations would still be cached as empty.
+      before { swap }
+
+      it "is 'outgoing' for the user who chose, naming their partner" do
+        sign_in chooser.reload
+
+        get "/api/v1/session"
+
+        expect(json["swap"]).to include(
+          "id" => swap.id,
+          "state" => "outgoing",
+          "confirmed" => false
+        )
+        expect(json["swap"]["partner"]).to include(
+          "name" => chosen.name,
+          "constituencyName" => "Constituency2"
+        )
+        # The partner's email is only ever shared through the explicit consent
+        # step in the swap flow, never through the session payload.
+        expect(json["swap"]["partner"]).not_to have_key("email")
+      end
+
+      it "is 'incoming' for the user who was chosen" do
+        sign_in chosen.reload
+
+        get "/api/v1/session"
+
+        expect(json["swap"]).to include("state" => "incoming")
+        expect(json["swap"]["partner"]).to include(
+          "name" => chooser.name
+        )
+      end
+
+      it "locks voting info once voting is open and the swap is confirmed" do
+        stub_mode("open-and-voting")
+        swap.update!(confirmed: true)
+        sign_in chooser.reload
+
+        get "/api/v1/session"
+
+        expect(json["swap"]).to include("confirmed" => true)
+        expect(json["flags"]).to include("votingInfoLocked" => true)
+      end
+
+      it "does not lock voting info while the swap is unconfirmed" do
+        stub_mode("open-and-voting")
+        sign_in chooser.reload
+
+        get "/api/v1/session"
+
+        expect(json["flags"]).to include("votingInfoLocked" => false)
+      end
+    end
+  end
+
+  describe "DELETE /api/v1/session" do
+    let(:user) { create(:user) }
+
+    it "logs the user out and returns the logged-out payload" do
+      sign_in user
+
+      delete "/api/v1/session"
+
+      expect(response).to have_http_status(:ok)
+      expect(json["currentUser"]).to be_nil
+
+      get "/api/v1/session"
+      expect(json["currentUser"]).to be_nil
+    end
+
+    it "is 401 with the error convention when not logged in" do
+      delete "/api/v1/session"
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(json["error"]).to include("code" => "unauthenticated")
+      expect(json["error"]["messages"]).to be_an(Array)
+    end
+
+    context "with forgery protection on (as in production)" do
+      around do |example|
+        original = ActionController::Base.allow_forgery_protection
+        ActionController::Base.allow_forgery_protection = true
+        example.run
+        ActionController::Base.allow_forgery_protection = original
+      end
+
+      it "rejects a non-GET without a valid CSRF token, as JSON" do
+        sign_in user
+
+        delete "/api/v1/session", headers: { "X-CSRF-Token" => "not-the-token" }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json["error"]).to include("code" => "invalid_authenticity_token")
+      end
+
+      it "still allows the unprotected GET" do
+        sign_in user
+
+        get "/api/v1/session"
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Milestone 2 of the frontend modernization ([docs/frontend-modernization-plan.md](docs/frontend-modernization-plan.md)): the session backbone the rest of the migration hangs off, plus the first piece of chrome that consumes it.

## Why

M2 exists to **prove CSRF + Devise sessions across the SPA before any feature is built on them** — risk #1 in the plan. Everything downstream (auth, swap flow, mobile verification) assumes a working authenticated JSON API, so this lands one authed GET and one CSRF-protected non-GET first, with the tests to keep them honest.

It also establishes the single source of truth the SPA reads for auth, operational phase and swap state — one payload, re-fetched after mutations and on a poll, so the client sees out-of-band changes (a partner confirming or cancelling, `Swap.cancel_old` expiring an unconfirmed swap, an `?opensesame=` override).

## What changed

### Backend — JSON API under `/api/v1`

- **`Api::V1::BaseController`** — one error convention (`{ error: { code, messages, fields } }`), `rescue_from` for `RecordNotFound` / `RecordInvalid`, a `require_logged_in!` guard returning 401, and a JSON `handle_unverified_request` (the inherited one answers a forged request with a flash + `redirect_back`, meaningless to a `fetch()` caller).
- CSRF stays `protect_from_forgery with: :exception`; auth stays the existing Devise session cookie. The SPA is served same-origin, so `current_user` works with no new auth code — deliberately **not** `null_session`, which would drop the logged-in user.
- **`GET /api/v1/session`** → `appMode`, the four phase flags, `currentUser`, `swap`. Works logged out (`currentUser: null`).
- **`DELETE /api/v1/session`** → logs out and returns the logged-out payload, so the client primes its cache instead of racing a refetch. This is the CSRF proof.
- **Alba serializers** under `app/serializers/api/v1/`, camelCasing keys on the way out (`gem "alba"` added, `Alba.inflector = :active_support`).

### Frontend

- `lib/csrf.ts` + `lib/apiClient.ts` — `credentials: "same-origin"`, `X-CSRF-Token` on every non-GET (read afresh each request, since Rails can rotate it), and an `ApiError` carrying the server's error shape.
- `contexts/SessionContext.tsx` — holds the payload, polls and refetches on window focus, exposes `refetchSession()` and `logOut()`.
- `contexts/AppModeContext.tsx` — projects the phase flags for the UI, defaulting everything **closed** until the session loads, so a slow or failed fetch hides capabilities rather than offering ones the API would reject.
- `types/api.ts` — mirrors every serializer; this is the FE/BE contract.
- **`Navigation`** is now auth- and phase-aware: avatar + name + log out when logged in, a log in link only while logins are open (nothing during `closed-warm-up`), mirroring the legacy `_current_user` / `_login` partials and `require_logins_open`.

## Notes for reviewers

- **No legacy route changes.** The HAML site is untouched and still live; `config/routes.rb` only gains the `/api/v1` namespace. Links across the SPA→HAML boundary stay full-page anchors (`/`, `/users/sign_in`, `/user/edit`), each becoming a `<Link>` as its screen is ported.
- **The swap payload is deliberately thin** — enough for the chrome and the phase locks. It is serialized from the viewer's side (`outgoing` = they chose, `incoming` = they were chosen), and the partner's shape is strictly less than the current user's: no id, no email (sharing an email is a separate consented step in the swap flow). A request spec asserts the partner has no `email` key.
- **Client flags are UX only.** Phase rules stay in Ruby; every API action re-checks its own gates. Further guards (`require_swapping_open!` etc.) land with the milestones whose endpoints need them, rather than sitting here untested.
- **Two real bugs found while testing:** `voting_info_locked?` returned `nil` (not `false`) for an unconfirmed swap, leaking into what the contract says is a boolean; and Alba block attributes receive `params` via the resource reader, not a second block arg.

## Verification

- `yarn lint` and `yarn typecheck` clean; **Vitest 51/51 green** (new suites for `apiClient`, `SessionProvider`, `AppModeProvider`, and an expanded `Navigation`).
- **New request specs 16/16 green** (`spec/requests/api/v1/session_spec.rb`): payload shape, phase flags across modes, both swap sides, `votingInfoLocked`, 401 on an unauthenticated logout, and rejection of a forged CSRF token (forgery protection re-enabled for that example, since the test env disables it).
- Full suite: 417 examples, 6 failures — **all 6 pre-exist on `master`**, confirmed by stashing this branch and re-running them. `rubocop` clean across 252 files.
- **Browser end-to-end** against Rails + Vite: real login through the legacy form → nav rendered the user's name and gravatar from the session endpoint → authed `GET /api/v1/session` 200 → CSRF-protected `DELETE` 200 → nav back to the logged-out link.
- Known unrelated issue: the post-logout redirect to `/` hits the pre-existing `Webpacker::Manifest::MissingEntryError` for `postcodesHelper.js` (the Node ≥17 legacy-pack breakage noted in `AGENTS.md`). It resolves in M3 when that helper is ported to React.

🤖 Generated with [Claude Code](https://claude.com/claude-code)