### PR TITLE
Add a cookie-consent banner to the React SPA

### DIFF
--- a/app/frontend/app/App.tsx
+++ b/app/frontend/app/App.tsx
@@ -1,12 +1,15 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { GoogleTagManager } from "@/components/analytics/GoogleTagManager";
+import { CookieConsentBanner } from "@/components/cookieConsent/CookieConsentBanner";
 import { Footer } from "@/components/footer/Footer";
 import { Navigation } from "@/components/navigation/Navigation";
 import { About } from "@/components/static/About";
 import { Contact } from "@/components/static/Contact";
 import { Cookies } from "@/components/static/Cookies";
 import { Terms } from "@/components/static/Terms";
+import { CookieConsentProvider } from "@/contexts/CookieConsentContext";
 import { queryClient } from "@/lib/queryClient";
 import { STATIC_PATHS } from "@/lib/staticPaths";
 import { Ping } from "@/pages/Ping";
@@ -21,6 +24,10 @@ function Layout({ children }: { children: ReactNode }) {
       <Navigation />
       <main>{children}</main>
       <Footer />
+      <GoogleTagManager />
+      {/* Last in the DOM on purpose: the banner is a landmark, not a dialog,
+          so keyboard users reach the page content before it. */}
+      <CookieConsentBanner />
     </>
   );
 }
@@ -28,17 +35,19 @@ function Layout({ children }: { children: ReactNode }) {
 export function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <Layout>
-          <Routes>
-            <Route path="/app/ping" element={<Ping />} />
-            <Route path={STATIC_PATHS.about} element={<About />} />
-            <Route path={STATIC_PATHS.contact} element={<Contact />} />
-            <Route path={STATIC_PATHS.cookies} element={<Cookies />} />
-            <Route path={STATIC_PATHS.terms} element={<Terms />} />
-          </Routes>
-        </Layout>
-      </BrowserRouter>
+      <CookieConsentProvider>
+        <BrowserRouter>
+          <Layout>
+            <Routes>
+              <Route path="/app/ping" element={<Ping />} />
+              <Route path={STATIC_PATHS.about} element={<About />} />
+              <Route path={STATIC_PATHS.contact} element={<Contact />} />
+              <Route path={STATIC_PATHS.cookies} element={<Cookies />} />
+              <Route path={STATIC_PATHS.terms} element={<Terms />} />
+            </Routes>
+          </Layout>
+        </BrowserRouter>
+      </CookieConsentProvider>
     </QueryClientProvider>
   );
 }

--- a/app/frontend/components/analytics/GoogleTagManager.test.tsx
+++ b/app/frontend/components/analytics/GoogleTagManager.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  GoogleTagManager,
+  GTM_SCRIPT_ID,
+} from "@/components/analytics/GoogleTagManager";
+import { CookieConsentBanner } from "@/components/cookieConsent/CookieConsentBanner";
+import { CookieConsentProvider } from "@/contexts/CookieConsentContext";
+import { CONSENT_COOKIE_NAME } from "@/lib/cookieConsent";
+import { clearTestCookie, setTestCookie } from "@/test/cookieHelpers";
+
+function setGtmMeta(id: string) {
+  const meta = document.createElement("meta");
+  meta.setAttribute("name", "google-tag-manager-id");
+  meta.setAttribute("content", id);
+  document.head.appendChild(meta);
+}
+
+function gtmScripts() {
+  return document.querySelectorAll(`#${GTM_SCRIPT_ID}`);
+}
+
+function Stack() {
+  return (
+    <MemoryRouter>
+      <CookieConsentProvider>
+        <GoogleTagManager />
+        <CookieConsentBanner />
+      </CookieConsentProvider>
+    </MemoryRouter>
+  );
+}
+
+function renderWithConsent() {
+  return render(<Stack />);
+}
+
+afterEach(() => {
+  clearTestCookie(CONSENT_COOKIE_NAME);
+  for (const meta of document.head.querySelectorAll("meta")) {
+    meta.remove();
+  }
+  for (const script of gtmScripts()) {
+    script.remove();
+  }
+});
+
+describe("GoogleTagManager", () => {
+  it("does not load analytics before consent is given", () => {
+    setGtmMeta("GTM-TEST");
+    renderWithConsent();
+    expect(gtmScripts()).toHaveLength(0);
+  });
+
+  it("does not load analytics when consent is denied", () => {
+    setGtmMeta("GTM-TEST");
+    setTestCookie(CONSENT_COOKIE_NAME, "deny");
+    renderWithConsent();
+    expect(gtmScripts()).toHaveLength(0);
+  });
+
+  it("loads analytics for an existing allow", () => {
+    setGtmMeta("GTM-TEST");
+    setTestCookie(CONSENT_COOKIE_NAME, "allow");
+    renderWithConsent();
+    const script = document.getElementById(GTM_SCRIPT_ID) as HTMLScriptElement;
+    expect(script.src).toContain(
+      "https://www.googletagmanager.com/gtm.js?id=GTM-TEST",
+    );
+  });
+
+  it("loads analytics for a legacy dismiss", () => {
+    setGtmMeta("GTM-TEST");
+    setTestCookie(CONSENT_COOKIE_NAME, "dismiss");
+    renderWithConsent();
+    expect(gtmScripts()).toHaveLength(1);
+  });
+
+  it("loads analytics as soon as the banner is accepted", async () => {
+    setGtmMeta("GTM-TEST");
+    renderWithConsent();
+    expect(gtmScripts()).toHaveLength(0);
+    await userEvent.click(screen.getByRole("button", { name: /accept/i }));
+    expect(gtmScripts()).toHaveLength(1);
+  });
+
+  it("never injects the script twice", () => {
+    setGtmMeta("GTM-TEST");
+    setTestCookie(CONSENT_COOKIE_NAME, "allow");
+    const { rerender } = renderWithConsent();
+    rerender(<Stack />);
+    expect(gtmScripts()).toHaveLength(1);
+  });
+
+  it("loads nothing when the layout supplied no GTM id", () => {
+    setTestCookie(CONSENT_COOKIE_NAME, "allow");
+    renderWithConsent();
+    expect(gtmScripts()).toHaveLength(0);
+  });
+});

