### PR TITLE
M3 part 1: entry-form API and postcode/constituency lookup

### DIFF
--- a/app/controllers/api/v1/constituencies_controller.rb
+++ b/app/controllers/api/v1/constituencies_controller.rb
@@ -1,0 +1,14 @@
+module Api
+  module V1
+    # The constituencies the site is currently running swaps in — two for a
+    # by-election, the full list for a general election. Reference data, same
+    # as parties: no auth, no phase gate.
+    class ConstituenciesController < BaseController
+      def index
+        render json: ConstituencySerializer.new(
+          OnsConstituency.all.order(:name)
+        ).to_h
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/election_controller.rb
+++ b/app/controllers/api/v1/election_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V1
+    # The election being run for — dates, type, and the prose the SPA builds
+    # its headings from. Immutable for the life of a deploy, so it is a
+    # separate endpoint the client can cache indefinitely rather than part of
+    # the session payload, which is re-fetched on a poll.
+    class ElectionController < BaseController
+      def show
+        render json: ElectionSerializer.new(ElectionPresenter.new(self)).to_h
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  module V1
+    # The parties a user can pick as their preferred or willing party.
+    # Reference data: no auth, no phase gate, changes only when we seed it.
+    class PartiesController < BaseController
+      def index
+        render json: PartySerializer.new(Party.all.order(:name)).to_h
+      end
+    end
+  end
+end

--- a/app/frontend/components/home/ConstituencyAutocomplete.test.tsx
+++ b/app/frontend/components/home/ConstituencyAutocomplete.test.tsx
@@ -90,6 +90,41 @@ describe("ConstituencyAutocomplete", () => {
     expect(input).toHaveValue("Wakefield");
   });
 
