### PR TITLE
Move log out into a user menu, and stop the nav name rendering bold

### DIFF
--- a/app/frontend/components/navigation/Navigation.module.scss
+++ b/app/frontend/components/navigation/Navigation.module.scss
@@ -1,0 +1,16 @@
+// The logged-in user's name is body text, not a heading.
+//
+// `$btn-font-family` puts every button on the Rubik stack, and this project
+// ships a single Rubik face — Bold. CSS font matching resolves a request the
+// family cannot satisfy to the nearest face *within that family*, so asking
+// for weight 400 still renders Rubik Bold; family fallback only happens when
+// the family has no faces at all. A `fw-normal` utility alone therefore looks
+// like it does nothing. Naming the body family is what actually gets a
+// regular face.
+// Qualified with the element on purpose: Bootstrap's own `.btn` sets
+// font-family at the same specificity and is loaded after this module, so a
+// bare `.userMenuToggle` loses on source order. (`fw-normal` has no such
+// problem — Bootstrap's utilities carry !important.)
+button.userMenuToggle {
+  font-family: var(--bs-body-font-family);
+}

--- a/app/frontend/components/navigation/Navigation.test.tsx
+++ b/app/frontend/components/navigation/Navigation.test.tsx
@@ -27,6 +27,13 @@ function loggedInAs(user = testUser) {
   return { session: sessionPayload({ currentUser: user }) };
 }
 