--- a/app/frontend/components/analytics/GoogleTagManager.tsx
+++ b/app/frontend/components/analytics/GoogleTagManager.tsx
@@ -1,0 +1,52 @@
+import { useEffect } from "react";
+import { useCookieConsent } from "@/contexts/CookieConsentContext";
+import { readMeta } from "@/lib/meta";
+
+// Consent-gated Google Tag Manager for the SPA. This is a deliberate divergence
+// from the legacy site, which loads GTM unconditionally in
+// app/views/layouts/_google_tag_manager_head.html.haml — gating the legacy
+// partials on the same cookie is tracked as a follow-up.
+//
+// No <noscript> iframe counterpart: the SPA renders nothing without JS anyway.
+
+export const GTM_ID_META = "google-tag-manager-id";
+export const GTM_SCRIPT_ID = "gtm-script";
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+  }
+}
+
+function injectGoogleTagManager(id: string) {
+  // Guard on the element rather than a module flag: a script tag cannot be
+  // un-injected, and this stays correct under StrictMode's double effects.
+  if (document.getElementById(GTM_SCRIPT_ID) !== null) {
+    return;
+  }
+  window.dataLayer = window.dataLayer ?? [];
+  window.dataLayer.push({ "gtm.start": Date.now(), event: "gtm.js" });
+
+  const script = document.createElement("script");
+  script.id = GTM_SCRIPT_ID;
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtm.js?id=${encodeURIComponent(id)}`;
+  document.head.appendChild(script);
+}
+
+export function GoogleTagManager() {
+  const { analyticsAllowed } = useCookieConsent();
+
+  useEffect(() => {
+    if (!analyticsAllowed) {
+      return;
+    }
+    const id = readMeta(GTM_ID_META);
+    if (id === null) {
+      return;
+    }
+    injectGoogleTagManager(id);
+  }, [analyticsAllowed]);
+
+  return null;
+}

--- a/app/frontend/components/cookieConsent/CookieConsentBanner.module.scss
+++ b/app/frontend/components/cookieConsent/CookieConsentBanner.module.scss
@@ -1,0 +1,7 @@
+// Bootstrap's .fixed-bottom and .sticky-top share z-index 1030, so the banner
+// would sit under the sticky navigation when the page is scrolled to the end.
+// One step up (Bootstrap's $zindex-fixed + 10) keeps it above the nav without
+// reaching modal/toast territory.
+.banner {
+  z-index: 1040;
+}

--- a/app/frontend/components/cookieConsent/CookieConsentBanner.module.scss
+++ b/app/frontend/components/cookieConsent/CookieConsentBanner.module.scss
@@ -1,7 +1,12 @@
-// Bootstrap's .fixed-bottom and .sticky-top share z-index 1030, so the banner
-// would sit under the sticky navigation when the page is scrolled to the end.
-// One step up (Bootstrap's $zindex-fixed + 10) keeps it above the nav without
-// reaching modal/toast territory.
+// Bootstrap's .fixed-bottom would do the pinning, but it also sets z-index 1030
+// — the same layer as the .sticky-top navigation — and its global rule wins on
+// source order over an equally-specific CSS-module class, so the banner ends up
+// under the nav. Owning the positioning here keeps one source of truth and puts
+// the banner one layer above the nav without reaching modal/toast territory.
 .banner {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
   z-index: 1040;
 }

--- a/app/frontend/components/cookieConsent/CookieConsentBanner.test.tsx
+++ b/app/frontend/components/cookieConsent/CookieConsentBanner.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it } from "vitest";
+import { CookieConsentBanner } from "@/components/cookieConsent/CookieConsentBanner";
+import { CookieConsentProvider } from "@/contexts/CookieConsentContext";
+import { CONSENT_COOKIE_NAME } from "@/lib/cookieConsent";
+import { STATIC_PATHS } from "@/lib/staticPaths";
+import { clearTestCookie, setTestCookie } from "@/test/cookieHelpers";
+
+function renderBanner() {
+  return render(
+    <MemoryRouter>
+      <CookieConsentProvider>
+        <CookieConsentBanner />
+      </CookieConsentProvider>
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  clearTestCookie(CONSENT_COOKIE_NAME);
+});
+
+describe("CookieConsentBanner", () => {
+  it("shows when consent has not been given", () => {
+    renderBanner();
+    expect(
+      screen.getByRole("complementary", { name: /cookie consent/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/we use cookies to improve your experience/i),
+    ).toBeInTheDocument();
+  });
+
+  it("links the in-SPA cookie policy", () => {
+    renderBanner();
+    expect(
+      screen.getByRole("link", { name: /cookie policy/i }),
+    ).toHaveAttribute("href", STATIC_PATHS.cookies);
+  });
+
+  it("stays hidden when the legacy site already recorded consent", () => {
+    setTestCookie(CONSENT_COOKIE_NAME, "dismiss");
+    renderBanner();
+    expect(screen.queryByRole("complementary")).not.toBeInTheDocument();
+  });
+
+  it("hides and persists allow when accepted", async () => {
+    renderBanner();
+    await userEvent.click(screen.getByRole("button", { name: /accept/i }));
+    expect(screen.queryByRole("complementary")).not.toBeInTheDocument();
+    expect(document.cookie).toContain(`${CONSENT_COOKIE_NAME}=allow`);
+  });
+
+  it("hides and persists deny when declined", async () => {
+    renderBanner();
+    await userEvent.click(screen.getByRole("button", { name: /decline/i }));
+    expect(screen.queryByRole("complementary")).not.toBeInTheDocument();
+    expect(document.cookie).toContain(`${CONSENT_COOKIE_NAME}=deny`);
+  });
+
+  it("puts both choices in the keyboard tab order", async () => {
+    renderBanner();
+    await userEvent.tab();
+    await userEvent.tab();
+    expect(screen.getByRole("button", { name: /decline/i })).toHaveFocus();
+    await userEvent.tab();
+    expect(screen.getByRole("button", { name: /accept/i })).toHaveFocus();
+  });
+});

--- a/app/frontend/components/cookieConsent/CookieConsentBanner.tsx
+++ b/app/frontend/components/cookieConsent/CookieConsentBanner.tsx
@@ -22,7 +22,7 @@ export function CookieConsentBanner() {
   return (
     <aside
       aria-label="Cookie consent"
-      className={`${styles.banner} fixed-bottom bg-white border-top shadow p-3`}
+      className={`${styles.banner} bg-white border-top shadow p-3`}
     >
       <Container className="d-flex flex-column flex-md-row align-items-md-center gap-3 px-lg-5">
         <p className="mb-0 flex-grow-1 small">

--- a/app/frontend/components/cookieConsent/CookieConsentBanner.tsx
+++ b/app/frontend/components/cookieConsent/CookieConsentBanner.tsx
@@ -1,0 +1,44 @@
+import Button from "react-bootstrap/Button";
+import Container from "react-bootstrap/Container";
+import { Link } from "react-router-dom";
+import { useCookieConsent } from "@/contexts/CookieConsentContext";
+import { STATIC_PATHS } from "@/lib/staticPaths";
+import styles from "./CookieConsentBanner.module.scss";
+
+// React replacement for the legacy cookieconsent@3 bar. Deliberately NOT a
+// dialog: no aria-modal, no focus trap, no focus stealing. It is a
+// complementary landmark rendered last in the DOM, so a keyboard user reaches
+// the page content first and the banner never blocks it.
+//
+// Unlike the legacy bar (dismiss-only), this offers a real choice, because the
+// SPA gates Google Tag Manager on the answer. See GoogleTagManager.tsx.
+export function CookieConsentBanner() {
+  const { hasAnswered, accept, decline } = useCookieConsent();
+
+  if (hasAnswered) {
+    return null;
+  }
+
+  return (
+    <aside
+      aria-label="Cookie consent"
+      className={`${styles.banner} fixed-bottom bg-white border-top shadow p-3`}
+    >
+      <Container className="d-flex flex-column flex-md-row align-items-md-center gap-3 px-lg-5">
+        <p className="mb-0 flex-grow-1 small">
+          We use cookies to improve your experience. Analytics cookies are only
+          set if you accept.{" "}
+          <Link to={STATIC_PATHS.cookies}>Cookie Policy</Link>
+        </p>
+        <div className="d-flex gap-2 flex-shrink-0">
+          <Button variant="outline-dark" onClick={decline}>
+            Decline
+          </Button>
+          <Button variant="primary" onClick={accept}>
+            Accept
+          </Button>
+        </div>
+      </Container>
+    </aside>
+  );
+}

--- a/app/frontend/contexts/CookieConsentContext.test.tsx
+++ b/app/frontend/contexts/CookieConsentContext.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  CookieConsentProvider,
+  useCookieConsent,
+} from "@/contexts/CookieConsentContext";
+import { CONSENT_COOKIE_NAME } from "@/lib/cookieConsent";
+import { clearTestCookie, setTestCookie } from "@/test/cookieHelpers";
+
+function Probe() {
+  const { status, hasAnswered, analyticsAllowed, accept, decline } =
+    useCookieConsent();
+  return (
+    <div>
+      <span data-testid="status">{status ?? "unset"}</span>
+      <span data-testid="answered">{String(hasAnswered)}</span>
+      <span data-testid="analytics">{String(analyticsAllowed)}</span>
+      <button type="button" onClick={accept}>
+        accept
+      </button>
+      <button type="button" onClick={decline}>
+        decline
+      </button>
+    </div>
+  );
+}
+
+function renderProbe() {
+  return render(
+    <CookieConsentProvider>
+      <Probe />
+    </CookieConsentProvider>,
+  );
+}
+
+afterEach(() => {
+  clearTestCookie(CONSENT_COOKIE_NAME);
+});
+
+describe("CookieConsentProvider", () => {
+  it("starts unanswered when no cookie is set", () => {
+    renderProbe();
+    expect(screen.getByTestId("status")).toHaveTextContent("unset");
+    expect(screen.getByTestId("answered")).toHaveTextContent("false");
+    expect(screen.getByTestId("analytics")).toHaveTextContent("false");
+  });
+
+  it("seeds from an existing legacy dismiss cookie", () => {
+    setTestCookie(CONSENT_COOKIE_NAME, "dismiss");
+    renderProbe();
+    expect(screen.getByTestId("answered")).toHaveTextContent("true");
+    expect(screen.getByTestId("analytics")).toHaveTextContent("true");
+  });
+
+  it("records an accept in state and in the cookie", async () => {
+    renderProbe();
+    await userEvent.click(screen.getByRole("button", { name: "accept" }));
+    expect(screen.getByTestId("status")).toHaveTextContent("allow");
+    expect(screen.getByTestId("analytics")).toHaveTextContent("true");
+    expect(document.cookie).toContain(`${CONSENT_COOKIE_NAME}=allow`);
+  });
+
+  it("records a decline in state and in the cookie", async () => {
+    renderProbe();
+    await userEvent.click(screen.getByRole("button", { name: "decline" }));
+    expect(screen.getByTestId("status")).toHaveTextContent("deny");
+    expect(screen.getByTestId("analytics")).toHaveTextContent("false");
+    expect(document.cookie).toContain(`${CONSENT_COOKIE_NAME}=deny`);
+  });
+});
+
+describe("useCookieConsent", () => {
+  it("throws when used outside a provider", () => {
+    expect(() => render(<Probe />)).toThrow(/CookieConsentProvider/);
+  });
+});

--- a/app/frontend/contexts/CookieConsentContext.tsx
+++ b/app/frontend/contexts/CookieConsentContext.tsx
@@ -1,0 +1,65 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+import {
+  analyticsAllowed as isAnalyticsAllowed,
+  type ConsentStatus,
+  readConsent,
+  saveConsent,
+} from "@/lib/cookieConsent";
+
+export type CookieConsent = {
+  status: ConsentStatus | null;
+  hasAnswered: boolean;
+  analyticsAllowed: boolean;
+  accept: () => void;
+  decline: () => void;
+};
+
+const CookieConsentContext = createContext<CookieConsent | null>(null);
+
+export function CookieConsentProvider({ children }: { children: ReactNode }) {
+  const [status, setStatus] = useState<ConsentStatus | null>(() =>
+    readConsent(),
+  );
+
+  // The cookie write is best-effort: if it fails (hardened privacy settings),
+  // still update state so the banner dismisses for this session rather than
+  // becoming undismissable.
+  const record = useCallback((next: ConsentStatus) => {
+    saveConsent(next);
+    setStatus(next);
+  }, []);
+
+  const value = useMemo<CookieConsent>(
+    () => ({
+      status,
+      hasAnswered: status !== null,
+      analyticsAllowed: isAnalyticsAllowed(status),
+      accept: () => record("allow"),
+      decline: () => record("deny"),
+    }),
+    [status, record],
+  );
+
+  return (
+    <CookieConsentContext.Provider value={value}>
+      {children}
+    </CookieConsentContext.Provider>
+  );
+}
+
+export function useCookieConsent(): CookieConsent {
+  const value = useContext(CookieConsentContext);
+  if (value === null) {
+    throw new Error(
+      "useCookieConsent must be used inside a CookieConsentProvider",
+    );
+  }
+  return value;
+}

--- a/app/frontend/lib/cookieConsent.test.ts
+++ b/app/frontend/lib/cookieConsent.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  analyticsAllowed,
+  CONSENT_COOKIE_NAME,
+  readConsent,
+  saveConsent,
+} from "@/lib/cookieConsent";
+import * as cookies from "@/lib/cookies";
+import { clearTestCookie, setTestCookie } from "@/test/cookieHelpers";
+
+function setDomainMeta(content: string) {
+  const meta = document.createElement("meta");
+  meta.setAttribute("name", "cookie-consent-domain");
+  meta.setAttribute("content", content);
+  document.head.appendChild(meta);
+}
+
+afterEach(() => {
+  clearTestCookie(CONSENT_COOKIE_NAME);
+  for (const meta of document.head.querySelectorAll("meta")) {
+    meta.remove();
+  }
+  vi.restoreAllMocks();
+});
+
+describe("readConsent", () => {
+  it("returns null when the cookie is not set", () => {
+    expect(readConsent()).toBeNull();
+  });
+
+  it("reads the legacy library's dismiss value", () => {
+    setTestCookie(CONSENT_COOKIE_NAME, "dismiss");
+    expect(readConsent()).toBe("dismiss");
+  });
+
+  it("reads allow and deny", () => {
+    setTestCookie(CONSENT_COOKIE_NAME, "allow");
+    expect(readConsent()).toBe("allow");
+    setTestCookie(CONSENT_COOKIE_NAME, "deny");
+    expect(readConsent()).toBe("deny");
+  });
+
+  it("treats an unrecognised value as unset", () => {
+    setTestCookie(CONSENT_COOKIE_NAME, "banana");
+    expect(readConsent()).toBeNull();
+  });
+});
+
+describe("saveConsent", () => {
+  it("persists a status that readConsent can read back", () => {
+    saveConsent("allow");
+    expect(readConsent()).toBe("allow");
+  });
+
+  it("writes the legacy cookie name, path, expiry and domain", () => {
+    setDomainMeta("swapmyvote.uk");
+    const write = vi.spyOn(cookies, "writeCookie").mockReturnValue(true);
+    saveConsent("deny");
+    expect(write).toHaveBeenCalledWith(
+      "_swapmyvote_cookie_consent",
+      "deny",
+      expect.objectContaining({
+        domain: "swapmyvote.uk",
+        path: "/",
+        maxAgeSeconds: 31536000,
+        sameSite: "Lax",
+      }),
+    );
+  });
+
+  it("omits the domain when no meta tag is present", () => {
+    const write = vi.spyOn(cookies, "writeCookie").mockReturnValue(true);
+    saveConsent("allow");
+    expect(write.mock.calls[0][2]?.domain).toBeUndefined();
+  });
+});
+
+describe("analyticsAllowed", () => {
+  it("allows analytics for an explicit allow", () => {
+    expect(analyticsAllowed("allow")).toBe(true);
+  });
+
+  it("allows analytics for a legacy dismiss (analytics already ran for them)", () => {
+    expect(analyticsAllowed("dismiss")).toBe(true);
+  });
+
+  it("refuses analytics for deny and for an unanswered banner", () => {
+    expect(analyticsAllowed("deny")).toBe(false);
+    expect(analyticsAllowed(null)).toBe(false);
+  });
+});

--- a/app/frontend/lib/cookieConsent.ts
+++ b/app/frontend/lib/cookieConsent.ts
@@ -1,0 +1,45 @@
+import { readCookie, writeCookie } from "@/lib/cookies";
+import { readMeta } from "@/lib/meta";
+
+// The consent cookie is SHARED with the legacy HAML site, which writes it via
+// cookieconsent@3 (app/views/layouts/_cookie_consent.html.haml). Name, path and
+// expiry below match that library's defaults exactly, and the domain comes from
+// ENV["SERVER_HOST"] via a meta tag — so a user who answered on one side of the
+// HAML/SPA boundary is never re-prompted on the other.
+//
+// SameSite=Lax and Secure are additions the legacy library does not set. Neither
+// affects the legacy site: the cookie is first-party and still readable there.
+
+export const CONSENT_COOKIE_NAME = "_swapmyvote_cookie_consent";
+export const CONSENT_DOMAIN_META = "cookie-consent-domain";
+
+const CONSENT_MAX_AGE_SECONDS = 365 * 24 * 60 * 60;
+
+// "dismiss" is written by the legacy library's OK button; "allow"/"deny" are
+// its opt-in vocabulary, which the legacy site also reads as "already answered".
+export type ConsentStatus = "dismiss" | "allow" | "deny";
+
+const CONSENT_STATUSES: readonly string[] = ["dismiss", "allow", "deny"];
+
+export function readConsent(): ConsentStatus | null {
+  const value = readCookie(CONSENT_COOKIE_NAME);
+  if (value !== null && CONSENT_STATUSES.includes(value)) {
+    return value as ConsentStatus;
+  }
+  return null;
+}
+
+export function saveConsent(status: ConsentStatus): boolean {
+  const domain = readMeta(CONSENT_DOMAIN_META);
+  return writeCookie(CONSENT_COOKIE_NAME, status, {
+    domain: domain ?? undefined,
+    path: "/",
+    maxAgeSeconds: CONSENT_MAX_AGE_SECONDS,
+    sameSite: "Lax",
+    secure: window.location.protocol === "https:",
+  });
+}
+
+export function analyticsAllowed(status: ConsentStatus | null): boolean {
+  return status === "allow" || status === "dismiss";
+}

--- a/app/frontend/lib/cookies.test.ts
+++ b/app/frontend/lib/cookies.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildCookieString, readCookie, writeCookie } from "@/lib/cookies";
+import { clearTestCookie } from "@/test/cookieHelpers";
+
+describe("buildCookieString", () => {
+  it("defaults to a root path and SameSite=Lax", () => {
+    expect(buildCookieString("a", "b")).toBe("a=b; path=/; SameSite=Lax");
+  });
+
+  it("includes the domain when one is given", () => {
+    expect(buildCookieString("a", "b", { domain: "swapmyvote.uk" })).toContain(
+      "domain=swapmyvote.uk",
+    );
+  });
+
+  it("omits the domain attribute when it is blank or absent", () => {
+    expect(buildCookieString("a", "b", { domain: "" })).not.toContain("domain");
+    expect(buildCookieString("a", "b")).not.toContain("domain");
+  });
+
+  it("includes max-age and Secure when asked", () => {
+    const built = buildCookieString("a", "b", {
+      maxAgeSeconds: 31536000,
+      secure: true,
+    });
+    expect(built).toContain("max-age=31536000");
+    expect(built).toContain("Secure");
+  });
+
+  it("omits Secure by default", () => {
+    expect(buildCookieString("a", "b")).not.toContain("Secure");
+  });
+
+  it("encodes the value", () => {
+    expect(buildCookieString("a", "b c")).toContain("a=b%20c");
+  });
+});
+
+describe("readCookie / writeCookie", () => {
+  afterEach(() => {
+    clearTestCookie("smv_test");
+    clearTestCookie("smv_other");
+  });
+
+  it("round-trips a value", () => {
+    expect(writeCookie("smv_test", "allow")).toBe(true);
+    expect(readCookie("smv_test")).toBe("allow");
+  });
+
+  it("returns null for a cookie that is not set", () => {
+    expect(readCookie("smv_missing")).toBeNull();
+  });
+
+  it("does not match on a name prefix", () => {
+    writeCookie("smv_other", "nope");
+    expect(readCookie("smv_oth")).toBeNull();
+  });
+});

--- a/app/frontend/lib/cookies.test.ts
+++ b/app/frontend/lib/cookies.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { buildCookieString, readCookie, writeCookie } from "@/lib/cookies";
-import { clearTestCookie } from "@/test/cookieHelpers";
+import { clearTestCookie, setTestCookie } from "@/test/cookieHelpers";
 
 describe("buildCookieString", () => {
   it("defaults to a root path and SameSite=Lax", () => {
@@ -54,5 +54,12 @@ describe("readCookie / writeCookie", () => {
   it("does not match on a name prefix", () => {
     writeCookie("smv_other", "nope");
     expect(readCookie("smv_oth")).toBeNull();
+  });
+
+  it("returns the raw value rather than throwing on a malformed escape", () => {
+    // Anything on the domain can write a cookie, and readCookie runs during the
+    // consent provider's first render — a URIError here would break the SPA.
+    setTestCookie("smv_test", "100%");
+    expect(readCookie("smv_test")).toBe("100%");
   });
 });

--- a/app/frontend/lib/cookies.ts
+++ b/app/frontend/lib/cookies.ts
@@ -48,7 +48,16 @@ export function readCookie(name: string): string | null {
   for (const part of jar.split(";")) {
     const entry = part.trim();
     if (entry.startsWith(prefix)) {
-      return decodeURIComponent(entry.slice(prefix.length));
+      const raw = entry.slice(prefix.length);
+      try {
+        return decodeURIComponent(raw);
+      } catch {
+        // decodeURIComponent throws on a malformed escape ("%", "%zz"). Anything
+        // on the domain can write a cookie, and readConsent() runs during the
+        // provider's first render, so a throw here would take down the whole
+        // SPA. Fall back to the raw value; callers validate what they get.
+        return raw;
+      }
     }
   }
   return null;

--- a/app/frontend/lib/cookies.ts
+++ b/app/frontend/lib/cookies.ts
@@ -1,0 +1,69 @@
+// Minimal document.cookie helpers. No dependency, no consent knowledge — the
+// cookie contract itself lives in @/lib/cookieConsent.
+//
+// buildCookieString is exported separately from writeCookie so the attributes
+// can be asserted in tests: jsdom silently drops a cookie whose `domain` does
+// not match the test host, so a round-trip cannot prove the domain was set.
+
+export type CookieOptions = {
+  domain?: string;
+  path?: string;
+  maxAgeSeconds?: number;
+  sameSite?: "Lax" | "Strict" | "None";
+  secure?: boolean;
+};
+
+export function buildCookieString(
+  name: string,
+  value: string,
+  options: CookieOptions = {},
+): string {
+  const parts = [
+    `${encodeURIComponent(name)}=${encodeURIComponent(value)}`,
+    `path=${options.path ?? "/"}`,
+  ];
+  if (options.domain) {
+    parts.push(`domain=${options.domain}`);
+  }
+  if (options.maxAgeSeconds !== undefined) {
+    parts.push(`max-age=${options.maxAgeSeconds}`);
+  }
+  parts.push(`SameSite=${options.sameSite ?? "Lax"}`);
+  if (options.secure) {
+    parts.push("Secure");
+  }
+  return parts.join("; ");
+}
+
+export function readCookie(name: string): string | null {
+  let jar: string;
+  try {
+    jar = document.cookie;
+  } catch {
+    // Hardened privacy settings can make document.cookie throw. Treat that as
+    // "no cookie" rather than crashing the app.
+    return null;
+  }
+  const prefix = `${encodeURIComponent(name)}=`;
+  for (const part of jar.split(";")) {
+    const entry = part.trim();
+    if (entry.startsWith(prefix)) {
+      return decodeURIComponent(entry.slice(prefix.length));
+    }
+  }
+  return null;
+}
+
+export function writeCookie(
+  name: string,
+  value: string,
+  options: CookieOptions = {},
+): boolean {
+  try {
+    // biome-ignore lint/suspicious/noDocumentCookie: the Cookie Store API is async and unsupported in Safari/Firefox
+    document.cookie = buildCookieString(name, value, options);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/app/frontend/lib/meta.test.ts
+++ b/app/frontend/lib/meta.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { readMeta } from "@/lib/meta";
+
+function setMeta(name: string, content: string) {
+  const meta = document.createElement("meta");
+  meta.setAttribute("name", name);
+  meta.setAttribute("content", content);
+  document.head.appendChild(meta);
+}
+
+afterEach(() => {
+  for (const meta of document.head.querySelectorAll("meta")) {
+    meta.remove();
+  }
+});
+
+describe("readMeta", () => {
+  it("returns the content of a matching meta tag", () => {
+    setMeta("smv-thing", "swapmyvote.uk");
+    expect(readMeta("smv-thing")).toBe("swapmyvote.uk");
+  });
+
+  it("returns null when the tag is absent", () => {
+    expect(readMeta("smv-thing")).toBeNull();
+  });
+
+  it("returns null when the content is blank", () => {
+    setMeta("smv-thing", "   ");
+    expect(readMeta("smv-thing")).toBeNull();
+  });
+});

--- a/app/frontend/lib/meta.ts
+++ b/app/frontend/lib/meta.ts
@@ -1,0 +1,12 @@
+// Reads server-provided configuration out of <meta> tags rendered by the SPA
+// layout (app/views/layouts/spa.html.haml). Blank content reads as absent, so
+// an env var that is set but empty behaves the same as one that is unset.
+
+export function readMeta(name: string): string | null {
+  const element = document.querySelector(`meta[name="${name}"]`);
+  const content = element?.getAttribute("content")?.trim();
+  if (!content) {
+    return null;
+  }
+  return content;
+}

--- a/app/frontend/test/cookieHelpers.ts
+++ b/app/frontend/test/cookieHelpers.ts
@@ -1,0 +1,16 @@
+// Test-only cookie helpers.
+//
+// Assigning to document.cookie is the only way to seed or clear a cookie in
+// jsdom — the Cookie Store API that Biome's noDocumentCookie rule suggests is
+// not implemented there (nor in Safari/Firefox). Suppress the rule once here
+// instead of at every call site.
+
+export function setTestCookie(name: string, value: string) {
+  // biome-ignore lint/suspicious/noDocumentCookie: jsdom implements no Cookie Store API
+  document.cookie = `${name}=${value}; path=/`;
+}
+
+export function clearTestCookie(name: string) {
+  // biome-ignore lint/suspicious/noDocumentCookie: jsdom implements no Cookie Store API
+  document.cookie = `${name}=; path=/; max-age=0`;
+}

--- a/app/views/layouts/spa.html.haml
+++ b/app/views/layouts/spa.html.haml
@@ -3,6 +3,14 @@
   %head
     %meta{ charset: "utf-8" }
     %meta{ name: "viewport", content: "width=device-width, initial-scale=1" }
+    -#
+      Server config the SPA needs in the browser. Both are optional: without
+      SERVER_HOST the consent cookie is written host-only, and without a GTM
+      id the SPA loads no analytics at all. See app/frontend/lib/meta.ts.
+    - if ENV["SERVER_HOST"].present?
+      %meta{ name: "cookie-consent-domain", content: ENV["SERVER_HOST"] }
+    - if ENV["GOOGLE_TAG_MANAGER_ID"].present?
+      %meta{ name: "google-tag-manager-id", content: ENV["GOOGLE_TAG_MANAGER_ID"] }
     %title Swap My Vote
     = csrf_meta_tags
     = vite_react_refresh_tag

--- a/docs/superpowers/plans/2026-08-16-spa-cookie-consent.md
+++ b/docs/superpowers/plans/2026-08-16-spa-cookie-consent.md
@@ -1,0 +1,1246 @@
+# SPA Cookie-Consent Banner Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the React SPA a cookie-consent banner that shares the legacy site's `_swapmyvote_cookie_consent` cookie, and load Google Tag Manager in the SPA only after explicit consent.
+
+**Architecture:** Two dependency-free DOM helpers (`cookies.ts`, `meta.ts`) sit under a pure consent module (`cookieConsent.ts`) that owns the cookie contract. A React context turns that into reactive state, consumed by a presentational banner and a render-nothing GTM loader. The only Rails change is two conditional `<meta>` tags in the SPA layout that carry `ENV["SERVER_HOST"]` and `ENV["GOOGLE_TAG_MANAGER_ID"]` into the browser.
+
+**Tech Stack:** React 19 + TypeScript, react-bootstrap 2.10, react-router-dom 7, Vitest 4 + React Testing Library, Biome, Sass modules, Rails 6.1 / HAML.
+
+**Spec:** [`docs/superpowers/specs/2026-08-16-spa-cookie-consent-design.md`](../specs/2026-08-16-spa-cookie-consent-design.md) — issue [#1039](https://github.com/swapmyvote/swapmyvote/issues/1039).
+
+## Global Constraints
+
+- Cookie name is exactly `_swapmyvote_cookie_consent`. Never rename, never prefix.
+- Cookie attributes: `path=/`, `max-age` 365 days (`31536000` seconds), `SameSite=Lax`, `Secure` only when `location.protocol === "https:"`, `domain` from the `cookie-consent-domain` meta tag and **omitted entirely** when that tag is missing or blank.
+- Cookie values are exactly `dismiss` (written by the legacy site), `allow`, `deny`. Any other value is treated as unset.
+- `analyticsAllowed` is true for `allow` **and** `dismiss`; false for `deny` and for unset.
+- TypeScript style: always use braces in `if`/`else`/`for`/`while` bodies, even for a single statement. No `if (foo) { return null; }` written as `if (foo) return null;`.
+- Styling: Bootstrap utility classes first. Custom CSS only in a co-located `*.module.scss`. No inline `style={{…}}` for static values.
+- Path alias `@/*` → `app/frontend/*`. Imports use `@/…`, never long relative paths.
+- Every new module gets a co-located test. Run `corepack yarn lint:fix && corepack yarn typecheck && corepack yarn test` before every commit.
+- Prefix Ruby commands with `PATH="$HOME/.rbenv/shims:$PATH"` so the pinned Ruby 3.3.2 wins.
+- Branch: `frontend-cookie-consent-banner`. Never push to `master`.
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `app/frontend/lib/cookies.ts` (create) | Build/read/write `document.cookie` strings. Knows nothing about consent. |
+| `app/frontend/lib/cookies.test.ts` (create) | Tests for the above. |
+| `app/frontend/lib/meta.ts` (create) | Read a `<meta name=…>` content value. |
+| `app/frontend/lib/meta.test.ts` (create) | Tests for the above. |
+| `app/views/layouts/spa.html.haml` (modify) | Emit `cookie-consent-domain` and `google-tag-manager-id` meta tags. |
+| `app/frontend/lib/cookieConsent.ts` (create) | The cookie contract: name, statuses, read/save, `analyticsAllowed`. |
+| `app/frontend/lib/cookieConsent.test.ts` (create) | Tests for the above. |
+| `app/frontend/contexts/CookieConsentContext.tsx` (create) | Consent state + `accept`/`decline` actions for React. |
+| `app/frontend/contexts/CookieConsentContext.test.tsx` (create) | Tests for the above. |
+| `app/frontend/components/cookieConsent/CookieConsentBanner.tsx` (create) | The banner UI. |
+| `app/frontend/components/cookieConsent/CookieConsentBanner.module.scss` (create) | z-index only. |
+| `app/frontend/components/cookieConsent/CookieConsentBanner.test.tsx` (create) | Tests for the above. |
+| `app/frontend/components/analytics/GoogleTagManager.tsx` (create) | Injects `gtm.js` when consent allows. Renders nothing. |
+| `app/frontend/components/analytics/GoogleTagManager.test.tsx` (create) | Tests for the above. |
+| `app/frontend/app/App.tsx` (modify) | Wrap in the provider; render the loader and banner inside `Layout`. |
+
+---
+
+### Task 1: DOM primitives — `cookies.ts` and `meta.ts`
+
+Two tiny helpers with no consent knowledge. `buildCookieString` is exported separately from `writeCookie` because jsdom silently drops a cookie whose `domain` doesn't match the test host — the only reliable way to assert the `domain` attribute is to assert the string we build.
+
+**Files:**
+- Create: `app/frontend/lib/cookies.ts`
+- Create: `app/frontend/lib/cookies.test.ts`
+- Create: `app/frontend/lib/meta.ts`
+- Create: `app/frontend/lib/meta.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `type CookieOptions = { domain?: string; path?: string; maxAgeSeconds?: number; sameSite?: "Lax" | "Strict" | "None"; secure?: boolean }`
+  - `buildCookieString(name: string, value: string, options?: CookieOptions): string`
+  - `readCookie(name: string): string | null`
+  - `writeCookie(name: string, value: string, options?: CookieOptions): boolean`
+  - `readMeta(name: string): string | null`
+
+- [ ] **Step 1: Write the failing tests**
+
+`app/frontend/lib/cookies.test.ts`:
+
+```ts
+import { afterEach, describe, expect, it } from "vitest";
+import { buildCookieString, readCookie, writeCookie } from "@/lib/cookies";
+
+function clearCookie(name: string) {
+  document.cookie = `${name}=; path=/; max-age=0`;
+}
+
+describe("buildCookieString", () => {
+  it("defaults to a root path and SameSite=Lax", () => {
+    expect(buildCookieString("a", "b")).toBe("a=b; path=/; SameSite=Lax");
+  });
+
+  it("includes the domain when one is given", () => {
+    expect(buildCookieString("a", "b", { domain: "swapmyvote.uk" })).toContain(
+      "domain=swapmyvote.uk",
+    );
+  });
+
+  it("omits the domain attribute when it is blank or absent", () => {
+    expect(buildCookieString("a", "b", { domain: "" })).not.toContain("domain");
+    expect(buildCookieString("a", "b")).not.toContain("domain");
+  });
+
+  it("includes max-age and Secure when asked", () => {
+    const built = buildCookieString("a", "b", {
+      maxAgeSeconds: 31536000,
+      secure: true,
+    });
+    expect(built).toContain("max-age=31536000");
+    expect(built).toContain("Secure");
+  });
+
+  it("omits Secure by default", () => {
+    expect(buildCookieString("a", "b")).not.toContain("Secure");
+  });
+
+  it("encodes the value", () => {
+    expect(buildCookieString("a", "b c")).toContain("a=b%20c");
+  });
+});
+
+describe("readCookie / writeCookie", () => {
+  afterEach(() => {
+    clearCookie("smv_test");
+    clearCookie("smv_other");
+  });
+
+  it("round-trips a value", () => {
+    expect(writeCookie("smv_test", "allow")).toBe(true);
+    expect(readCookie("smv_test")).toBe("allow");
+  });
+
+  it("returns null for a cookie that is not set", () => {
+    expect(readCookie("smv_missing")).toBeNull();
+  });
+
+  it("does not match on a name prefix", () => {
+    writeCookie("smv_other", "nope");
+    expect(readCookie("smv_oth")).toBeNull();
+  });
+});
+```
+
+`app/frontend/lib/meta.test.ts`:
+
+```ts
+import { afterEach, describe, expect, it } from "vitest";
+import { readMeta } from "@/lib/meta";
+
+function setMeta(name: string, content: string) {
+  const meta = document.createElement("meta");
+  meta.setAttribute("name", name);
+  meta.setAttribute("content", content);
+  document.head.appendChild(meta);
+}
+
+afterEach(() => {
+  for (const meta of document.head.querySelectorAll("meta")) {
+    meta.remove();
+  }
+});
+
+describe("readMeta", () => {
+  it("returns the content of a matching meta tag", () => {
+    setMeta("smv-thing", "swapmyvote.uk");
+    expect(readMeta("smv-thing")).toBe("swapmyvote.uk");
+  });
+
+  it("returns null when the tag is absent", () => {
+    expect(readMeta("smv-thing")).toBeNull();
+  });
+
+  it("returns null when the content is blank", () => {
+    setMeta("smv-thing", "   ");
+    expect(readMeta("smv-thing")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+corepack yarn vitest run app/frontend/lib/cookies.test.ts app/frontend/lib/meta.test.ts
+```
+
+Expected: FAIL — `Failed to resolve import "@/lib/cookies"` and `"@/lib/meta"`.
+
+- [ ] **Step 3: Write the implementations**
+
+`app/frontend/lib/cookies.ts`:
+
+```ts
+// Minimal document.cookie helpers. No dependency, no consent knowledge — the
+// cookie contract itself lives in @/lib/cookieConsent.
+//
+// buildCookieString is exported separately from writeCookie so the attributes
+// can be asserted in tests: jsdom silently drops a cookie whose `domain` does
+// not match the test host, so a round-trip cannot prove the domain was set.
+
+export type CookieOptions = {
+  domain?: string;
+  path?: string;
+  maxAgeSeconds?: number;
+  sameSite?: "Lax" | "Strict" | "None";
+  secure?: boolean;
+};
+
+export function buildCookieString(
+  name: string,
+  value: string,
+  options: CookieOptions = {},
+): string {
+  const parts = [
+    `${encodeURIComponent(name)}=${encodeURIComponent(value)}`,
+    `path=${options.path ?? "/"}`,
+  ];
+  if (options.domain) {
+    parts.push(`domain=${options.domain}`);
+  }
+  if (options.maxAgeSeconds !== undefined) {
+    parts.push(`max-age=${options.maxAgeSeconds}`);
+  }
+  parts.push(`SameSite=${options.sameSite ?? "Lax"}`);
+  if (options.secure) {
+    parts.push("Secure");
+  }
+  return parts.join("; ");
+}
+
+export function readCookie(name: string): string | null {
+  let jar: string;
+  try {
+    jar = document.cookie;
+  } catch {
+    // Hardened privacy settings can make document.cookie throw. Treat that as
+    // "no cookie" rather than crashing the app.
+    return null;
+  }
+  const prefix = `${encodeURIComponent(name)}=`;
+  for (const part of jar.split(";")) {
+    const entry = part.trim();
+    if (entry.startsWith(prefix)) {
+      return decodeURIComponent(entry.slice(prefix.length));
+    }
+  }
+  return null;
+}
+
+export function writeCookie(
+  name: string,
+  value: string,
+  options: CookieOptions = {},
+): boolean {
+  try {
+    document.cookie = buildCookieString(name, value, options);
+    return true;
+  } catch {
+    return false;
+  }
+}
+```
+
+`app/frontend/lib/meta.ts`:
+
+```ts
+// Reads server-provided configuration out of <meta> tags rendered by the SPA
+// layout (app/views/layouts/spa.html.haml). Blank content reads as absent, so
+// an env var that is set but empty behaves the same as one that is unset.
+
+export function readMeta(name: string): string | null {
+  const element = document.querySelector(`meta[name="${name}"]`);
+  const content = element?.getAttribute("content")?.trim();
+  if (!content) {
+    return null;
+  }
+  return content;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+corepack yarn vitest run app/frontend/lib/cookies.test.ts app/frontend/lib/meta.test.ts
+```
+
+Expected: PASS, 12 tests.
+
+- [ ] **Step 5: Run the gates and commit**
+
+```bash
+corepack yarn lint:fix && corepack yarn typecheck && corepack yarn test
+```
+
+```bash
+git add app/frontend/lib/cookies.ts app/frontend/lib/cookies.test.ts app/frontend/lib/meta.ts app/frontend/lib/meta.test.ts
+git commit -m "Add cookie and meta-tag DOM helpers for the SPA"
+```
+
+---
+
+### Task 2: Expose `SERVER_HOST` and the GTM id to the SPA
+
+The only Rails change. Both tags are conditional: in local dev `SERVER_HOST` may be unset, and `GOOGLE_TAG_MANAGER_ID` is normally unset outside production. Absent tags are the correct degradation (host-only cookie, no analytics), matching how `_google_tag_manager_head.html.haml` already guards.
+
+**Files:**
+- Modify: `app/views/layouts/spa.html.haml`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `<meta name="cookie-consent-domain" content="…">` and `<meta name="google-tag-manager-id" content="…">`, both read via `readMeta` from Task 1.
+
+- [ ] **Step 1: Add the meta tags**
+
+In `app/views/layouts/spa.html.haml`, immediately after the `viewport` meta line and before `%title`, insert:
+
+```haml
+    -# Server config the SPA needs in the browser. Both are optional: without
+    -# SERVER_HOST the consent cookie is written host-only, and without a GTM
+    -# id the SPA loads no analytics at all. See app/frontend/lib/meta.ts.
+    - if ENV["SERVER_HOST"].present?
+      %meta{ name: "cookie-consent-domain", content: ENV["SERVER_HOST"] }
+    - if ENV["GOOGLE_TAG_MANAGER_ID"].present?
+      %meta{ name: "google-tag-manager-id", content: ENV["GOOGLE_TAG_MANAGER_ID"] }
+```
+
+- [ ] **Step 2: Verify the template lints and renders**
+
+```bash
+PATH="$HOME/.rbenv/shims:$PATH" bundle exec haml-lint app/views/layouts/spa.html.haml
+```
+
+Expected: no offenses.
+
+Then, with the dev stack running (`foreman start -f Procfile.dev`):
+
+```bash
+SERVER_HOST=localhost curl -s http://localhost:3000/app/ping | grep -i 'meta name="cookie-consent-domain"'
+```
+
+Expected: the meta tag is present with `content="localhost"`. If `SERVER_HOST` is exported in your `.env`, no prefix is needed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/views/layouts/spa.html.haml
+git commit -m "Expose SERVER_HOST and the GTM id to the SPA as meta tags"
+```
+
+---
+
+### Task 3: The consent cookie contract — `cookieConsent.ts`
+
+Pure module, no React. This is the correctness-critical unit: it must write the *same* cookie the legacy `cookieconsent@3` library writes, so consent carries across the HAML↔SPA boundary in both directions.
+
+**Files:**
+- Create: `app/frontend/lib/cookieConsent.ts`
+- Create: `app/frontend/lib/cookieConsent.test.ts`
+
+**Interfaces:**
+- Consumes: `readCookie`, `writeCookie` from `@/lib/cookies`; `readMeta` from `@/lib/meta` (Task 1).
+- Produces:
+  - `const CONSENT_COOKIE_NAME = "_swapmyvote_cookie_consent"`
+  - `const CONSENT_DOMAIN_META = "cookie-consent-domain"`
+  - `type ConsentStatus = "dismiss" | "allow" | "deny"`
+  - `readConsent(): ConsentStatus | null`
+  - `saveConsent(status: ConsentStatus): boolean`
+  - `analyticsAllowed(status: ConsentStatus | null): boolean`
+
+- [ ] **Step 1: Write the failing test**
+
+`app/frontend/lib/cookieConsent.test.ts`:
+
+```ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as cookies from "@/lib/cookies";
+import {
+  analyticsAllowed,
+  CONSENT_COOKIE_NAME,
+  readConsent,
+  saveConsent,
+} from "@/lib/cookieConsent";
+
+function setConsentCookie(value: string) {
+  document.cookie = `${CONSENT_COOKIE_NAME}=${value}; path=/`;
+}
+
+function clearConsentCookie() {
+  document.cookie = `${CONSENT_COOKIE_NAME}=; path=/; max-age=0`;
+}
+
+function setDomainMeta(content: string) {
+  const meta = document.createElement("meta");
+  meta.setAttribute("name", "cookie-consent-domain");
+  meta.setAttribute("content", content);
+  document.head.appendChild(meta);
+}
+
+afterEach(() => {
+  clearConsentCookie();
+  for (const meta of document.head.querySelectorAll("meta")) {
+    meta.remove();
+  }
+  vi.restoreAllMocks();
+});
+
+describe("readConsent", () => {
+  it("returns null when the cookie is not set", () => {
+    expect(readConsent()).toBeNull();
+  });
+
+  it("reads the legacy library's dismiss value", () => {
+    setConsentCookie("dismiss");
+    expect(readConsent()).toBe("dismiss");
+  });
+
+  it("reads allow and deny", () => {
+    setConsentCookie("allow");
+    expect(readConsent()).toBe("allow");
+    setConsentCookie("deny");
+    expect(readConsent()).toBe("deny");
+  });
+
+  it("treats an unrecognised value as unset", () => {
+    setConsentCookie("banana");
+    expect(readConsent()).toBeNull();
+  });
+});
+
+describe("saveConsent", () => {
+  it("persists a status that readConsent can read back", () => {
+    saveConsent("allow");
+    expect(readConsent()).toBe("allow");
+  });
+
+  it("writes the legacy cookie name, path, expiry and domain", () => {
+    setDomainMeta("swapmyvote.uk");
+    const write = vi.spyOn(cookies, "writeCookie").mockReturnValue(true);
+    saveConsent("deny");
+    expect(write).toHaveBeenCalledWith(
+      "_swapmyvote_cookie_consent",
+      "deny",
+      expect.objectContaining({
+        domain: "swapmyvote.uk",
+        path: "/",
+        maxAgeSeconds: 31536000,
+        sameSite: "Lax",
+      }),
+    );
+  });
+
+  it("omits the domain when no meta tag is present", () => {
+    const write = vi.spyOn(cookies, "writeCookie").mockReturnValue(true);
+    saveConsent("allow");
+    expect(write.mock.calls[0][2]).not.toHaveProperty("domain", "swapmyvote.uk");
+    expect(write.mock.calls[0][2]?.domain).toBeUndefined();
+  });
+});
+
+describe("analyticsAllowed", () => {
+  it("allows analytics for an explicit allow", () => {
+    expect(analyticsAllowed("allow")).toBe(true);
+  });
+
+  it("allows analytics for a legacy dismiss (analytics already ran for them)", () => {
+    expect(analyticsAllowed("dismiss")).toBe(true);
+  });
+
+  it("refuses analytics for deny and for an unanswered banner", () => {
+    expect(analyticsAllowed("deny")).toBe(false);
+    expect(analyticsAllowed(null)).toBe(false);
+  });
+});
+```
+
+The `vi.spyOn(cookies, "writeCookie")` calls require Vitest's module interop; if the spy fails with "not extensible", add this at the top of the file instead and keep the same assertions:
+
+```ts
+vi.mock("@/lib/cookies", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/cookies")>();
+  return { ...actual, writeCookie: vi.fn(actual.writeCookie) };
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+corepack yarn vitest run app/frontend/lib/cookieConsent.test.ts
+```
+
+Expected: FAIL — `Failed to resolve import "@/lib/cookieConsent"`.
+
+- [ ] **Step 3: Write the implementation**
+
+`app/frontend/lib/cookieConsent.ts`:
+
+```ts
+import { readCookie, writeCookie } from "@/lib/cookies";
+import { readMeta } from "@/lib/meta";
+
+// The consent cookie is SHARED with the legacy HAML site, which writes it via
+// cookieconsent@3 (app/views/layouts/_cookie_consent.html.haml). Name, path and
+// expiry below match that library's defaults exactly, and the domain comes from
+// ENV["SERVER_HOST"] via a meta tag — so a user who answered on one side of the
+// HAML/SPA boundary is never re-prompted on the other.
+//
+// SameSite=Lax and Secure are additions the legacy library does not set. Neither
+// affects the legacy site: the cookie is first-party and still readable there.
+
+export const CONSENT_COOKIE_NAME = "_swapmyvote_cookie_consent";
+export const CONSENT_DOMAIN_META = "cookie-consent-domain";
+
+const CONSENT_MAX_AGE_SECONDS = 365 * 24 * 60 * 60;
+
+// "dismiss" is written by the legacy library's OK button; "allow"/"deny" are
+// its opt-in vocabulary, which the legacy site also reads as "already answered".
+export type ConsentStatus = "dismiss" | "allow" | "deny";
+
+const CONSENT_STATUSES: readonly string[] = ["dismiss", "allow", "deny"];
+
+export function readConsent(): ConsentStatus | null {
+  const value = readCookie(CONSENT_COOKIE_NAME);
+  if (value !== null && CONSENT_STATUSES.includes(value)) {
+    return value as ConsentStatus;
+  }
+  return null;
+}
+
+export function saveConsent(status: ConsentStatus): boolean {
+  const domain = readMeta(CONSENT_DOMAIN_META);
+  return writeCookie(CONSENT_COOKIE_NAME, status, {
+    domain: domain ?? undefined,
+    path: "/",
+    maxAgeSeconds: CONSENT_MAX_AGE_SECONDS,
+    sameSite: "Lax",
+    secure: window.location.protocol === "https:",
+  });
+}
+
+export function analyticsAllowed(status: ConsentStatus | null): boolean {
+  return status === "allow" || status === "dismiss";
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+corepack yarn vitest run app/frontend/lib/cookieConsent.test.ts
+```
+
+Expected: PASS, 9 tests.
+
+- [ ] **Step 5: Run the gates and commit**
+
+```bash
+corepack yarn lint:fix && corepack yarn typecheck && corepack yarn test
+```
+
+```bash
+git add app/frontend/lib/cookieConsent.ts app/frontend/lib/cookieConsent.test.ts
+git commit -m "Add the shared cookie-consent contract for the SPA"
+```
+
+---
+
+### Task 4: `CookieConsentContext`
+
+Turns the pure module into reactive state so the banner and the analytics loader stay in sync in a single render pass.
+
+**Files:**
+- Create: `app/frontend/contexts/CookieConsentContext.tsx`
+- Create: `app/frontend/contexts/CookieConsentContext.test.tsx`
+
+**Interfaces:**
+- Consumes: `readConsent`, `saveConsent`, `analyticsAllowed`, `ConsentStatus`, `CONSENT_COOKIE_NAME` from `@/lib/cookieConsent` (Task 3).
+- Produces:
+  - `type CookieConsent = { status: ConsentStatus | null; hasAnswered: boolean; analyticsAllowed: boolean; accept: () => void; decline: () => void }`
+  - `<CookieConsentProvider>{children}</CookieConsentProvider>`
+  - `useCookieConsent(): CookieConsent` — throws outside a provider.
+
+- [ ] **Step 1: Write the failing test**
+
+`app/frontend/contexts/CookieConsentContext.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  CookieConsentProvider,
+  useCookieConsent,
+} from "@/contexts/CookieConsentContext";
+import { CONSENT_COOKIE_NAME } from "@/lib/cookieConsent";
+
+function Probe() {
+  const { status, hasAnswered, analyticsAllowed, accept, decline } =
+    useCookieConsent();
+  return (
+    <div>
+      <span data-testid="status">{status ?? "unset"}</span>
+      <span data-testid="answered">{String(hasAnswered)}</span>
+      <span data-testid="analytics">{String(analyticsAllowed)}</span>
+      <button type="button" onClick={accept}>
+        accept
+      </button>
+      <button type="button" onClick={decline}>
+        decline
+      </button>
+    </div>
+  );
+}
+
+function renderProbe() {
+  return render(
+    <CookieConsentProvider>
+      <Probe />
+    </CookieConsentProvider>,
+  );
+}
+
+afterEach(() => {
+  document.cookie = `${CONSENT_COOKIE_NAME}=; path=/; max-age=0`;
+});
+
+describe("CookieConsentProvider", () => {
+  it("starts unanswered when no cookie is set", () => {
+    renderProbe();
+    expect(screen.getByTestId("status")).toHaveTextContent("unset");
+    expect(screen.getByTestId("answered")).toHaveTextContent("false");
+    expect(screen.getByTestId("analytics")).toHaveTextContent("false");
+  });
+
+  it("seeds from an existing legacy dismiss cookie", () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=dismiss; path=/`;
+    renderProbe();
+    expect(screen.getByTestId("answered")).toHaveTextContent("true");
+    expect(screen.getByTestId("analytics")).toHaveTextContent("true");
+  });
+
+  it("records an accept in state and in the cookie", async () => {
+    renderProbe();
+    await userEvent.click(screen.getByRole("button", { name: "accept" }));
+    expect(screen.getByTestId("status")).toHaveTextContent("allow");
+    expect(screen.getByTestId("analytics")).toHaveTextContent("true");
+    expect(document.cookie).toContain(`${CONSENT_COOKIE_NAME}=allow`);
+  });
+
+  it("records a decline in state and in the cookie", async () => {
+    renderProbe();
+    await userEvent.click(screen.getByRole("button", { name: "decline" }));
+    expect(screen.getByTestId("status")).toHaveTextContent("deny");
+    expect(screen.getByTestId("analytics")).toHaveTextContent("false");
+    expect(document.cookie).toContain(`${CONSENT_COOKIE_NAME}=deny`);
+  });
+});
+
+describe("useCookieConsent", () => {
+  it("throws when used outside a provider", () => {
+    expect(() => render(<Probe />)).toThrow(/CookieConsentProvider/);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+corepack yarn vitest run app/frontend/contexts/CookieConsentContext.test.tsx
+```
+
+Expected: FAIL — `Failed to resolve import "@/contexts/CookieConsentContext"`.
+
+- [ ] **Step 3: Write the implementation**
+
+`app/frontend/contexts/CookieConsentContext.tsx`:
+
+```tsx
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+import {
+  analyticsAllowed as isAnalyticsAllowed,
+  type ConsentStatus,
+  readConsent,
+  saveConsent,
+} from "@/lib/cookieConsent";
+
+export type CookieConsent = {
+  status: ConsentStatus | null;
+  hasAnswered: boolean;
+  analyticsAllowed: boolean;
+  accept: () => void;
+  decline: () => void;
+};
+
+const CookieConsentContext = createContext<CookieConsent | null>(null);
+
+export function CookieConsentProvider({ children }: { children: ReactNode }) {
+  const [status, setStatus] = useState<ConsentStatus | null>(() =>
+    readConsent(),
+  );
+
+  // The cookie write is best-effort: if it fails (hardened privacy settings),
+  // still update state so the banner dismisses for this session rather than
+  // becoming undismissable.
+  const record = useCallback((next: ConsentStatus) => {
+    saveConsent(next);
+    setStatus(next);
+  }, []);
+
+  const value = useMemo<CookieConsent>(
+    () => ({
+      status,
+      hasAnswered: status !== null,
+      analyticsAllowed: isAnalyticsAllowed(status),
+      accept: () => record("allow"),
+      decline: () => record("deny"),
+    }),
+    [status, record],
+  );
+
+  return (
+    <CookieConsentContext.Provider value={value}>
+      {children}
+    </CookieConsentContext.Provider>
+  );
+}
+
+export function useCookieConsent(): CookieConsent {
+  const value = useContext(CookieConsentContext);
+  if (value === null) {
+    throw new Error(
+      "useCookieConsent must be used inside a CookieConsentProvider",
+    );
+  }
+  return value;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+corepack yarn vitest run app/frontend/contexts/CookieConsentContext.test.tsx
+```
+
+Expected: PASS, 5 tests. React logs the expected error for the "throws outside a provider" case — that is normal.
+
+- [ ] **Step 5: Run the gates and commit**
+
+```bash
+corepack yarn lint:fix && corepack yarn typecheck && corepack yarn test
+```
+
+```bash
+git add app/frontend/contexts/CookieConsentContext.tsx app/frontend/contexts/CookieConsentContext.test.tsx
+git commit -m "Add a cookie-consent React context"
+```
+
+---
+
+### Task 5: The banner component
+
+Presentational. Renders nothing once answered. Uses an `<aside>` (implicit `complementary` landmark) with an `aria-label` rather than `<div role="region">` — same landmark semantics, no redundant-role lint. It is deliberately **not** a dialog: no `aria-modal`, no focus trap, no focus stealing, and it sits last in the DOM so it never blocks keyboard access to page content.
+
+**Files:**
+- Create: `app/frontend/components/cookieConsent/CookieConsentBanner.tsx`
+- Create: `app/frontend/components/cookieConsent/CookieConsentBanner.module.scss`
+- Create: `app/frontend/components/cookieConsent/CookieConsentBanner.test.tsx`
+
+**Interfaces:**
+- Consumes: `useCookieConsent` (Task 4); `STATIC_PATHS` from `@/lib/staticPaths`.
+- Produces: `<CookieConsentBanner />` — no props.
+
+- [ ] **Step 1: Write the failing test**
+
+`app/frontend/components/cookieConsent/CookieConsentBanner.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it } from "vitest";
+import { CookieConsentBanner } from "@/components/cookieConsent/CookieConsentBanner";
+import { CookieConsentProvider } from "@/contexts/CookieConsentContext";
+import { CONSENT_COOKIE_NAME } from "@/lib/cookieConsent";
+import { STATIC_PATHS } from "@/lib/staticPaths";
+
+function renderBanner() {
+  return render(
+    <MemoryRouter>
+      <CookieConsentProvider>
+        <CookieConsentBanner />
+      </CookieConsentProvider>
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  document.cookie = `${CONSENT_COOKIE_NAME}=; path=/; max-age=0`;
+});
+
+describe("CookieConsentBanner", () => {
+  it("shows when consent has not been given", () => {
+    renderBanner();
+    expect(
+      screen.getByRole("complementary", { name: /cookie consent/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/we use cookies to improve your experience/i),
+    ).toBeInTheDocument();
+  });
+
+  it("links the in-SPA cookie policy", () => {
+    renderBanner();
+    expect(
+      screen.getByRole("link", { name: /cookie policy/i }),
+    ).toHaveAttribute("href", STATIC_PATHS.cookies);
+  });
+
+  it("stays hidden when the legacy site already recorded consent", () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=dismiss; path=/`;
+    renderBanner();
+    expect(screen.queryByRole("complementary")).not.toBeInTheDocument();
+  });
+
+  it("hides and persists allow when accepted", async () => {
+    renderBanner();
+    await userEvent.click(screen.getByRole("button", { name: /accept/i }));
+    expect(screen.queryByRole("complementary")).not.toBeInTheDocument();
+    expect(document.cookie).toContain(`${CONSENT_COOKIE_NAME}=allow`);
+  });
+
+  it("hides and persists deny when declined", async () => {
+    renderBanner();
+    await userEvent.click(screen.getByRole("button", { name: /decline/i }));
+    expect(screen.queryByRole("complementary")).not.toBeInTheDocument();
+    expect(document.cookie).toContain(`${CONSENT_COOKIE_NAME}=deny`);
+  });
+
+  it("puts both choices in the keyboard tab order", async () => {
+    renderBanner();
+    await userEvent.tab();
+    await userEvent.tab();
+    expect(screen.getByRole("button", { name: /decline/i })).toHaveFocus();
+    await userEvent.tab();
+    expect(screen.getByRole("button", { name: /accept/i })).toHaveFocus();
+  });
+});
+```
+
+The tab test walks: cookie-policy link → Decline → Accept. If the DOM order in your implementation differs, fix the implementation to match this order rather than loosening the test — Decline must not come after Accept.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+corepack yarn vitest run app/frontend/components/cookieConsent/CookieConsentBanner.test.tsx
+```
+
+Expected: FAIL — `Failed to resolve import "@/components/cookieConsent/CookieConsentBanner"`.
+
+- [ ] **Step 3: Write the implementation**
+
+`app/frontend/components/cookieConsent/CookieConsentBanner.module.scss`:
+
+```scss
+// Bootstrap's .fixed-bottom and .sticky-top share z-index 1030, so the banner
+// would sit under the sticky navigation when the page is scrolled to the end.
+// One step up (Bootstrap's $zindex-fixed + 10) keeps it above the nav without
+// reaching modal/toast territory.
+.banner {
+  z-index: 1040;
+}
+```
+
+`app/frontend/components/cookieConsent/CookieConsentBanner.tsx`:
+
+```tsx
+import Button from "react-bootstrap/Button";
+import Container from "react-bootstrap/Container";
+import { Link } from "react-router-dom";
+import { useCookieConsent } from "@/contexts/CookieConsentContext";
+import { STATIC_PATHS } from "@/lib/staticPaths";
+import styles from "./CookieConsentBanner.module.scss";
+
+// React replacement for the legacy cookieconsent@3 bar. Deliberately NOT a
+// dialog: no aria-modal, no focus trap, no focus stealing. It is a
+// complementary landmark rendered last in the DOM, so a keyboard user reaches
+// the page content first and the banner never blocks it.
+//
+// Unlike the legacy bar (dismiss-only), this offers a real choice, because the
+// SPA gates Google Tag Manager on the answer. See GoogleTagManager.tsx.
+export function CookieConsentBanner() {
+  const { hasAnswered, accept, decline } = useCookieConsent();
+
+  if (hasAnswered) {
+    return null;
+  }
+
+  return (
+    <aside
+      aria-label="Cookie consent"
+      className={`${styles.banner} fixed-bottom bg-white border-top shadow p-3`}
+    >
+      <Container className="d-flex flex-column flex-md-row align-items-md-center gap-3 px-lg-5">
+        <p className="mb-0 flex-grow-1 small">
+          We use cookies to improve your experience. Analytics cookies are only
+          set if you accept.{" "}
+          <Link to={STATIC_PATHS.cookies}>Cookie Policy</Link>
+        </p>
+        <div className="d-flex gap-2 flex-shrink-0">
+          <Button variant="outline-dark" onClick={decline}>
+            Decline
+          </Button>
+          <Button variant="primary" onClick={accept}>
+            Accept
+          </Button>
+        </div>
+      </Container>
+    </aside>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+corepack yarn vitest run app/frontend/components/cookieConsent/CookieConsentBanner.test.tsx
+```
+
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Run the gates and commit**
+
+```bash
+corepack yarn lint:fix && corepack yarn typecheck && corepack yarn test
+```
+
+```bash
+git add app/frontend/components/cookieConsent
+git commit -m "Add the SPA cookie-consent banner"
+```
+
+---
+
+### Task 6: Consent-gated Google Tag Manager
+
+Renders nothing. Injects `gtm.js` once, only when consent allows and the layout supplied an id. Idempotence is guarded by the script element's own id rather than module state, so it survives StrictMode double-effects and is trivially assertable in tests. There is no `<noscript>` iframe: the SPA does not render at all without JS.
+
+**Files:**
+- Create: `app/frontend/components/analytics/GoogleTagManager.tsx`
+- Create: `app/frontend/components/analytics/GoogleTagManager.test.tsx`
+
+**Interfaces:**
+- Consumes: `useCookieConsent` (Task 4); `readMeta` from `@/lib/meta` (Task 1).
+- Produces: `<GoogleTagManager />` — no props; `const GTM_ID_META = "google-tag-manager-id"`; `const GTM_SCRIPT_ID = "gtm-script"`.
+
+- [ ] **Step 1: Write the failing test**
+
+`app/frontend/components/analytics/GoogleTagManager.test.tsx`:
+
+```tsx
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  GoogleTagManager,
+  GTM_SCRIPT_ID,
+} from "@/components/analytics/GoogleTagManager";
+import { CookieConsentBanner } from "@/components/cookieConsent/CookieConsentBanner";
+import { CookieConsentProvider } from "@/contexts/CookieConsentContext";
+import { CONSENT_COOKIE_NAME } from "@/lib/cookieConsent";
+import { MemoryRouter } from "react-router-dom";
+import { screen } from "@testing-library/react";
+
+function setGtmMeta(id: string) {
+  const meta = document.createElement("meta");
+  meta.setAttribute("name", "google-tag-manager-id");
+  meta.setAttribute("content", id);
+  document.head.appendChild(meta);
+}
+
+function gtmScripts() {
+  return document.querySelectorAll(`#${GTM_SCRIPT_ID}`);
+}
+
+function renderWithConsent() {
+  return render(
+    <MemoryRouter>
+      <CookieConsentProvider>
+        <GoogleTagManager />
+        <CookieConsentBanner />
+      </CookieConsentProvider>
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  document.cookie = `${CONSENT_COOKIE_NAME}=; path=/; max-age=0`;
+  for (const meta of document.head.querySelectorAll("meta")) {
+    meta.remove();
+  }
+  for (const script of gtmScripts()) {
+    script.remove();
+  }
+});
+
+describe("GoogleTagManager", () => {
+  it("does not load analytics before consent is given", () => {
+    setGtmMeta("GTM-TEST");
+    renderWithConsent();
+    expect(gtmScripts()).toHaveLength(0);
+  });
+
+  it("does not load analytics when consent is denied", () => {
+    setGtmMeta("GTM-TEST");
+    document.cookie = `${CONSENT_COOKIE_NAME}=deny; path=/`;
+    renderWithConsent();
+    expect(gtmScripts()).toHaveLength(0);
+  });
+
+  it("loads analytics for an existing allow", () => {
+    setGtmMeta("GTM-TEST");
+    document.cookie = `${CONSENT_COOKIE_NAME}=allow; path=/`;
+    renderWithConsent();
+    const script = document.getElementById(GTM_SCRIPT_ID) as HTMLScriptElement;
+    expect(script.src).toContain(
+      "https://www.googletagmanager.com/gtm.js?id=GTM-TEST",
+    );
+  });
+
+  it("loads analytics for a legacy dismiss", () => {
+    setGtmMeta("GTM-TEST");
+    document.cookie = `${CONSENT_COOKIE_NAME}=dismiss; path=/`;
+    renderWithConsent();
+    expect(gtmScripts()).toHaveLength(1);
+  });
+
+  it("loads analytics as soon as the banner is accepted", async () => {
+    setGtmMeta("GTM-TEST");
+    renderWithConsent();
+    expect(gtmScripts()).toHaveLength(0);
+    await userEvent.click(screen.getByRole("button", { name: /accept/i }));
+    expect(gtmScripts()).toHaveLength(1);
+  });
+
+  it("never injects the script twice", () => {
+    setGtmMeta("GTM-TEST");
+    document.cookie = `${CONSENT_COOKIE_NAME}=allow; path=/`;
+    const { rerender } = renderWithConsent();
+    rerender(
+      <MemoryRouter>
+        <CookieConsentProvider>
+          <GoogleTagManager />
+          <CookieConsentBanner />
+        </CookieConsentProvider>
+      </MemoryRouter>,
+    );
+    expect(gtmScripts()).toHaveLength(1);
+  });
+
+  it("loads nothing when the layout supplied no GTM id", () => {
+    document.cookie = `${CONSENT_COOKIE_NAME}=allow; path=/`;
+    renderWithConsent();
+    expect(gtmScripts()).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+corepack yarn vitest run app/frontend/components/analytics/GoogleTagManager.test.tsx
+```
+
+Expected: FAIL — `Failed to resolve import "@/components/analytics/GoogleTagManager"`.
+
+- [ ] **Step 3: Write the implementation**
+
+`app/frontend/components/analytics/GoogleTagManager.tsx`:
+
+```tsx
+import { useEffect } from "react";
+import { useCookieConsent } from "@/contexts/CookieConsentContext";
+import { readMeta } from "@/lib/meta";
+
+// Consent-gated Google Tag Manager for the SPA. This is a deliberate divergence
+// from the legacy site, which loads GTM unconditionally in
+// app/views/layouts/_google_tag_manager_head.html.haml — gating the legacy
+// partials on the same cookie is tracked as a follow-up.
+//
+// No <noscript> iframe counterpart: the SPA renders nothing without JS anyway.
+
+export const GTM_ID_META = "google-tag-manager-id";
+export const GTM_SCRIPT_ID = "gtm-script";
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+  }
+}
+
+function injectGoogleTagManager(id: string) {
+  // Guard on the element rather than a module flag: a script tag cannot be
+  // un-injected, and this stays correct under StrictMode's double effects.
+  if (document.getElementById(GTM_SCRIPT_ID) !== null) {
+    return;
+  }
+  window.dataLayer = window.dataLayer ?? [];
+  window.dataLayer.push({ "gtm.start": Date.now(), event: "gtm.js" });
+
+  const script = document.createElement("script");
+  script.id = GTM_SCRIPT_ID;
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtm.js?id=${encodeURIComponent(id)}`;
+  document.head.appendChild(script);
+}
+
+export function GoogleTagManager() {
+  const { analyticsAllowed } = useCookieConsent();
+
+  useEffect(() => {
+    if (!analyticsAllowed) {
+      return;
+    }
+    const id = readMeta(GTM_ID_META);
+    if (id === null) {
+      return;
+    }
+    injectGoogleTagManager(id);
+  }, [analyticsAllowed]);
+
+  return null;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+corepack yarn vitest run app/frontend/components/analytics/GoogleTagManager.test.tsx
+```
+
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Run the gates and commit**
+
+```bash
+corepack yarn lint:fix && corepack yarn typecheck && corepack yarn test
+```
+
+```bash
+git add app/frontend/components/analytics
+git commit -m "Load Google Tag Manager in the SPA only after consent"
+```
+
+---
+
+### Task 7: Wire into the SPA and verify in the browser
+
+**Files:**
+- Modify: `app/frontend/app/App.tsx`
+
+**Interfaces:**
+- Consumes: `CookieConsentProvider` (Task 4), `CookieConsentBanner` (Task 5), `GoogleTagManager` (Task 6).
+- Produces: nothing further.
+
+- [ ] **Step 1: Wire the provider, loader and banner into `App.tsx`**
+
+Add the imports:
+
+```tsx
+import { GoogleTagManager } from "@/components/analytics/GoogleTagManager";
+import { CookieConsentBanner } from "@/components/cookieConsent/CookieConsentBanner";
+import { CookieConsentProvider } from "@/contexts/CookieConsentContext";
+```
+
+Change `Layout` to render the loader and banner after the footer:
+
+```tsx
+function Layout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <Navigation />
+      <main>{children}</main>
+      <Footer />
+      <GoogleTagManager />
+      {/* Last in the DOM on purpose: the banner is a landmark, not a dialog,
+          so keyboard users reach the page content before it. */}
+      <CookieConsentBanner />
+    </>
+  );
+}
+```
+
+Wrap the router in the provider — it must sit outside `<BrowserRouter>`'s children that use it, but the banner needs router context for its `<Link>`, so the provider goes **outside** `BrowserRouter`:
+
+```tsx
+export function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <CookieConsentProvider>
+        <BrowserRouter>
+          <Layout>
+            <Routes>{/* unchanged */}</Routes>
+          </Layout>
+        </BrowserRouter>
+      </CookieConsentProvider>
+    </QueryClientProvider>
+  );
+}
+```
+
+- [ ] **Step 2: Run every gate**
+
+```bash
+corepack yarn lint:fix && corepack yarn typecheck && corepack yarn test
+```
+
+Expected: Biome clean, no TypeScript errors, all Vitest suites pass.
+
+- [ ] **Step 3: Verify in the browser**
+
+Start the stack (`foreman start -f Procfile.dev`) with `SERVER_HOST` and `GOOGLE_TAG_MANAGER_ID` set in `.env`, then on `http://localhost:3000/app/cookies`:
+
+1. Banner appears at the bottom, above the sticky nav when scrolled.
+2. "Cookie Policy" navigates in-SPA (no full page load).
+3. Tab order reaches Decline then Accept; no focus trap.
+4. Click Decline → banner disappears, `document.cookie` shows `_swapmyvote_cookie_consent=deny`, no `googletagmanager.com` request in the network log.
+5. Clear the cookie, reload, click Accept → cookie is `allow` and a `gtm.js` request fires.
+6. Cross-boundary check: with the cookie set to `allow`, load a legacy page (`/about`) — the legacy bar must **not** appear. Then clear it, dismiss the bar on `/about`, and load `/app/cookies` — the React banner must **not** appear.
+
+Step 6 is the whole point of the cookie contract. If either half re-prompts, compare the two cookies in devtools: name, domain and path must match exactly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/frontend/app/App.tsx
+git commit -m "Show the cookie-consent banner on every SPA route"
+```
+
+- [ ] **Step 5: Open the pull request**
+
+```bash
+git push -u origin frontend-cookie-consent-banner
+```
+
+PR description must include `Closes #1039` and call out the deliberate behaviour change (SPA gates GTM on consent; the legacy site still does not).
+
+- [ ] **Step 6: File the follow-up issue**
+
+```bash
+gh issue create --title "Gate the legacy HAML Google Tag Manager partials on the consent cookie" --body "Follow-up to #1039. The SPA now loads GTM only after an explicit accept, but app/views/layouts/_google_tag_manager_head.html.haml and _google_tag_manager_body.html.haml still load it unconditionally, so a user who declines on an SPA page is still tracked on legacy pages. Gate both partials on _swapmyvote_cookie_consent being 'allow' or 'dismiss' (see app/frontend/lib/cookieConsent.ts for the contract), and add a request spec."
+```

