### PR TITLE
Add yarn deploy scripts for the Heroku Git staging/production apps

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,6 +7,7 @@
       "app/frontend/**",
       "playwright-tests/**",
       "playwright.config.ts",
+      "scripts/**",
       "vite.config.mts",
       "vitest.config.mts",
       "!**/node_modules",

--- a/config/initializers/webpacker.rb
+++ b/config/initializers/webpacker.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# The legacy packs in app/javascript/packs are still built by webpack 4, which
+# hashes with md4 in several hardcoded places. OpenSSL 3 (bundled with Node >=
+# 17) dropped md4, so `rake assets:precompile` dies with
+# "error:0308010C:digital envelope routines::unsupported" on any modern Node,
+# including the one Heroku's nodejs buildpack installs. Setting
+# output.hashFunction is not enough, because the plugins bypass it, so the node
+# process needs the legacy provider switched back on.
+#
+# Scoped to the webpack subprocess, so the Vite build and the Rails server do
+# not inherit it. Delete this file once the packs are ported to React and the
+# webpacker gem is dropped.
+if defined?(Webpacker::Compiler)
+  node_options = ENV.fetch("NODE_OPTIONS", "")
+
+  unless node_options.include?("--openssl-legacy-provider")
+    Webpacker::Compiler.env["NODE_OPTIONS"] =
+      "#{node_options} --openssl-legacy-provider".strip
+  end
+end

--- a/package.json
+++ b/package.json
@@ -26,12 +26,14 @@
   "homepage": "https://github.com/swapmyvote/swapmyvote#readme",
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "lint": "biome check app/frontend playwright-tests playwright.config.ts",
-    "lint:fix": "biome check --write app/frontend playwright-tests playwright.config.ts",
-    "format": "biome format --write app/frontend playwright-tests playwright.config.ts",
+    "lint": "biome check app/frontend playwright-tests playwright.config.ts scripts",
+    "lint:fix": "biome check --write app/frontend playwright-tests playwright.config.ts scripts",
+    "format": "biome format --write app/frontend playwright-tests playwright.config.ts scripts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "e2e": "playwright test"
+    "e2e": "playwright test",
+    "deploy:staging": "node scripts/heroku-deploy.mjs staging",
+    "deploy:production": "node scripts/heroku-deploy.mjs production"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",