+// Everything a logged-in user can do lives behind the avatar menu, so the
+// tests have to open it first — that it is closed until then is itself
+// asserted below.
+async function openUserMenu(name: RegExp = /ada lovelace/i) {
+  await userEvent.click(screen.getByRole("button", { name }));
+}
+
 describe("Navigation", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -83,11 +90,22 @@ describe("Navigation", () => {
   });
 
   describe("when logged in", () => {
-    it("shows the user's name, linking to the (legacy) profile page", () => {
+    it("labels the menu with the user's name", () => {
       renderNav(loggedInAs());
 
-      const profile = screen.getByRole("link", { name: /ada lovelace/i });
-      expect(profile).toHaveAttribute("href", "/user/edit");
+      expect(
+        screen.getByRole("button", { name: /ada lovelace/i }),
+      ).toBeVisible();
+    });
+
+    it("links to the (legacy) profile page from the menu", async () => {
+      renderNav(loggedInAs());
+
+      await openUserMenu();
+
+      expect(
+        screen.getByRole("link", { name: /edit profile/i }),
+      ).toHaveAttribute("href", "/user/edit");
     });
 
     it("shows the user's avatar", () => {
@@ -102,11 +120,21 @@ describe("Navigation", () => {
       expect(avatar.alt).toBe("");
     });
 
-    it("offers log out instead of log in", () => {
+    it("offers log out instead of log in", async () => {
       renderNav(loggedInAs());
+
+      await openUserMenu();
 
       expect(screen.getByRole("button", { name: /log out/i })).toBeVisible();
       expect(screen.queryByRole("link", { name: /log in/i })).toBeNull();
+    });
+
+    // Log out used to sit in the bar next to the name, one stray click from
+    // the logo. It is only reachable through the menu now.
+    it("keeps log out out of the bar until the menu is opened", () => {
+      renderNav(loggedInAs());
+
+      expect(screen.queryByRole("button", { name: /log out/i })).toBeNull();
     });
 
     it("logs out through the API, then leaves the SPA for the legacy home", async () => {
@@ -121,6 +149,7 @@ describe("Navigation", () => {
 
       renderNav({ ...loggedInAs(), logOut });
 
+      await openUserMenu();
       await userEvent.click(screen.getByRole("button", { name: /log out/i }));
 
       expect(logOut).toHaveBeenCalledOnce();
@@ -137,6 +166,7 @@ describe("Navigation", () => {
 
       renderNav({ ...loggedInAs(), logOut });
 
+      await openUserMenu();
       await userEvent.click(screen.getByRole("button", { name: /log out/i }));
 
       expect(assign).toHaveBeenCalledWith("/");

--- a/app/frontend/components/navigation/Navigation.tsx
+++ b/app/frontend/components/navigation/Navigation.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import Button from "react-bootstrap/Button";
 import Container from "react-bootstrap/Container";
+import Dropdown from "react-bootstrap/Dropdown";
 import Navbar from "react-bootstrap/Navbar";
 import { Link } from "react-router-dom";
 import logoNav from "@/assets/images/logo_nav.png";
@@ -20,10 +20,17 @@ const hamlEditProfile = "/user/edit";
 // deliberately NOT the tacticalvote black bar, so the SPA doesn't diverge from
 // the live site during migration.
 //
-// Auth and phase state come from the session payload: the logged-in user's
-// avatar + name + log out, or a log in link — and nothing at all while logins
-// are closed (closed-warm-up), mirroring the legacy _current_user / _login
-// partials and `require_logins_open`.
+// Auth and phase state come from the session payload: a menu under the logged-in
+// user's avatar, or a log in link — and nothing at all while logins are closed
+// (closed-warm-up), mirroring the legacy _current_user / _login partials and
+// `require_logins_open`.
+//
+// Log out lives in that menu rather than sitting in the bar as the legacy
+// _current_user partial has it. Two reasons: it is a destructive action and does
+// not belong one stray click from the logo, and as a bare link it inherited
+// whichever stylesheet the page had loaded — Bootstrap 5's underlined `.btn-link`
+// here, the legacy `.stealth-link` there — so the same control looked different
+// depending on where you saw it. A menu item is styled by the menu.
 export function Navigation() {
   const { session, logOut } = useSession();
   const { loginsOpen } = useAppMode();
@@ -58,10 +65,16 @@ export function Navigation() {
           </Navbar.Brand>
 
           {currentUser ? (
-            <div className="d-flex align-items-center gap-2">
-              <a
-                href={hamlEditProfile}
-                className="d-flex align-items-center gap-2 text-decoration-none"
+            <Dropdown align="end">
+              {/* The avatar is decorative — the name beside it is the toggle's
+                  accessible label, so the alt stays empty rather than repeating
+                  it. `variant="link"` for a button that reads as the user's
+                  name, with the underline and link colour that variant brings
+                  turned back off. */}
+              <Dropdown.Toggle
+                variant="link"
+                id="user-menu"
+                className="d-flex align-items-center gap-2 p-0 text-body text-decoration-none"
               >
                 <img
                   src={currentUser.imageUrl}
@@ -71,17 +84,24 @@ export function Navigation() {
                   className="rounded-circle"
                 />
                 <span>{currentUser.name}</span>
-              </a>
-              <Button
-                variant="link"
-                size="sm"
-                className="p-0"
-                onClick={handleLogOut}
-                disabled={loggingOut}
-              >
-                Log out
-              </Button>
-            </div>
+              </Dropdown.Toggle>
+
+              <Dropdown.Menu>
+                {/* Still legacy HAML (M6 owns the mobile number this page also
+                    carries), so a real page load. */}
+                <Dropdown.Item href={hamlEditProfile}>
+                  Edit profile
+                </Dropdown.Item>
+                <Dropdown.Divider />
+                <Dropdown.Item
+                  as="button"
+                  onClick={handleLogOut}
+                  disabled={loggingOut}
+                >
+                  Log out
+                </Dropdown.Item>
+              </Dropdown.Menu>
+            </Dropdown>
           ) : (
             loginsOpen && (
               <Link to={spaPaths.login} className="small">

--- a/app/frontend/components/navigation/Navigation.tsx
+++ b/app/frontend/components/navigation/Navigation.tsx
@@ -8,6 +8,7 @@ import logoNav2x from "@/assets/images/logo_nav@2x.png";
 import { useAppMode } from "@/contexts/useAppMode";
 import { useSession } from "@/contexts/useSession";
 import { spaPaths } from "@/lib/spaPaths";
+import styles from "./Navigation.module.scss";
 
 // Paths still served by the legacy HAML site. Crossing the SPA→HAML boundary
 // needs a real page load, so these are plain `href`s, never react-router
@@ -69,12 +70,16 @@ export function Navigation() {
               {/* The avatar is decorative — the name beside it is the toggle's
                   accessible label, so the alt stays empty rather than repeating
                   it. `variant="link"` for a button that reads as the user's
-                  name, with the underline and link colour that variant brings
-                  turned back off. */}
+                  name, with what that variant brings turned back off: the
+                  underline, the link colour, the bold globals.scss puts on
+                  every .btn-link, and the Rubik stack $btn-font-family puts on
+                  every button (see the module — Rubik ships Bold only here, so
+                  fw-normal on its own would still render bold). A name is not
+                  emphasis. */}
               <Dropdown.Toggle
                 variant="link"
                 id="user-menu"
-                className="d-flex align-items-center gap-2 p-0 text-body text-decoration-none"
+                className={`d-flex align-items-center gap-2 p-0 text-body text-decoration-none fw-normal ${styles.userMenuToggle}`}
               >
                 <img
                   src={currentUser.imageUrl}

--- a/app/frontend/styles/globals.scss
+++ b/app/frontend/styles/globals.scss
@@ -335,12 +335,13 @@ footer {
   }
 }
 
-// tacticalvote recolours footer underlines to the magenta primary on hover.
-// Deliberately not carried over: links here are already underlined
-// (--bs-link-decoration), so hover only changed the underline's colour, which
-// reads as a highlight rather than as feedback and puts the brand accent on
-// whichever link the pointer happens to be near. The underline keeps the
-// link's own ink instead.
+// Footer links are already underlined (--bs-link-decoration), so hover picks
+// the underline out in the magenta primary rather than adding one. Shared
+// Forward Democracy brand behaviour — tacticalvote does the same, and the two
+// sites are meant to feel like one.
+footer a:hover {
+  text-decoration-color: var(--bs-primary);
+}
 
 .footer ul svg {
   color: var(--bs-black);

--- a/app/frontend/styles/globals.scss
+++ b/app/frontend/styles/globals.scss
@@ -335,9 +335,12 @@ footer {
   }
 }
 
-footer a:hover {
-  text-decoration-color: var(--bs-primary);
-}
+// tacticalvote recolours footer underlines to the magenta primary on hover.
+// Deliberately not carried over: links here are already underlined
+// (--bs-link-decoration), so hover only changed the underline's colour, which
+// reads as a highlight rather than as feedback and puts the brand accent on
+// whichever link the pointer happens to be near. The underline keeps the
+// link's own ink instead.
 
 .footer ul svg {
   color: var(--bs-black);

--- a/playwright-tests/auth.spec.ts
+++ b/playwright-tests/auth.spec.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import { spaPaths } from "@/lib/spaPaths";
 
 // See seedProfileUser.ts: a stale Spring preloader leaves `runner` hanging
@@ -11,6 +11,21 @@ const railsEnv = { ...process.env, DISABLE_SPRING: "1" };
 // no other spec touches.
 const email = "e2e-auth@example.com";
 const password = "e2e-auth-password";
+const name = "E2E Auth";
+
+// User#name appends " (test user)" for @example.com addresses, and that is
+// what the nav renders — so it is also the accessible name of the menu toggle.
+const menuLabel = `${name} (test user)`;
+
+// Everything a logged-in user can do lives behind the avatar menu, so the
+// toggle is the nav's logged-in signal and log out is only reachable through
+// it.
+const userMenu = (page: Page) => page.getByRole("button", { name: menuLabel });
+
+async function logOutFromMenu(page: Page) {
+  await userMenu(page).click();
+  await page.getByRole("button", { name: "Log out" }).click();
+}
 
 test.beforeEach(() => {
   execFileSync(
@@ -35,7 +50,7 @@ test("must sign up, then log out, then log back in", async ({ page }) => {
   // ("Opt-in to Forward Democracy email updates") and the "Confirm password"
   // field's accessible name both contain these labels as substrings, and
   // Playwright's getByLabel matches substrings by default.
-  await page.getByLabel("Your name").fill("E2E Auth");
+  await page.getByLabel("Your name").fill(name);
   await page.getByLabel("Email", { exact: true }).fill(email);
   await page.getByLabel("Password", { exact: true }).fill(password);
   await page.getByLabel("Confirm password").fill(password);
@@ -50,9 +65,9 @@ test("must sign up, then log out, then log back in", async ({ page }) => {
     page.getByRole("combobox", { name: "My constituency is" }),
   ).toBeVisible();
   // The nav bar reflects the new session, not just the page.
-  await expect(page.getByRole("button", { name: "Log out" })).toBeVisible();
+  await expect(userMenu(page)).toBeVisible();
 
-  await page.getByRole("button", { name: "Log out" }).click();
+  await logOutFromMenu(page);
 
   // Log out deliberately ends on the legacy HAML home page. A mere URL match
   // would still pass if DELETE /api/v1/session silently failed server-side —
@@ -72,7 +87,7 @@ test("must sign up, then log out, then log back in", async ({ page }) => {
   await page.getByRole("button", { name: "Log in" }).click();
 
   await expect(page).toHaveURL(new RegExp(`${spaPaths.constituency}$`));
-  await expect(page.getByRole("button", { name: "Log out" })).toBeVisible();
+  await expect(userMenu(page)).toBeVisible();
 });
 
 test("must refuse a wrong password without saying which field was wrong", async ({


### PR DESCRIPTION
Three navigation and brand-style changes found while testing M5.

**Why this replaces #1054.** #1054 was stacked on `frontend-react-auth` while M5 was still open. M5 (#1053) was squash-merged to `master` first, then #1054 merged into `frontend-react-auth` — which no longer went anywhere, so these three commits landed on that branch and never reached `master`. This is the same three commits cherry-picked onto `master`; the resulting tree is byte-identical to `origin/frontend-react-auth`.

## Log out moves into a menu under the avatar

Log out sat in the bar next to the user's name as a bare link, so it inherited whichever stylesheet the page had loaded — Bootstrap 5's underlined `.btn-link` on the React screens, the legacy `.stealth-link` on the HAML ones. The same control looked different depending on where you saw it. It also put a destructive action one stray click from the logo.

The avatar and name are now a dropdown toggle, with **Edit profile** and **Log out** inside. A menu item is styled by the menu, and logging out takes a deliberate second click.

The legacy `_current_user` partial is untouched and keeps its own bar-level link until cutover, so that nav still looks as it does today.

## The user's name is no longer bold

Worth reading if you ever fight this font again. `$btn-font-family` puts every button on the Rubik stack, and this project ships a single Rubik face — Bold. CSS font matching resolves a request the family cannot satisfy to the nearest face *within that family*, so asking for weight 400 still rendered Rubik Bold; family fallback only happens when the family has no faces at all. A `fw-normal` utility therefore looked like it did nothing — the computed weight really was 400, and the text was still bold.

The toggle now names the body font family, in a co-located module qualified as `button.userMenuToggle` because Bootstrap's own `.btn` sets `font-family` at the same specificity and is loaded later, so a bare class loses on source order.

The name now renders identically to body copy: system-ui 400.

## A comment on the magenta footer hover

No behaviour change. I removed `footer a:hover { text-decoration-color: var(--bs-primary) }` reading it as stray styling, and Steve corrected me — it is deliberate Forward Democracy brand behaviour shared with tacticalvote. It is restored, with a comment saying so, so the next person does not make the same call. The two commits are kept rather than squashed so the history says what happened.

## Verification

`yarn test` 273 passed, `yarn lint` and `tsc` clean, run on this branch against `master`. The behaviour was driven in the browser on the original branch: the menu opens, `Edit profile` still points at `/user/edit`, log out clears the session and lands on the legacy home, and the name computes system-ui 400 against body copy's system-ui 400.

Not covered by tests: font-family resolution and hover colour are not observable in jsdom, and asserting a utility class would only restate the implementation. A Playwright assertion could pin the hover colour if that is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