--- a/docs/superpowers/specs/2026-08-16-spa-cookie-consent-design.md
+++ b/docs/superpowers/specs/2026-08-16-spa-cookie-consent-design.md
@@ -99,7 +99,8 @@ Fixed-bottom bar, hidden entirely once `hasAnswered`. Content: "We use cookies t
 improve your experience.", a `<Link>` to `STATIC_PATHS.cookies`, and Accept /
 Decline buttons.
 
-a11y: `role="region"` with an `aria-label`, placed last in the DOM. It is **not**
+a11y: an `<aside>` (implicit `complementary` landmark) with an `aria-label`,
+placed last in the DOM. It is **not**
 a dialog — no `aria-modal`, no focus trap, no focus stealing. Both buttons are
 real `<button>`s, reachable by keyboard in document order, so the banner never
 blocks access to page content (ties into the axe work in #1038).
@@ -152,7 +153,8 @@ Vitest + React Testing Library, co-located `*.test.tsx` / `*.test.ts`:
 - **`CookieConsentBanner`** — renders when no cookie is set; does **not** render
   when the cookie holds `dismiss` (the legacy-consent case); Accept hides it and
   persists `allow`; Decline hides it and persists `deny`; the policy link points
-  at `STATIC_PATHS.cookies`; the region has an accessible name.
+  at `STATIC_PATHS.cookies`; the landmark has an accessible name; both buttons are
+  in the keyboard tab order.
 - **`GoogleTagManager`** — no script when consent is unset or `deny`; script
   injected once when `allow`; no script when the GTM id meta is absent.
 

--- a/docs/superpowers/specs/2026-08-16-spa-cookie-consent-design.md
+++ b/docs/superpowers/specs/2026-08-16-spa-cookie-consent-design.md
@@ -1,0 +1,167 @@
+# React cookie-consent banner for the SPA
+
+Design for [issue #1039](https://github.com/swapmyvote/swapmyvote/issues/1039). Follow-up to #1037 (M1).
+
+## Problem
+
+The React SPA renders no cookie-consent prompt. The legacy HAML site shows one on
+every page via a CDN copy of `cookieconsent@3`, initialised in
+`app/views/layouts/_cookie_consent.html.haml`. The `spa` layout deliberately omits
+that script (no-CDN posture, Bootstrap 4 era), so migrated `/app/*` routes have no
+consent UI. That gap must close before any React route is cut over.
+
+The legacy cookie is `_swapmyvote_cookie_consent`, scoped to `ENV["SERVER_HOST"]`,
+and is documented on the Cookie Policy page (already ported to `/app/cookies`).
+
+## Decisions
+
+| Question | Decision |
+| --- | --- |
+| Reuse `cookieconsent@3` or write our own? | **Bespoke React component.** The library is unmaintained, imperative, and carries a11y problems we would inherit. The behaviour we need is ~60 lines. |
+| How does the SPA learn the cookie domain? | **Meta tag in the `spa` layout.** Exact parity on name + domain + path means HAML and SPA share one cookie, so consent carries across the coexistence boundary in both directions. |
+| Gate analytics on consent? | **Yes — behaviour change, accepted deliberately.** The SPA loads Google Tag Manager only after an explicit accept. |
+| Banner buttons | **Accept + Decline.** Gating is meaningless without a way to refuse. |
+| Gate the legacy HAML GTM partials too? | **Out of scope.** Filed as a follow-up so this change stays frontend-only. A user who declines on an SPA page will still get GTM on legacy pages until that lands. |
+
+## Cookie contract
+
+This is the correctness-critical part: the SPA must write *the same cookie* the
+legacy library writes, not a same-named sibling.
+
+- **Name**: `_swapmyvote_cookie_consent`
+- **Domain**: `ENV["SERVER_HOST"]`, delivered to the SPA as a meta tag. When the
+  value is blank the `domain` attribute is omitted entirely (host-only cookie),
+  which is the correct degradation for local dev where the env var may be unset.
+- **Path**: `/` — matches the library default.
+- **Expiry**: 365 days via `max-age` — matches the library default.
+- **`SameSite=Lax`**, and `Secure` when `location.protocol === "https:"`. The
+  legacy library sets neither. Adding them changes nothing the legacy site
+  depends on: the cookie is still first-party, still sent on top-level
+  navigation, and still readable by `document.cookie` on both sides.
+
+### Values
+
+`cookieconsent@3`'s own vocabulary, so the legacy site interprets anything we
+write as "already answered" and never re-prompts:
+
+| Value | Written by | Meaning |
+| --- | --- | --- |
+| `dismiss` | legacy "OK" button | answered; analytics were running anyway |
+| `allow` | SPA Accept | answered; analytics allowed |
+| `deny` | SPA Decline | answered; analytics refused |
+
+Derived predicates:
+
+- `hasAnswered` — the cookie is present with any of the three values. Controls
+  whether the banner renders.
+- `analyticsAllowed` — value is `allow` **or** `dismiss`. A legacy "OK" already
+  meant GTM ran for that user, so treating it as consent preserves their
+  experience rather than silently downgrading it, and avoids re-prompting.
+
+An unrecognised value is treated as unset: the banner shows and analytics stay off.
+
+## Components
+
+Each unit is independently testable and depends only on the one below it.
+
+### `app/views/layouts/spa.html.haml`
+
+Adds two meta tags inside `%head`, each rendered only when its env var is set:
+
+- `cookie-consent-domain` → `ENV["SERVER_HOST"]`
+- `google-tag-manager-id` → `ENV["GOOGLE_TAG_MANAGER_ID"]`
+
+The only Rails change in this work.
+
+### `app/frontend/lib/cookies.ts`
+
+`readCookie(name)` and `writeCookie(name, value, options)` over `document.cookie`.
+No dependency. Handles URI encoding and omits blank attributes. Knows nothing
+about consent.
+
+### `app/frontend/lib/cookieConsent.ts`
+
+The cookie contract as code: the name, the `ConsentStatus` union, `readConsent()`,
+`saveConsent(status)`, `analyticsAllowed(status)`, and `readConsentDomain()`
+(the meta-tag lookup). Pure module, no React.
+
+### `app/frontend/contexts/CookieConsentContext.tsx`
+
+Provider holding the current status in state, seeded from `readConsent()` on
+mount. Exposes `{ status, hasAnswered, analyticsAllowed, accept, decline }`.
+`accept`/`decline` write the cookie and update state, so the banner disappears
+and the analytics loader reacts in the same render pass. `useCookieConsent()`
+throws outside a provider.
+
+### `app/frontend/components/cookieConsent/CookieConsentBanner.tsx`
+
+Fixed-bottom bar, hidden entirely once `hasAnswered`. Content: "We use cookies to
+improve your experience.", a `<Link>` to `STATIC_PATHS.cookies`, and Accept /
+Decline buttons.
+
+a11y: `role="region"` with an `aria-label`, placed last in the DOM. It is **not**
+a dialog — no `aria-modal`, no focus trap, no focus stealing. Both buttons are
+real `<button>`s, reachable by keyboard in document order, so the banner never
+blocks access to page content (ties into the axe work in #1038).
+
+Styling: Bootstrap utilities plus a co-located `CookieConsentBanner.module.scss`
+for the fixed positioning and z-index only. SPA brand colours, not the legacy
+teal/yellow palette.
+
+### `app/frontend/components/analytics/GoogleTagManager.tsx`
+
+Renders nothing. On mount and on consent change, if `analyticsAllowed` and the
+GTM id meta tag is present, injects the `gtm.js` script once (guarded by a
+module-level flag, since the script cannot be un-injected). No `<noscript>`
+iframe — the SPA requires JS to render at all.
+
+### `app/frontend/app/App.tsx`
+
+`CookieConsentProvider` wraps the router. `Layout` renders `<GoogleTagManager />`
+and `<CookieConsentBanner />` after `<Footer />`.
+
+## Data flow
+
+```
+spa.html.haml meta tags
+  └─> cookieConsent.ts (domain, GTM id) ─┬─> CookieConsentContext (status, actions)
+document.cookie ──> readConsent() ───────┘        ├─> CookieConsentBanner (render / accept / decline)
+                                                  └─> GoogleTagManager (inject when allowed)
+                    saveConsent() <───────────────┘
+```
+
+## Error handling
+
+- Missing or blank meta tags: `domain` attribute omitted; GTM never injected.
+  Neither is an error, both are the correct local-dev state.
+- `document.cookie` unavailable or throwing (hardened privacy settings): treat
+  consent as unset, show the banner, keep analytics off. The click handlers
+  swallow write failures and still update in-memory state, so a user is not stuck
+  with an undismissable banner within a session.
+- Unrecognised cookie value: treated as unset (above).
+
+## Testing
+
+Vitest + React Testing Library, co-located `*.test.tsx` / `*.test.ts`:
+
+- **`cookies`** — round-trips a value; emits `domain`/`path`/`max-age`/`SameSite`;
+  omits `domain` when blank; returns `null` for an absent cookie.
+- **`cookieConsent`** — maps each cookie value to its status; unknown value reads
+  as unset; `analyticsAllowed` true for `allow` and `dismiss`, false for `deny`;
+  `saveConsent` writes the exact legacy name and the domain from the meta tag.
+- **`CookieConsentBanner`** — renders when no cookie is set; does **not** render
+  when the cookie holds `dismiss` (the legacy-consent case); Accept hides it and
+  persists `allow`; Decline hides it and persists `deny`; the policy link points
+  at `STATIC_PATHS.cookies`; the region has an accessible name.
+- **`GoogleTagManager`** — no script when consent is unset or `deny`; script
+  injected once when `allow`; no script when the GTM id meta is absent.
+
+No Rails specs: the layout change is two conditional meta tags with no
+controller or model behaviour behind them.
+
+## Out of scope
+
+- Gating the legacy HAML GTM partials on the consent cookie (follow-up issue).
+- A cookie-preferences UI for changing an answer after the fact. Neither the
+  legacy site nor this design offers one; clearing the cookie re-prompts.
+- Any change to the Cookie Policy page copy.


### PR DESCRIPTION
Closes #1039.

The SPA had no consent prompt: the `spa` layout deliberately omits the legacy CDN copy of `cookieconsent@3`, so migrated `/app/*` routes rendered with nothing. This adds a bespoke React banner that **shares the legacy cookie**, and gates Google Tag Manager on the answer.

## The cookie contract

The correctness-critical part. The SPA writes *the same cookie* the legacy library writes, not a same-named sibling:

- name `_swapmyvote_cookie_consent`, `path=/`, `max-age` 365 days — all matching `cookieconsent@3`'s defaults
- `domain` from `ENV["SERVER_HOST"]`, delivered to the browser as a new meta tag in `spa.html.haml` (omitted entirely when the env var is blank, which is the right local-dev degradation)
- `SameSite=Lax` and `Secure` on https are additions the legacy library doesn't set; neither affects the legacy side (still first-party, still readable)

Values use the library's own vocabulary so the legacy site reads anything we write as "already answered": `dismiss` (legacy OK), `allow`, `deny`. `dismiss` counts as analytics consent — those users already had GTM running, so treating it otherwise would both downgrade them and re-prompt.

## Deliberate behaviour change: analytics are gated

The legacy site loads GTM unconditionally. In the SPA it loads only after an explicit **Accept**, which is why the banner offers Accept **and** Decline rather than the legacy dismiss-only "OK".

The legacy partials still load GTM unconditionally, so a user who declines on an SPA page is still tracked on HAML pages. Gating those is deliberately out of scope here and filed as #1043.

## Structure

| File | Responsibility |
| --- | --- |
| `lib/cookies.ts`, `lib/meta.ts` | DOM primitives, no consent knowledge |
| `lib/cookieConsent.ts` | the cookie contract |
| `contexts/CookieConsentContext.tsx` | consent state + accept/decline |
| `components/cookieConsent/CookieConsentBanner.tsx` | the banner |
| `components/analytics/GoogleTagManager.tsx` | injects gtm.js when allowed |

a11y: the banner is a complementary landmark (`<aside aria-label>`), **not** a dialog — no `aria-modal`, no focus trap, no focus stealing, rendered last in the DOM so keyboard users reach page content first.

The banner owns its fixed positioning in its CSS module instead of using Bootstrap's `.fixed-bottom`: that utility also sets `z-index: 1030`, the same layer as the sticky nav, and its global rule wins on source order over an equally specific module class — leaving the banner underneath the nav.

## Verification

63 Vitest tests pass (cookie attributes, status mapping, show/hide, persistence, GTM gating, tab order).

Manually verified against the running stack, both directions of the coexistence boundary:

- Decline on `/app/cookies` → cookie `deny`, banner gone, no `googletagmanager.com` request; loading legacy `/about` afterwards shows **no** legacy bar
- Dismiss the legacy bar on `/about` → loading `/app/cookies` shows **no** React banner, and GTM loads (parity with legacy)
- Accept → cookie `allow`, `gtm.js` requested

Design and plan are committed under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)