+  describe("text that matches no constituency", () => {
+    it("is wiped when the field is left, as the legacy combobox did", async () => {
+      const { input, onChange } = renderAutocomplete();
+
+      await userEvent.type(input, "Wakef");
+      expect(input).toHaveValue("Wakef");
+
+      await userEvent.tab();
+
+      // A half-typed name must never sit in the box looking like a choice.
+      expect(input).toHaveValue("");
+      expect(onChange).toHaveBeenLastCalledWith("");
+    });
+
+    it("leaves a complete name alone", async () => {
+      const { input, onChange } = renderAutocomplete();
+
+      await userEvent.type(input, "Wakefield");
+      await userEvent.tab();
+
+      expect(input).toHaveValue("Wakefield");
+      expect(onChange).toHaveBeenLastCalledWith("E14001009");
+    });
+
+    it("leaves an empty field alone", async () => {
+      const { input, onChange } = renderAutocomplete();
+
+      await userEvent.click(input);
+      await userEvent.tab();
+
+      expect(input).toHaveValue("");
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
   it("can be disabled", () => {
     render(
       <ConstituencyAutocomplete

--- a/app/frontend/components/home/ConstituencyAutocomplete.test.tsx
+++ b/app/frontend/components/home/ConstituencyAutocomplete.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ConstituencyAutocomplete } from "@/components/home/ConstituencyAutocomplete";
+import type { Constituency } from "@/types/api";
+
+const CONSTITUENCIES: Constituency[] = [
+  { onsId: "E14001009", name: "Wakefield" },
+  { onsId: "E14000996", name: "Tiverton and Honiton" },
+];
+
+function renderAutocomplete(value = "") {
+  const onChange = vi.fn();
+  render(
+    <ConstituencyAutocomplete
+      constituencies={CONSTITUENCIES}
+      value={value}
+      onChange={onChange}
+    />,
+  );
+  return { onChange, input: screen.getByLabelText(/my constituency is/i) };
+}
+
+describe("ConstituencyAutocomplete", () => {
+  it("offers every constituency as a suggestion", () => {
+    renderAutocomplete();
+
+    const options = Array.from(document.querySelectorAll("datalist option"));
+    expect(options.map((option) => option.getAttribute("value"))).toEqual([
+      "Wakefield",
+      "Tiverton and Honiton",
+    ]);
+  });
+
+  it("reports the ONS code once a full name is typed", async () => {
+    const { input, onChange } = renderAutocomplete();
+
+    await userEvent.type(input, "Wakefield");
+
+    expect(onChange).toHaveBeenLastCalledWith("E14001009");
+  });
+
+  it("matches a name regardless of case or surrounding space", async () => {
+    const { input, onChange } = renderAutocomplete();
+
+    await userEvent.type(input, "  wakefield  ");
+
+    expect(onChange).toHaveBeenLastCalledWith("E14001009");
+  });
+
+  it("reports no selection while the name is still partial", async () => {
+    const { input, onChange } = renderAutocomplete();
+
+    await userEvent.type(input, "Wakef");
+
+    expect(onChange).toHaveBeenLastCalledWith("");
+  });
+
+  it("shows the name of an already-selected constituency", () => {
+    const { input } = renderAutocomplete("E14000996");
+
+    expect(input).toHaveValue("Tiverton and Honiton");
+  });
+
+  it("picks up a selection made elsewhere, such as by the postcode lookup", async () => {
+    function Harness() {
+      const [onsId, setOnsId] = useState("");
+      return (
+        <>
+          <ConstituencyAutocomplete
+            constituencies={CONSTITUENCIES}
+            value={onsId}
+            onChange={setOnsId}
+          />
+          <button type="button" onClick={() => setOnsId("E14001009")}>
+            Found by postcode
+          </button>
+        </>
+      );
+    }
+    render(<Harness />);
+    const input = screen.getByLabelText(/my constituency is/i);
+    expect(input).toHaveValue("");
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Found by postcode" }),
+    );
+
+    expect(input).toHaveValue("Wakefield");
+  });
+
+  it("can be disabled", () => {
+    render(
+      <ConstituencyAutocomplete
+        constituencies={CONSTITUENCIES}
+        value=""
+        onChange={vi.fn()}
+        disabled
+      />,
+    );
+
+    expect(screen.getByLabelText(/my constituency is/i)).toBeDisabled();
+  });
+});

--- a/app/frontend/components/home/ConstituencyAutocomplete.tsx
+++ b/app/frontend/components/home/ConstituencyAutocomplete.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useId, useState } from "react";
+import Form from "react-bootstrap/Form";
+import type { Constituency } from "@/types/api";
+
+interface ConstituencyAutocompleteProps {
+  constituencies: Constituency[];
+  /** The selected constituency's ONS GSS code, or "" for none. */
+  value: string;
+  onChange: (onsId: string) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Pick a constituency by typing its name.
+ *
+ * Replaces the legacy pairing of a `<select>` holding the ONS code and a
+ * jQuery autocomplete input showing the name. A native `<datalist>` does the
+ * same job with no library: the browser filters as you type, the control stays
+ * a real text input for screen readers and keyboards, and it scales from the
+ * two constituencies of a by-election to all 650 of a general election.
+ *
+ * The name is what the user sees and types; the ONS code is what leaves this
+ * component, since that is what the whole domain keys on.
+ */
+export function ConstituencyAutocomplete({
+  constituencies,
+  value,
+  onChange,
+  disabled = false,
+}: ConstituencyAutocompleteProps) {
+  const inputId = useId();
+  const listId = useId();
+
+  const selectedName =
+    constituencies.find((constituency) => constituency.onsId === value)?.name ??
+    "";
+
+  // What the user has typed, which is only the selected name once they have
+  // actually matched one. Kept in step with `value` so that a selection made
+  // elsewhere — the postcode lookup filling this in, as the legacy helper did
+  // — shows up here, without fighting the user mid-keystroke.
+  const [text, setText] = useState(selectedName);
+
+  useEffect(() => {
+    setText(selectedName);
+  }, [selectedName]);
+
+  function handleChange(typed: string) {
+    setText(typed);
+    // Only a full, exact name is a selection — a partial one means the user is
+    // still typing, and nothing is selected yet.
+    const match = constituencies.find(
+      (constituency) =>
+        constituency.name.toLowerCase() === typed.trim().toLowerCase(),
+    );
+    onChange(match?.onsId ?? "");
+  }
+
+  return (
+    <Form.Group controlId={inputId}>
+      <Form.Label>My constituency is</Form.Label>
+      <Form.Control
+        type="text"
+        list={listId}
+        value={text}
+        onChange={(event) => handleChange(event.target.value)}
+        disabled={disabled}
+        autoComplete="off"
+        placeholder="Start typing a constituency name"
+      />
+      <datalist id={listId}>
+        {constituencies.map((constituency) => (
+          <option key={constituency.onsId} value={constituency.name} />
+        ))}
+      </datalist>
+    </Form.Group>
+  );
+}

--- a/app/frontend/components/home/ConstituencyAutocomplete.tsx
+++ b/app/frontend/components/home/ConstituencyAutocomplete.tsx
@@ -45,15 +45,29 @@ export function ConstituencyAutocomplete({
     setText(selectedName);
   }, [selectedName]);
 
-  function handleChange(typed: string) {
-    setText(typed);
-    // Only a full, exact name is a selection — a partial one means the user is
-    // still typing, and nothing is selected yet.
-    const match = constituencies.find(
+  function matchFor(typed: string) {
+    return constituencies.find(
       (constituency) =>
         constituency.name.toLowerCase() === typed.trim().toLowerCase(),
     );
-    onChange(match?.onsId ?? "");
+  }
+
+  function handleChange(typed: string) {
+    setText(typed);
+    // Partial text narrows the suggestion list, but only a complete name is a
+    // selection — matching the legacy combobox, where `_source` filters on a
+    // substring while `_removeIfInvalid` requires an exact match.
+    onChange(matchFor(typed)?.onsId ?? "");
+  }
+
+  function handleBlur() {
+    // The legacy widget's `_removeIfInvalid`: text that matches no
+    // constituency is wiped on the way out, so a half-typed name can never sit
+    // in the box looking like a choice the user has made.
+    if (text !== "" && !matchFor(text)) {
+      setText("");
+      onChange("");
+    }
   }
 
   return (
@@ -64,9 +78,10 @@ export function ConstituencyAutocomplete({
         list={listId}
         value={text}
         onChange={(event) => handleChange(event.target.value)}
+        onBlur={handleBlur}
         disabled={disabled}
         autoComplete="off"
-        placeholder="Start typing a constituency name"
+        placeholder="Type to select your constituency"
       />
       <datalist id={listId}>
         {constituencies.map((constituency) => (

--- a/app/frontend/components/home/PostcodeLookup.test.tsx
+++ b/app/frontend/components/home/PostcodeLookup.test.tsx
@@ -1,0 +1,166 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PostcodeLookup } from "@/components/home/PostcodeLookup";
+import { lookupPostcode, PostcodeLookupError } from "@/lib/postcodes";
+import type { Constituency } from "@/types/api";
+
+vi.mock("@/lib/postcodes", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/postcodes")>();
+  return { ...actual, lookupPostcode: vi.fn() };
+});
+
+const CONSTITUENCIES: Constituency[] = [
+  { onsId: "E14001009", name: "Wakefield" },
+  { onsId: "E14000996", name: "Tiverton and Honiton" },
+];
+
+function renderLookup() {
+  const onConstituencyFound = vi.fn();
+  render(
+    <PostcodeLookup
+      constituencies={CONSTITUENCIES}
+      onConstituencyFound={onConstituencyFound}
+    />,
+  );
+  return {
+    onConstituencyFound,
+    input: screen.getByLabelText(/find my constituency using my postcode/i),
+    search: screen.getByRole("button", { name: "Search" }),
+  };
+}
+
+describe("PostcodeLookup", () => {
+  beforeEach(() => {
+    vi.mocked(lookupPostcode).mockResolvedValue({
+      onsId: "E14001009",
+      name: "Wakefield",
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports the constituency a postcode resolves to", async () => {
+    const { input, search, onConstituencyFound } = renderLookup();
+
+    await userEvent.type(input, "WF1 1AA");
+    await userEvent.click(search);
+
+    expect(lookupPostcode).toHaveBeenCalledWith("WF1 1AA");
+    await waitFor(() => {
+      expect(onConstituencyFound).toHaveBeenCalledWith("E14001009");
+    });
+  });
+
+  it("searches on Enter without submitting the surrounding form", async () => {
+    const onSubmit = vi.fn((event: React.FormEvent) => event.preventDefault());
+    const onConstituencyFound = vi.fn();
+    render(
+      <form onSubmit={onSubmit}>
+        <PostcodeLookup
+          constituencies={CONSTITUENCIES}
+          onConstituencyFound={onConstituencyFound}
+        />
+      </form>,
+    );
+
+    await userEvent.type(
+      screen.getByLabelText(/find my constituency/i),
+      "WF1 1AA{Enter}",
+    );
+
+    await waitFor(() => {
+      expect(onConstituencyFound).toHaveBeenCalledWith("E14001009");
+    });
+    // The user has not filled in the rest of the entry form yet.
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  describe("when the postcode is outside the constituencies we cover", () => {
+    beforeEach(() => {
+      vi.mocked(lookupPostcode).mockResolvedValue({
+        onsId: "E14000123",
+        name: "Somewhere Else",
+      });
+    });
+
+    it("says so", async () => {
+      const { input, search } = renderLookup();
+
+      await userEvent.type(input, "SW1A 1AA");
+      await userEvent.click(search);
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        "Postcode is not in one of the accepted constituencies",
+      );
+    });
+
+    it("clears the selection rather than leaving a stale one", async () => {
+      const { input, search, onConstituencyFound } = renderLookup();
+
+      await userEvent.type(input, "SW1A 1AA");
+      await userEvent.click(search);
+
+      await waitFor(() => {
+        expect(onConstituencyFound).toHaveBeenCalledWith("");
+      });
+    });
+  });
+
+  it("shows the service's own message when it rejects the postcode", async () => {
+    vi.mocked(lookupPostcode).mockRejectedValue(
+      new PostcodeLookupError("Postcode not found"),
+    );
+    const { input, search } = renderLookup();
+
+    await userEvent.type(input, "ZZ1 1ZZ");
+    await userEvent.click(search);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Postcode not found",
+    );
+  });
+
+  it("does not leak an unexpected failure to the user", async () => {
+    vi.mocked(lookupPostcode).mockRejectedValue(
+      new TypeError("Failed to fetch"),
+    );
+    const { input, search } = renderLookup();
+
+    await userEvent.type(input, "WF1 1AA");
+    await userEvent.click(search);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(
+      "Postcode lookup failed - please try again.",
+    );
+    expect(alert).not.toHaveTextContent("Failed to fetch");
+  });
+
+  it("clears a previous error once a later search succeeds", async () => {
+    vi.mocked(lookupPostcode).mockRejectedValueOnce(
+      new PostcodeLookupError("Postcode not found"),
+    );
+    const { input, search } = renderLookup();
+
+    await userEvent.type(input, "ZZ1 1ZZ");
+    await userEvent.click(search);
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+
+    await userEvent.clear(input);
+    await userEvent.type(input, "WF1 1AA");
+    await userEvent.click(search);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).toBeNull();
+    });
+  });
+
+  it("tells the user their postcode is not retained", () => {
+    renderLookup();
+
+    expect(screen.getByText(/we do not retain this info/i)).toBeVisible();
+  });
+});

--- a/app/frontend/components/home/PostcodeLookup.tsx
+++ b/app/frontend/components/home/PostcodeLookup.tsx
@@ -1,0 +1,121 @@
+import { type KeyboardEvent, useId, useState } from "react";
+import Alert from "react-bootstrap/Alert";
+import Button from "react-bootstrap/Button";
+import Form from "react-bootstrap/Form";
+import InputGroup from "react-bootstrap/InputGroup";
+import { lookupPostcode, PostcodeLookupError } from "@/lib/postcodes";
+import type { Constituency } from "@/types/api";
+
+interface PostcodeLookupProps {
+  /** The constituencies we actually run swaps in. */
+  constituencies: Constituency[];
+  /** Called with the matched ONS GSS code, or "" when the postcode resolves
+   *  to somewhere we do not cover. */
+  onConstituencyFound: (onsId: string) => void;
+}
+
+const NOT_COVERED = "Postcode is not in one of the accepted constituencies";
+
+/**
+ * Find a constituency from a postcode, as a convenience beside the
+ * constituency picker. Replaces app/javascript/packs/postcodesHelper.js.
+ *
+ * Two behaviours carried over deliberately from that helper:
+ *
+ *  - Enter runs the lookup instead of submitting the surrounding form. The
+ *    postcode field sits inside the entry form, and the user is unlikely to
+ *    have filled in the rest of it yet.
+ *  - A postcode outside our constituencies is an error *and* clears any
+ *    existing selection, rather than quietly leaving a stale one behind.
+ *
+ * The postcode is used and discarded — never sent to our own backend, and
+ * never stored. The copy below says so.
+ */
+export function PostcodeLookup({
+  constituencies,
+  onConstituencyFound,
+}: PostcodeLookupProps) {
+  const inputId = useId();
+  const [postcode, setPostcode] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [searching, setSearching] = useState(false);
+
+  async function handleSearch() {
+    setSearching(true);
+    setError(null);
+    try {
+      const { onsId } = await lookupPostcode(postcode);
+      const covered = constituencies.some(
+        (constituency) => constituency.onsId === onsId,
+      );
+      if (covered) {
+        onConstituencyFound(onsId);
+      } else {
+        setError(NOT_COVERED);
+        onConstituencyFound("");
+      }
+    } catch (caught) {
+      setError(
+        caught instanceof PostcodeLookupError
+          ? caught.message
+          : "Postcode lookup failed - please try again.",
+      );
+      onConstituencyFound("");
+    }
+    setSearching(false);
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Enter") {
+      // Search, don't submit the form around us.
+      event.preventDefault();
+      void handleSearch();
+    }
+  }
+
+  return (
+    <div>
+      <Form.Label htmlFor={inputId} className="mb-0">
+        Or find my constituency using my postcode
+      </Form.Label>
+
+      <InputGroup>
+        <Form.Control
+          id={inputId}
+          type="text"
+          value={postcode}
+          minLength={5}
+          maxLength={9}
+          spellCheck={false}
+          autoComplete="postal-code"
+          onChange={(event) => setPostcode(event.target.value)}
+          onKeyDown={handleKeyDown}
+          aria-describedby={error ? `${inputId}-error` : undefined}
+        />
+        <Button
+          variant="secondary"
+          onClick={() => void handleSearch()}
+          disabled={searching}
+        >
+          Search
+        </Button>
+      </InputGroup>
+
+      {error && (
+        <Alert
+          variant="danger"
+          className="small mt-2"
+          id={`${inputId}-error`}
+          role="alert"
+        >
+          {error}
+        </Alert>
+      )}
+
+      <p className="small text-muted mt-2">
+        Enter your postcode only to find your constituency; we do not retain
+        this info.
+      </p>
+    </div>
+  );
+}

--- a/app/frontend/lib/postcodes.test.ts
+++ b/app/frontend/lib/postcodes.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { lookupPostcode, PostcodeLookupError } from "@/lib/postcodes";
+
+function found(onsId: string | null, name: string | null) {
+  return new Response(
+    JSON.stringify({
+      result: {
+        parliamentary_constituency_2024: name,
+        codes: { parliamentary_constituency_2024: onsId },
+      },
+    }),
+    { status: 200 },
+  );
+}
+
+async function rejection(
+  promise: Promise<unknown>,
+): Promise<PostcodeLookupError> {
+  const error = await promise.catch((e: unknown) => e);
+  expect(error).toBeInstanceOf(PostcodeLookupError);
+  return error as PostcodeLookupError;
+}
+
+describe("lookupPostcode", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn(async () => found("E14001009", "Wakefield"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the 2024-boundary constituency and its ONS code", async () => {
+    await expect(lookupPostcode("WF1 1AA")).resolves.toEqual({
+      onsId: "E14001009",
+      name: "Wakefield",
+    });
+  });
+
+  it("calls postcodes.io directly, not our own backend", async () => {
+    await lookupPostcode("WF1 1AA");
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.postcodes.io/postcodes/WF1%201AA",
+    );
+  });
+
+  it("trims the postcode before looking it up", async () => {
+    await lookupPostcode("  WF11AA  ");
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.postcodes.io/postcodes/WF11AA",
+    );
+  });
+
+  it("escapes the postcode rather than pasting it into the URL", async () => {
+    await lookupPostcode("WF1/1AA");
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.postcodes.io/postcodes/WF1%2F1AA",
+    );
+  });
+
+  it("rejects an empty postcode without calling the service", async () => {
+    const error = await rejection(lookupPostcode("   "));
+
+    expect(error.message).toBe("Please enter a postcode");
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  describe("when the service rejects the postcode", () => {
+    it("surfaces its own wording for a 404", async () => {
+      vi.mocked(global.fetch).mockImplementation(
+        async () =>
+          new Response(JSON.stringify({ error: "Postcode not found" }), {
+            status: 404,
+          }),
+      );
+
+      const error = await rejection(lookupPostcode("ZZ1 1ZZ"));
+
+      expect(error.message).toBe("Postcode not found");
+    });
+
+    it("surfaces its own wording for a 400", async () => {
+      vi.mocked(global.fetch).mockImplementation(
+        async () =>
+          new Response(JSON.stringify({ error: "Invalid postcode" }), {
+            status: 400,
+          }),
+      );
+
+      const error = await rejection(lookupPostcode("nonsense"));
+
+      expect(error.message).toBe("Invalid postcode");
+    });
+  });
+
+  it("reports any other status as a service error, with the body", async () => {
+    vi.mocked(global.fetch).mockImplementation(
+      async () => new Response("upstream exploded", { status: 500 }),
+    );
+
+    const error = await rejection(lookupPostcode("WF1 1AA"));
+
+    // Distinguishes a postcodes.io outage from the user mistyping.
+    expect(error.message).toBe(
+      "Postcode Service Error Details: upstream exploded",
+    );
+  });
+
+  it("falls back to the raw body when an error response is not JSON", async () => {
+    vi.mocked(global.fetch).mockImplementation(
+      async () => new Response("<html>Bad Request</html>", { status: 400 }),
+    );
+
+    const error = await rejection(lookupPostcode("WF1 1AA"));
+
+    expect(error.message).toBe("<html>Bad Request</html>");
+  });
+
+  it("treats a postcode with no 2024 constituency as out of scope", async () => {
+    vi.mocked(global.fetch).mockImplementation(async () => found(null, null));
+
+    const error = await rejection(lookupPostcode("BT1 1AA"));
+
+    expect(error.message).toBe(
+      "Postcode is not in one of the accepted constituencies",
+    );
+  });
+});

--- a/app/frontend/lib/postcodes.ts
+++ b/app/frontend/lib/postcodes.ts
@@ -1,0 +1,85 @@
+// Postcode -> constituency lookup against postcodes.io, the free public API
+// the legacy jQuery helper (app/javascript/packs/postcodesHelper.js) already
+// used. Deliberately NOT routed through our own backend, and deliberately not
+// shared with tacticalvote's /api/lookup: see "Code sharing with tacticalvote"
+// in docs/frontend-modernization-plan.md.
+
+const POSTCODES_ENDPOINT = "https://api.postcodes.io/postcodes";
+
+/** The 2024 boundaries are the ones the whole domain keys on. */
+interface PostcodesIoResult {
+  parliamentary_constituency_2024: string | null;
+  codes: {
+    parliamentary_constituency_2024: string | null;
+  };
+}
+
+interface PostcodesIoResponse {
+  result: PostcodesIoResult;
+}
+
+interface PostcodesIoError {
+  error?: string;
+}
+
+export interface PostcodeConstituency {
+  onsId: string;
+  name: string;
+}
+
+/**
+ * A lookup that failed in a way the user needs to see. `message` is already
+ * user-facing — for 400/404 it is postcodes.io's own wording ("Invalid
+ * postcode", "Postcode not found"), which is what the legacy helper showed.
+ */
+export class PostcodeLookupError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PostcodeLookupError";
+  }
+}
+
+/**
+ * Look a postcode up. Mirrors the legacy helper's error handling exactly:
+ * 400 and 404 surface the service's own `error` string, anything else is
+ * reported as a service error with the raw body, so a postcodes.io outage is
+ * distinguishable from a typo.
+ */
+export async function lookupPostcode(
+  postcode: string,
+): Promise<PostcodeConstituency> {
+  const trimmed = postcode.trim();
+  if (trimmed === "") {
+    throw new PostcodeLookupError("Please enter a postcode");
+  }
+
+  const response = await fetch(
+    `${POSTCODES_ENDPOINT}/${encodeURIComponent(trimmed)}`,
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    if (response.status === 400 || response.status === 404) {
+      let message = body;
+      try {
+        message = (JSON.parse(body) as PostcodesIoError).error ?? body;
+      } catch {
+        // Not JSON — fall back to the raw body, as the legacy helper did.
+      }
+      throw new PostcodeLookupError(message);
+    }
+    throw new PostcodeLookupError(`Postcode Service Error Details: ${body}`);
+  }
+
+  const { result } = (await response.json()) as PostcodesIoResponse;
+  const onsId = result?.codes?.parliamentary_constituency_2024;
+  const name = result?.parliamentary_constituency_2024;
+
+  if (!onsId || !name) {
+    throw new PostcodeLookupError(
+      "Postcode is not in one of the accepted constituencies",
+    );
+  }
+
+  return { onsId, name };
+}

--- a/app/frontend/lib/referenceData.test.tsx
+++ b/app/frontend/lib/referenceData.test.tsx
@@ -1,0 +1,55 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { apiClient } from "@/lib/apiClient";
+import {
+  useConstituencies,
+  useElection,
+  useParties,
+} from "@/lib/referenceData";
+
+vi.mock("@/lib/apiClient", () => ({ apiClient: { get: vi.fn() } }));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("reference data hooks", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ["useParties", useParties, "/parties"],
+    ["useConstituencies", useConstituencies, "/constituencies"],
+    ["useElection", useElection, "/election"],
+  ])("%s reads %s", async (_name, useHook, path) => {
+    vi.mocked(apiClient.get).mockResolvedValue([]);
+
+    const { result } = renderHook(() => useHook(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(apiClient.get).toHaveBeenCalledWith(path);
+  });
+
+  it("never goes stale — none of this changes while the page is open", async () => {
+    vi.mocked(apiClient.get).mockResolvedValue([]);
+
+    const { result } = renderHook(() => useParties(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    // The session polls; reference data must not, or every open tab would
+    // re-request the party list on a timer for data that changes at seed time.
+    expect(result.current.isStale).toBe(false);
+  });
+});

--- a/app/frontend/lib/referenceData.ts
+++ b/app/frontend/lib/referenceData.ts
@@ -1,0 +1,36 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { apiClient } from "@/lib/apiClient";
+import type { Constituency, Election, Party } from "@/types/api";
+
+// Reference data for the entry form. Unlike the session, none of this changes
+// while someone is on the page: parties and constituencies change only when we
+// re-seed, and the election is fixed for the life of the deploy. So these
+// opt out of the refetching the query client defaults to.
+const NEVER_STALE = {
+  staleTime: Number.POSITIVE_INFINITY,
+  refetchOnWindowFocus: false,
+} as const;
+
+export function useParties(): UseQueryResult<Party[]> {
+  return useQuery({
+    queryKey: ["parties"],
+    queryFn: () => apiClient.get<Party[]>("/parties"),
+    ...NEVER_STALE,
+  });
+}
+
+export function useConstituencies(): UseQueryResult<Constituency[]> {
+  return useQuery({
+    queryKey: ["constituencies"],
+    queryFn: () => apiClient.get<Constituency[]>("/constituencies"),
+    ...NEVER_STALE,
+  });
+}
+
+export function useElection(): UseQueryResult<Election> {
+  return useQuery({
+    queryKey: ["election"],
+    queryFn: () => apiClient.get<Election>("/election"),
+    ...NEVER_STALE,
+  });
+}

--- a/app/frontend/types/api.ts
+++ b/app/frontend/types/api.ts
@@ -69,6 +69,53 @@ export interface SessionPayload {
   swap: SwapSummary | null;
 }
 
+/** A constituency the site runs swaps in. `onsId` is the ONS GSS code. */
+export interface Constituency {
+  onsId: string;
+  name: string;
+}
+
+/**
+ * `GET /api/v1/election` — the election being run for, and the prose the
+ * headings are built from. Derived server-side from env vars and the
+ * constituency count (see Api::V1::ElectionPresenter), and immutable for the
+ * life of a deploy.
+ */
+export interface Election {
+  generalElection: boolean;
+  /** True when there are so few constituencies that poll numbers give the
+   *  answer away. */
+  hidePolls: boolean;
+  year: string;
+  /** ISO 8601, e.g. "2024-07-04". */
+  date: string;
+  season: "winter" | "spring" | "summer" | "autumn";
+  /** "July 4th" */
+  dateMd: string;
+  /** "4th July" */
+  dateDm: string;
+  /** "June 2022 by-elections" */
+  dateAndTypeMy: string;
+  /** "June 23rd 2022 by-elections" */
+  dateAndTypeMdy: string;
+  /** "2022 summer by-elections" */
+  dateSeasonType: string;
+  /** "General Election 2024" */
+  eventTitleWithYear: string;
+  /** "Wakefield or Tiverton & Honiton by-elections" */
+  eventChoice: string;
+  /** "#GeneralElection" */
+  hashtags: string;
+  /** "another constituency" / "the other constituency" */
+  constituencyOther: string;
+  /** "Wakefield and Tiverton & Honiton" */
+  constituenciesAsSentence: string;
+  donate: {
+    link: string;
+    show: boolean;
+  };
+}
+
 /** Every non-2xx response body from /api/v1. */
 export interface ApiErrorBody {
   error: {

--- a/app/presenters/api/v1/election_presenter.rb
+++ b/app/presenters/api/v1/election_presenter.rb
@@ -1,0 +1,55 @@
+module Api
+  module V1
+    # The election the site is currently running for, as the SPA needs to talk
+    # about it: "the 2024 general election", "Wakefield & Tiverton and Honiton
+    # by-elections", "another constituency".
+    #
+    # Every value is derived in Ruby by ApplicationHelper, from ENV
+    # (ELECTION_DATE, ELECTION_TYPE, ELECTION_INSTITUTION) and from how many
+    # OnsConstituency rows exist. Re-deriving that in TypeScript would fork the
+    # source of truth and drift the moment either input changed, so the strings
+    # are computed server-side and sent whole.
+    #
+    # Unlike the session payload, this is immutable for the life of a deploy —
+    # the SPA fetches it once and caches it indefinitely.
+    class ElectionPresenter
+      # Exposed name => the ApplicationHelper method behind it. Predicates are
+      # renamed because `?` has no place in a JSON key.
+      ATTRIBUTES = {
+        general_election: :general_election?,
+        hide_polls: :hide_polls?,
+        year: :election_year,
+        date: :election_date,
+        season: :election_season,
+        date_md: :election_date_md,
+        date_dm: :election_date_dm,
+        date_and_type_my: :election_date_and_type_my,
+        date_and_type_mdy: :election_date_and_type_mdy,
+        date_season_type: :election_date_season_type,
+        event_title_with_year: :election_event_title_with_year,
+        event_choice: :election_event_choice,
+        hashtags: :election_hashtags,
+        constituency_other: :election_constituency_other,
+        constituencies_as_sentence: :by_election_constituencies_as_sentence
+      }.freeze
+
+      # @param context [Object] anything including ApplicationHelper — in
+      #   practice the controller, since several of these read `session`.
+      def initialize(context)
+        @context = context
+      end
+
+      ATTRIBUTES.each do |exposed, helper_method|
+        define_method(exposed) { @context.public_send(helper_method) }
+      end
+
+      def donate_link
+        @context.donate_info[:link]
+      end
+
+      def donate_show
+        @context.donate_info[:show]
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/constituency_serializer.rb
+++ b/app/serializers/api/v1/constituency_serializer.rb
@@ -1,0 +1,14 @@
+module Api
+  module V1
+    # A constituency the site runs swaps in. `onsId` is the ONS GSS code — the
+    # same code postcodes.io returns as `parliamentary_constituency_2024`, and
+    # the key the whole domain joins on.
+    class ConstituencySerializer
+      include Alba::Resource
+
+      transform_keys :lower_camel
+
+      attributes :ons_id, :name
+    end
+  end
+end

--- a/app/serializers/api/v1/election_serializer.rb
+++ b/app/serializers/api/v1/election_serializer.rb
@@ -1,0 +1,31 @@
+module Api
+  module V1
+    # See ElectionPresenter. Shape mirrored in app/frontend/types/api.ts.
+    class ElectionSerializer
+      include Alba::Resource
+
+      transform_keys :lower_camel
+
+      attributes :general_election, :hide_polls, :year, :season, :date_md,
+                 :date_dm, :date_and_type_my, :date_and_type_mdy,
+                 :date_season_type, :event_title_with_year, :event_choice,
+                 :hashtags, :constituency_other, :constituencies_as_sentence
+
+      # ISO 8601, so the client can format or compare it without parsing prose.
+      attribute :date do |election|
+        election.date.iso8601
+      end
+
+      # The crowdfunder call to action, shown only when DONATE_SHOW says so.
+      nested :donate do
+        attribute :link do |election|
+          election.donate_link
+        end
+
+        attribute :show do |election|
+          election.donate_show
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,11 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resource :session, only: [:show, :destroy], controller: "session"
+
+      # Reference data for the entry form: unauthenticated, ungated, cacheable.
+      resources :parties, only: [:index]
+      resources :constituencies, only: [:index]
+      resource :election, only: [:show], controller: "election"
     end
   end
 

--- a/spec/requests/api/v1/reference_data_spec.rb
+++ b/spec/requests/api/v1/reference_data_spec.rb
@@ -3,6 +3,18 @@ require "rails_helper"
 # Reference data for the entry form: parties, constituencies, and the election
 # prose the SPA builds its headings from.
 RSpec.describe "Api::V1 reference data", type: :request do
+  # These endpoints return *every* party and constituency, and the election
+  # payload is derived from how many constituencies exist — so each example has
+  # to own the whole table, not just the rows it adds. Other specs in the suite
+  # leave parties and constituencies behind (CI loads the schema and seeds
+  # nothing, yet these tables arrive populated), and RSpec's random ordering
+  # means that only bites sometimes. Clearing inside the example's transaction
+  # is rolled back afterwards, so nothing leaks back out.
+  before do
+    OnsConstituency.delete_all
+    Party.delete_all
+  end
+
   def json
     JSON.parse(response.body)
   end

--- a/spec/requests/api/v1/reference_data_spec.rb
+++ b/spec/requests/api/v1/reference_data_spec.rb
@@ -1,0 +1,131 @@
+require "rails_helper"
+
+# Reference data for the entry form: parties, constituencies, and the election
+# prose the SPA builds its headings from.
+RSpec.describe "Api::V1 reference data", type: :request do
+  def json
+    JSON.parse(response.body)
+  end
+
+  describe "GET /api/v1/parties" do
+    it "returns every party, alphabetically, in the shape types/api.ts expects" do
+      create(:party, name: "Zebra", color: "#000000")
+      create(:party, name: "Aardvark", color: "#ffffff")
+
+      get "/api/v1/parties"
+
+      expect(response).to have_http_status(:ok)
+      expect(json.map { |party| party["name"] }).to eq %w[Aardvark Zebra]
+      expect(json.first.keys).to match_array(%w[id name color smvCode])
+    end
+
+    it "is available logged out — the entry form comes before sign up" do
+      get "/api/v1/parties"
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns an empty list rather than an error when nothing is seeded" do
+      get "/api/v1/parties"
+
+      expect(response).to have_http_status(:ok)
+      expect(json).to eq []
+    end
+  end
+
+  describe "GET /api/v1/constituencies" do
+    it "returns every constituency, alphabetically, keyed on the ONS GSS code" do
+      create(:ons_constituency, name: "Woking")
+      create(:tiverton)
+
+      get "/api/v1/constituencies"
+
+      expect(response).to have_http_status(:ok)
+      expect(json.map { |c| c["name"] }).to eq ["Tiverton and Honiton", "Woking"]
+      expect(json.first).to eq(
+        "onsId" => "E14000996",
+        "name" => "Tiverton and Honiton"
+      )
+    end
+
+    it "is available logged out" do
+      get "/api/v1/constituencies"
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /api/v1/election" do
+    def stub_env(values)
+      allow(ENV).to receive(:[]).and_call_original
+      values.each do |key, value|
+        allow(ENV).to receive(:[]).with(key).and_return(value)
+      end
+    end
+
+    it "describes a general election in the prose the headings need" do
+      stub_env("ELECTION_DATE" => "2024-07-04", "ELECTION_TYPE" => "general")
+
+      get "/api/v1/election"
+
+      expect(response).to have_http_status(:ok)
+      expect(json).to include(
+        "generalElection" => true,
+        "year" => "2024",
+        "date" => "2024-07-04",
+        "season" => "summer",
+        "dateMd" => "July 4th",
+        "dateSeasonType" => "2024 general election",
+        "eventTitleWithYear" => "General Election 2024",
+        "hashtags" => "#GeneralElection"
+      )
+    end
+
+    it "describes by-elections by naming the constituencies involved" do
+      create(:wakefield)
+      create(:tiverton)
+      stub_env("ELECTION_DATE" => "2022-06-23", "ELECTION_TYPE" => "by")
+
+      get "/api/v1/election"
+
+      expect(json).to include(
+        "generalElection" => false,
+        "dateSeasonType" => "2022 summer by-elections",
+        # The ampersand substitution applies inside a name ("Tiverton and
+        # Honiton" -> "Tiverton & Honiton"); the list itself still joins
+        # with "and".
+        "constituenciesAsSentence" => "Wakefield and Tiverton & Honiton"
+      )
+      # Two constituencies means "the other constituency" reads correctly;
+      # with more it has to become "another".
+      expect(json["constituencyOther"]).to eq "the other constituency"
+    end
+
+    it "hides poll numbers when there are only two constituencies to swap between" do
+      create(:wakefield)
+      create(:tiverton)
+
+      get "/api/v1/election"
+
+      expect(json["hidePolls"]).to be true
+    end
+
+    it "carries the donate call to action, off by default" do
+      get "/api/v1/election"
+
+      expect(json["donate"]).to include("show" => false)
+      expect(json["donate"]["link"]).to be_present
+    end
+
+    it "turns the donate call to action on when DONATE_SHOW says so" do
+      stub_env("DONATE_SHOW" => "yes", "DONATE_LINK" => "https://example.com/give")
+
+      get "/api/v1/election"
+
+      expect(json["donate"]).to eq(
+        "link" => "https://example.com/give",
+        "show" => true
+      )
+    end
+  end
+end


### PR DESCRIPTION
First of two PRs for M3 (home / landing). This one lands the reference data the home page renders from, plus the two controls that replace the jQuery postcode helper. **No screens yet, and nothing is routed to React** — the two-step entry wizard and the five phase screens follow in part 2.

## API

All unauthenticated and ungated, on the `Api::V1::BaseController` M2 established — the entry form comes before sign up.

| endpoint | returns |
| --- | --- |
| `GET /api/v1/parties` | every party, alphabetically |
| `GET /api/v1/constituencies` | every constituency, keyed on the ONS GSS code |
| `GET /api/v1/election` | the election, and the prose built from it |

### Why an election endpoint

The plan didn't anticipate this one, so it's worth flagging. The home page's headings are assembled from about a dozen `ApplicationHelper` strings — `election_date_season_type`, `general_election?`, `election_constituency_other`, `hide_polls?`, `by_election_constituencies_as_sentence` — each derived from `ELECTION_DATE` / `ELECTION_TYPE` env vars and from how many `OnsConstituency` rows exist.

Reimplementing that date/season logic in TypeScript would fork the source of truth and drift the moment either input changed, so Ruby computes the strings and the API sends them whole.

It's a separate endpoint rather than part of the session payload because the two have opposite lifetimes: the session is re-fetched on a 60s poll, while the election is fixed for the life of a deploy. `lib/referenceData.ts` fetches it once and caches it indefinitely.

## Frontend

- `lib/postcodes.ts` — postcodes.io lookup, replacing `app/javascript/packs/postcodesHelper.js`. Still calling postcodes.io directly rather than tacticalvote's `/api/lookup`, per "Code sharing with tacticalvote" in the plan.
- `PostcodeLookup` — the field, its Search button and its error.
- `ConstituencyAutocomplete` — name in, ONS code out, via a native `<datalist>` rather than a library.

Behaviours carried over from the jQuery helper that would be easy to lose, each with a test:

- **Enter searches, it does not submit.** The postcode field sits inside the entry form and the user usually hasn't filled in the rest of it.
- **A postcode outside our constituencies is an error *and* clears the selection**, rather than leaving a stale one behind.
- **400/404 show postcodes.io's own wording** ("Postcode not found"); any other status is reported as a service error with the body, so an outage stays distinguishable from a typo.
- The autocomplete syncs when the postcode lookup fills it in — the legacy helper set that input directly.

The postcode is used and discarded: never sent to our backend, never stored. The copy under the field still says so.

## Note on the legacy pack

`postcodesHelper.js` and its HAML callers are untouched and still serving `/`. Deletion waits for cutover, per the plan.

## Checks

- `yarn lint`, `yarn typecheck` clean; `yarn test` 124 passing (20 files), 26 of them new here.
- `bundle exec rspec` 427 examples, 16 failures — the same 16 that fail on `master` (legacy HAML view specs dying on a missing Webpacker manifest, plus the mailer/snapshot ones). All 26 new request specs pass.
- `rubocop` clean on the new Ruby.