--- a/scripts/heroku-deploy.mjs
+++ b/scripts/heroku-deploy.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+//
+// Deploy the current checkout to a Heroku app via "Deploy using Heroku Git".
+//
+//   node scripts/heroku-deploy.mjs staging      -> swapmyvotedev
+//   node scripts/heroku-deploy.mjs production   -> swapmyvote
+//
+// Usually invoked through yarn: `corepack yarn deploy:staging` / `deploy:production`.
+//
+// Heroku builds whatever lands on its `master` branch, so we push the current
+// HEAD there. Staging is force-pushed, because a feature branch is normally not
+// a descendant of whatever was deployed last. Production refuses anything but a
+// clean local `master` that matches origin/master, and asks for confirmation.
+
+import { spawnSync } from "node:child_process";
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+
+const targets = {
+  staging: { app: "swapmyvotedev", force: true },
+  production: { app: "swapmyvote", force: false },
+};
+
+function run(command, args, options = {}) {
+  return spawnSync(command, args, { encoding: "utf8", ...options });
+}
+
+function capture(command, args) {
+  const result = run(command, args);
+  if (result.status !== 0) {
+    fail(`\`${command} ${args.join(" ")}\` failed:\n${result.stderr?.trim()}`);
+  }
+  return result.stdout.trim();
+}
+
+function fail(message, code = 1) {
+  console.error(message);
+  process.exit(code);
+}
+
+async function confirm(question) {
+  const rl = createInterface({ input: stdin, output: stdout });
+  try {
+    return (await rl.question(question)).trim();
+  } finally {
+    rl.close();
+  }
+}
+
+const target = process.argv[2];
+const config = targets[target];
+
+if (!config) {
+  fail("usage: node scripts/heroku-deploy.mjs {staging|production}", 64);
+}
+
+if (run("heroku", ["--version"]).status !== 0) {
+  fail(
+    "The Heroku CLI is not installed (brew install heroku/brew/heroku).",
+    69,
+  );
+}
+
+if (run("heroku", ["auth:whoami"]).status !== 0) {
+  fail("Not logged in to Heroku. Run: heroku login", 77);
+}
+
+if (capture("git", ["status", "--porcelain"]) !== "") {
+  fail(
+    "Working tree is dirty. Heroku deploys the committed HEAD, not your " +
+      "uncommitted changes. Commit or stash them first.",
+  );
+}
+
+const branch = capture("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+const sha = capture("git", ["rev-parse", "--short", "HEAD"]);
+
+if (target === "production") {
+  if (branch !== "master") {
+    fail(
+      `Refusing to deploy '${branch}' to production; check out master first.`,
+    );
+  }
+
+  capture("git", ["fetch", "origin", "master", "--quiet"]);
+  if (
+    capture("git", ["rev-parse", "HEAD"]) !==
+    capture("git", ["rev-parse", "origin/master"])
+  ) {
+    fail("Local master is not identical to origin/master. Pull/push first.");
+  }
+
+  console.log(`About to deploy master (${sha}) to PRODUCTION (${config.app}).`);
+  if ((await confirm("Type the app name to confirm: ")) !== config.app) {
+    fail("Aborted.");
+  }
+}
+
+console.log(`Deploying ${branch} (${sha}) to ${config.app} ...`);
+
+const push = run(
+  "git",
+  [
+    "push",
+    ...(config.force ? ["--force"] : []),
+    `https://git.heroku.com/${config.app}.git`,
+    "HEAD:refs/heads/master",
+  ],
+  { stdio: "inherit", encoding: undefined },
+);
+
+if (push.status !== 0) {
+  fail(`\nDeploy to ${config.app} failed.`, push.status ?? 1);
+}
+
+run("heroku", ["releases", "-a", config.app, "-n", "1"], {
+  stdio: "inherit",
+  encoding: undefined,
+});
+console.log(`\nLogs:  heroku logs -a ${config.app} --tail`);
+console.log(`Open:  heroku open -a ${config.app}`);


### PR DESCRIPTION
## What

Adds `yarn deploy:staging` and `yarn deploy:production`, wrapping the "Deploy using Heroku Git" push in [`scripts/heroku-deploy.mjs`](scripts/heroku-deploy.mjs):

```bash
corepack yarn deploy:staging     # -> swapmyvotedev
corepack yarn deploy:production  # -> swapmyvote
```

Also fixes an asset-precompile failure that blocked deploying at all (see below), and pulls `scripts/` into Biome's scope.

## Why

Getting the frontend modernization onto staging for review meant a hand-rolled `git push https://git.heroku.com/swapmyvotedev.git HEAD:refs/heads/master` each time — undocumented, easy to point at the wrong app, and easy to get the refspec wrong.

## Guardrails

Heroku builds whatever lands on its `master` branch, so the script pushes the current `HEAD` there.

- **Staging** force-pushes, because a feature branch is normally not a descendant of the last staging deploy.
- **Production** refuses anything but a clean local `master` that is identical to `origin/master`, then asks you to type the app name to confirm. No force push.
- Both refuse a dirty working tree (Heroku deploys the committed `HEAD`, not your uncommitted changes), and check that the Heroku CLI is installed and logged in before doing anything.

## The precompile fix

The first staging deploy was rejected in `assets:precompile`:

```
Error: error:0308010C:digital envelope routines::unsupported
```

The legacy packs in `app/javascript/packs` are still built by webpack 4, which hashes with md4. OpenSSL 3 (Node >= 17 — the buildpack installs Node 24) removed md4. `app.json` documents `NODE_OPTIONS=--openssl-legacy-provider` as the workaround, but only declares it for **review** apps; `swapmyvotedev` had no such config var.

Setting `output.hashFunction` is not sufficient — webpack 4 hardcodes `createHash("md4")` in `SplitChunksPlugin`, `ConcatenatedModule`, `NamedModulesPlugin` and `SourceMapDevToolPlugin`, bypassing that option. The node process needs the legacy provider re-enabled.

Rather than set a config var per app, [`config/initializers/webpacker.rb`](config/initializers/webpacker.rb) passes the flag through `Webpacker::Compiler.env`, which Webpacker merges into the environment of the webpack subprocess it shells out to. That means:

- staging, production and review apps all get it, with no manual Heroku config;
- it is scoped to the webpack subprocess, so the Vite build and the Rails server do not inherit it;
- it is one self-documenting file to delete once the packs are ported to React and the `webpacker` gem is dropped.

## Verification

Deployed this branch to staging — https://swapmyvotedev.herokuapp.com, release v259 (the previous deploy was v257, from Oct 2024).

- `/`, `/faq` still 200 from HAML — no route flipped, coexistence intact.
- `/app/about`, `/app/ping`, `/app/terms`, `/app/cookies` render the React SPA, with no console errors.
- Client-side routing confirmed: clicking the footer "Terms of Use" link on `/app/about` swapped the content and the URL to `/app/terms` while `performance.getEntriesByType('navigation')` still had exactly one entry, still named `/app/about` — no document reload.
- `/api/v1/session` returns staging's real state: `{"appMode":"closed-wind-down","flags":{...},"currentUser":null,"swap":null}`.
- `/app/nonexistent` returns 404, so `SpaController` is serving only the explicit allow-list, not a catch-all.

`yarn lint`, `yarn typecheck` and `rubocop` are clean.

## Notes for reviewers

- Staging runs `DISABLE_LOG_INS=all`, so auth-dependent screens can't be exercised there until that is flipped.
- Heroku warns that the Heroku-22 stack is EOL in April 2027 — out of scope here, but worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)